### PR TITLE
Run Python tests on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ build_script:
 - call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 - cmake -G "Ninja" -DCMAKE_MAKE_PROGRAM="C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2017\COMMUNITY\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\Ninja\ninja.exe" -DCMAKE_BUILD_TYPE="RelWithDebInfo" ..
 - cmake --build . --config RelWithDebInfo 
-- ctest -j2
+- ctest -j2 -V
 
 artifacts:
 - path: build\src\JSBSim.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ version: 1.0.{build}
 build_script:
 - set PATH=c:\python36-x64;c:\python36-x64\Scripts;%PATH%
 - ren c:\python27 python27-hide
-- pip install Cython
+- pip install Cython numpy pandas scipy
 - md build
 - cd build
 - call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ build_script:
 - call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 - cmake -G "Ninja" -DCMAKE_MAKE_PROGRAM="C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2017\COMMUNITY\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\Ninja\ninja.exe" -DCMAKE_BUILD_TYPE="RelWithDebInfo" ..
 - cmake --build . --config RelWithDebInfo 
-- ctest -j2 -V
+- ctest -j2
 
 artifacts:
 - path: build\src\JSBSim.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ build_script:
 - call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 - cmake -G "Ninja" -DCMAKE_MAKE_PROGRAM="C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2017\COMMUNITY\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\Ninja\ninja.exe" -DCMAKE_BUILD_TYPE="RelWithDebInfo" ..
 - cmake --build . --config RelWithDebInfo 
-
+- ctest -j2
 
 artifacts:
 - path: build\src\JSBSim.exe


### PR DESCRIPTION
@bcoconni @agodemar now that all the Python tests run under Windows I'm enabling them via `ctest` on AppVeyor. Don't merge this pull request until I've confirmed that the tests are running successfully on AppVeyor.