### PR TITLE
Improved configuration error detection in FGSwitch w.r.t. late bound …

### DIFF
--- a/aircraft/p51d/Systems/electrical.xml
+++ b/aircraft/p51d/Systems/electrical.xml
@@ -10,6 +10,7 @@
     <property value="0">systems/right-flor-gain</property>
 
     <!-- Additional properties which are defined separately in FlightGear -->
+    <property value="0">/controls/gear/gear-safe-light-check</property>
     <property value="0">/controls/gear/gear-unsafe-light-check</property>
     <property value="0">/controls/lighting/left-flor-pos</property>
     <property value="0">/controls/lighting/right-flor-pos</property>

--- a/src/models/flight_control/FGSwitch.cpp
+++ b/src/models/flight_control/FGSwitch.cpp
@@ -135,6 +135,13 @@ bool FGSwitch::Run(void )
   bool pass = false;
   double default_output=0.0;
 
+  // To detect errors early, make sure all conditions and values can be
+  // evaluated in the first time step.
+  if (!initialized) {
+    initialized = true;
+    VerifyProperties();
+  }
+
   for (unsigned int i=0; i<tests.size(); i++) {
     if (tests[i]->Default) {
       default_output = tests[i]->GetValue();
@@ -155,6 +162,18 @@ bool FGSwitch::Run(void )
   if (IsOutput) SetOutput();
 
   return true;
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+void FGSwitch::VerifyProperties(void)
+{
+  for (unsigned int i=0; i<tests.size(); i++) {
+    if (!tests[i]->Default) {
+      tests[i]->condition->Evaluate();
+    }
+    tests[i]->GetValue();
+  }
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/flight_control/FGSwitch.h
+++ b/src/models/flight_control/FGSwitch.h
@@ -193,7 +193,9 @@ private:
   };
 
   std::vector <test*> tests;
+  bool initialized = false;
 
+  void VerifyProperties(void);
   void Debug(int from);
 };
 }


### PR DESCRIPTION
Currently FGSwitch does not evaluate output values until they are selected and skips evaluation of conditions after the one selected. Hence, some configuration faults might not be detected until far into a run. This changes makes sure that all conditions and output values can be evaluated during the first time step so that problems do not get hidden until later times. This makes FGSwitch behave more like the other components w.r.t. late bound properties.

If there are no objections I'll add this to master tomorrow.
(Don't merge this request unless it is a fast-forward merge, thank you. I prefer a linear history.)