### PR TITLE
Update pressure and density altitude calculations

### DIFF
--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -130,8 +130,8 @@ void FGAtmosphere::Calculate(double altitude)
     Density = node->GetDouble("atmosphere/override/density");
 
   Soundspeed  = sqrt(SHRatio*Reng*(Temperature));
-  PressureAltitude = CalculatePressureAltitude(altitude);
-  DensityAltitude = CalculateDensityAltitude(altitude);
+  PressureAltitude = CalculatePressureAltitude(Pressure, altitude);
+  DensityAltitude = CalculateDensityAltitude(Density, altitude);
 
   Viscosity = Beta * pow(Temperature, 1.5) / (SutherlandConstant + Temperature);
   KinematicViscosity = Viscosity / Density;

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -232,9 +232,9 @@ protected:
   /// Calculate the atmosphere for the given altitude.
   void Calculate(double altitude);
 
-  virtual double CalculateDensityAltitude(const double altitude) { return altitude; }
+  virtual double CalculateDensityAltitude(double density, double geoalt) { return geoalt; }
 
-  virtual double CalculatePressureAltitude(const double altitude) { return altitude; }
+  virtual double CalculatePressureAltitude(double pressure, double geoalt) { return geoalt; }
 
   // Converts to Rankine from one of several unit systems.
   virtual double ConvertToRankine(double t, eTemperature unit) const;

--- a/src/models/atmosphere/FGStandardAtmosphere.cpp
+++ b/src/models/atmosphere/FGStandardAtmosphere.cpp
@@ -480,16 +480,13 @@ void FGStandardAtmosphere::ResetSLPressure()
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-double FGStandardAtmosphere::CalculateDensityAltitude(double altitude)
+double FGStandardAtmosphere::CalculateDensityAltitude(double density, double geoalt)
 {
-  if (altitude > TroposphereMaxAltitude)
-    return altitude;
+  if (geoalt > TroposphereMaxAltitude)
+    return geoalt;
   else {
-    // Calculate density given a non-standard temperature. GetPressure() and GetTemperature()
-    // take the temperature bias into account
-    double density = GetPressure(altitude) / (Reng * GetTemperature(altitude));
-
-    // Convert to density altitude based on ratio of density to standard sea-level density
+    // Convert to density altitude based on ratio of density to standard sea-level density.
+    // Passed in density has taken into account any non standard ISA day changes.
     double density_altitude = TroposphereAltitudeScaleFactor * (1.0 - pow(density / StdSLdensity, DATroposphereExponent));
 
     return GeometricAltitude(density_altitude);
@@ -498,19 +495,16 @@ double FGStandardAtmosphere::CalculateDensityAltitude(double altitude)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-double FGStandardAtmosphere::CalculatePressureAltitude(double altitude)
+double FGStandardAtmosphere::CalculatePressureAltitude(double pressure, double geoalt)
 {
-  if (TemperatureBias == 0.0 && TemperatureDeltaGradient == 0.0 && PressureBreakpointVector[0] == StdSLpressure) {
-    return altitude;
-  }
+  if (geoalt > TroposphereMaxAltitude)
+    return geoalt;
   else {
-    if (altitude > TroposphereMaxAltitude)
-      return altitude;
-    else {
-      double pressure_altitude = TroposphereAltitudeScaleFactor * (1 - pow(GetPressure(altitude) / StdSLpressure, PATroposphereExponent));
+    // Convert to pressure altitude base on ratio of pressure to sea-level pressure.
+    // Passed in pressure has taken into account any non standard ISA day changes.
+    double pressure_altitude = TroposphereAltitudeScaleFactor * (1 - pow(pressure / StdSLpressure, PATroposphereExponent));
 
-      return GeometricAltitude(pressure_altitude);
-    }
+    return GeometricAltitude(pressure_altitude);
   }
 }
 

--- a/src/models/atmosphere/FGStandardAtmosphere.h
+++ b/src/models/atmosphere/FGStandardAtmosphere.h
@@ -281,7 +281,7 @@ protected:
   https://en.wikipedia.org/wiki/Density_altitude
   https://wahiduddin.net/calc/density_altitude.htm
   */
-  virtual double CalculateDensityAltitude(double altitude);
+  virtual double CalculateDensityAltitude(double density, double geoalt);
 
   /** Calculates the pressure altitude given any temperature or pressure bias.
   Currently the formula used is only valid up until the top of the Troposphere,
@@ -290,7 +290,7 @@ protected:
   @see
   https://en.wikipedia.org/wiki/Pressure_altitude
   */
-  virtual double CalculatePressureAltitude(double altitude);
+  virtual double CalculatePressureAltitude(double pressure, double geoalt);
 
   virtual void bind(void);
   void Debug(int from);


### PR DESCRIPTION
To support the 'atmosphere/override/*' properties and to implement @djlinse's suggestion for passing in the already calculated pressure and density values rather than re-computing them.

Next step is to extend the calculations above the troposphere.