### PR TITLE
activated Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-#  - "3.6"
+  - "3.6"
 # command to install dependencies
 notifications:
   email: false


### PR DESCRIPTION
Allow Travis CI to test for Python 2.7 and 3.6