### PR TITLE
Python 3 compatability for query_property_catalog()

### DIFF
--- a/python/jsbsim.pyx
+++ b/python/jsbsim.pyx
@@ -509,7 +509,8 @@ cdef class FGFDMExec:
         @return the carriage-return-delimited string containing all matching strings
             in the catalog.
         """
-        return (self.thisptr.QueryPropertyCatalog(check)).rstrip().split('\n')
+        check = check.encode()
+        return (self.thisptr.QueryPropertyCatalog(check)).decode('utf-8').rstrip().split('\n')
 
     def get_property_catalog(self, check):
         """


### PR DESCRIPTION
To fix a Python 3 string incompatibility within `query_property_catalog()` based on an issue report - [75](https://github.com/JSBSim-Team/jsbsim/issues/75). 