### PR TITLE
Correct GetStdPressure

### DIFF
--- a/src/models/atmosphere/FGStandardAtmosphere.h
+++ b/src/models/atmosphere/FGStandardAtmosphere.h
@@ -258,6 +258,7 @@ protected:
   FGTable* StdAtmosTemperatureTable;
   std::vector<double> LapseRateVector;
   std::vector<double> PressureBreakpointVector;
+  std::vector<double> StdPressureBreakpointVector;
 
   /// Recalculate the lapse rate vectors when the temperature profile is altered
   /// in a way that would change the lapse rates, such as when a gradient is applied.


### PR DESCRIPTION
Not sure what GetStdPressure100K() is supposed to be doing in GetStdPressure, but its return value was never used, so the returned pressure is always zero when conditions were "non-standard".  But why should GetStdPressure() be returning non-standard conditions anyway?

Changed to calculate pressure at Standard Conditions based on the GetPressure() calculations (which look correct), but using StdTemp and StdPressure breakpoints (i.e. no temp/press variations)