### PR TITLE
Changes to prevent tests failing on Windows due to files/directory in use

### DIFF
--- a/tests/CheckMomentsUpdate.py
+++ b/tests/CheckMomentsUpdate.py
@@ -87,4 +87,6 @@ class CheckMomentsUpdate(JSBSimTestCase):
         self.assertAlmostEqual(Fbx * CGz - Fbz * CGx, Mby, delta=1E-7,
                                msg="Fbx*CGz-Fbz*CGx = %f and Mby = %f do not match" % (Fbx*CGz-Fbz*CGx, Mby))
 
+        del self.fdm
+
 RunTest(CheckMomentsUpdate)

--- a/tests/JSBSim_utils.py
+++ b/tests/JSBSim_utils.py
@@ -140,8 +140,8 @@ class JSBSimTestCase(unittest.TestCase):
         os.chdir(self.sandbox())
 
     def tearDown(self):
-        self.sandbox.erase()
         os.chdir(self.currentdir)
+        self.sandbox.erase()
 
     # Generator that returns the full path to all the scripts in JSBSim
     def script_list(self, blacklist=[]):

--- a/tests/ResetOutputFiles.py
+++ b/tests/ResetOutputFiles.py
@@ -110,15 +110,16 @@ class ResetOutputFiles(JSBSimTestCase):
         self.assertTrue(self.sandbox.exists('that_one.csv'),
                         msg="Output name overwritten: 'that_one.csv' should exist.")
 
+        # Because JSBSim internals use static pointers, we cannot rely on
+        # Python garbage collector to decide when the FDM is destroyed
+        # otherwise we can get dangling pointers.
+        del fdm
+
         #
         # Check again on a brand new FDM
         #
         self.sandbox.delete_csv_files()
 
-        # Because JSBSim internals use static pointers, we cannot rely on
-        # Python garbage collector to decide when the FDM is destroyed
-        # otherwise we can get dangling pointers.
-        del fdm
 
         fdm = CreateFDM(self.sandbox)
         fdm.load_script(self.sandbox.path_to_jsbsim_file('scripts',
@@ -142,5 +143,7 @@ class ResetOutputFiles(JSBSimTestCase):
 
         self.assertTrue(self.sandbox.exists('oops.csv'),
                         msg="Reset new FDM: 'oops.csv' should exist.")
+
+        del fdm
 
 RunTest(ResetOutputFiles)

--- a/tests/TestICOverride.py
+++ b/tests/TestICOverride.py
@@ -64,14 +64,14 @@ class TestICOverride(JSBSimTestCase):
         property.attrib['value'] = str(vt0)
         tree.write('c1724_0.xml')
 
-        # Re-run the same check than above. This time we are making sure than
-        # the total initial velocity is increased by 1 ft/s
-        self.sandbox.delete_csv_files()
-
         # Because JSBSim internals use static pointers, we cannot rely on
         # Python garbage collector to decide when the FDM is destroyed
         # otherwise we can get dangling pointers.
         del fdm
+
+        # Re-run the same check than above. This time we are making sure than
+        # the total initial velocity is increased by 1 ft/s
+        self.sandbox.delete_csv_files()
 
         fdm = CreateFDM(self.sandbox)
         fdm.load_script('c1724_0.xml')

--- a/tests/TestSuspend.py
+++ b/tests/TestSuspend.py
@@ -69,6 +69,8 @@ class TestSuspend(JSBSimTestCase):
         self.longMessage = True
         self.assertEqual(len(diff), 0, msg='\n'+diff.to_string())
 
+        del fdm
+
     def testHold(self):
         fdm = self.initFDM()
         ExecuteUntil(fdm, 1.0)
@@ -88,5 +90,7 @@ class TestSuspend(JSBSimTestCase):
         diff = FindDifferences(self.ref, out, 1E-8)
         self.longMessage = True
         self.assertEqual(len(diff), 0, msg='\n'+diff.to_string())
+
+        del fdm
 
 RunTest(TestSuspend)


### PR DESCRIPTION
Windows is different to Linux in terms of deleting files and directories which still have open handles. Which meant pretty much all 35 tests were failing on Windows due to the cleanup failing to delete temporary files and directories.

With this commit 33 of the 35 tests now pass on Windows. Tests that are currently still failing on Windows are:

CheckFGBug1503
TestInitialConditions
TestSuspend