### PR TITLE
Update appveyor to use correct tag for releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,8 +40,8 @@ skip_tags: true
 
 deploy:
 - provider: GitHub
-  tag: JSBSim-win64-v2018a
-  description: VS 2017 - Release - x64
+  tag: JSBSim-trusty-v2018a
+  description: Windows - Release - x64
   auth_token:
     secure: YWG8FRFWv/ylTuA1DIFNcN01uFGz7xKit8CayOMTE0orPKXhztwLmwm8MZ4IzFbr
   artifact: build\src\JSBSim.exe,build\utils\aeromatic++\aeromatic.exe


### PR DESCRIPTION
Change tag name for releases to JSBSim-trusty-v2018a.