### PR TITLE
Add support for optional path for included files in FGOutput

### DIFF
--- a/src/input_output/FGScript.cpp
+++ b/src/input_output/FGScript.cpp
@@ -210,7 +210,7 @@ bool FGScript::LoadScript(const SGPath& script, double default_dT,
   // Now, read output spec if given.
   element = document->FindElement("output");
   while (element) {
-    if (!FDMExec->GetOutput()->Load(element))
+    if (!FDMExec->GetOutput()->Load(element, SGPath(script.dir())))
       return false;
  
     element = document->FindNextElement("output");

--- a/src/models/FGOutput.cpp
+++ b/src/models/FGOutput.cpp
@@ -243,8 +243,11 @@ bool FGOutput::Load(int subSystems, std::string protocol, std::string type,
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-bool FGOutput::Load(Element* document)
+bool FGOutput::Load(Element* document, const SGPath& dir)
 {
+  // Optional path to use for included files
+  includePath = dir;
+
   // Perform base class Pre-Load
   if (!FGModel::Load(document, false))
     return false;
@@ -295,6 +298,19 @@ bool FGOutput::Load(Element* document)
 
   Debug(2);
   return true;
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+SGPath FGOutput::FindFullPathName(const SGPath& path) const
+{
+  // Check optional include path if set
+  if (!includePath.isNull()) {
+    SGPath name = CheckPathName(includePath, path);
+    if (!name.isNull()) return name;
+  }
+
+  return FGModel::FindFullPathName(path);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGOutput.h
+++ b/src/models/FGOutput.h
@@ -200,8 +200,9 @@ public:
   /** Load the output directives and adds a new output instance to the Output
       Manager list.
       @param el XMLElement that is pointing to the output directives
+      @param dir optional directory path to load included files from
       @result true if the execution succeeded. */
-  virtual bool Load(Element* el);
+  virtual bool Load(Element* el, const SGPath& dir = SGPath());
   /** Load the output directives and adds a new output instance to the Output
       Manager list. Unlike the Load() method, the new output instance is not
       generated from output directives read in a XML file but from a list of
@@ -223,6 +224,8 @@ public:
       @result the name identifier.*/
   std::string GetOutputName(unsigned int idx) const;
 
+  SGPath FindFullPathName(const SGPath& path) const;
+
   FGTemplateFunc* GetTemplateFunc(const std::string& name) {
     if (TemplateFunctions.count(name))
       return TemplateFunctions[name];
@@ -234,6 +237,7 @@ private:
   std::vector<FGOutputType*> OutputTypes;
   std::map<std::string, FGTemplateFunc_ptr> TemplateFunctions;
   bool enabled;
+  SGPath includePath;
 
   void Debug(int from);
 };


### PR DESCRIPTION
Currently used by FGScript so that that Output elements within a script that include a file, e.g. unitconversions.xml for template functions can store the include file in the same directory as the script file rather than being forced to store it in the aircraft's directory.