### PR TITLE
Filters: fix incorrect coefficient rates caused by execrate.

### DIFF
--- a/src/models/flight_control/FGFilter.cpp
+++ b/src/models/flight_control/FGFilter.cpp
@@ -190,6 +190,9 @@ bool FGFilter::Run(void)
 {
   if (Initialize) {
 
+    // need to do this now as dt will not be correct during initialization
+    CalculateDynamicFilters();
+
     PreviousOutput2 = PreviousInput2 = PreviousOutput1 = PreviousInput1 = Output = Input;
     Initialize = false;
 


### PR DESCRIPTION
The coefficients are initialized during construction - however at this point dT isn't correct - so we need to set these up again the first time they are used.