### PR TITLE
Allow any trim type to be specified in initialization file

### DIFF
--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -440,7 +440,8 @@ int real_main(int argc, char* argv[])
 
     if (!FDMExec->GetPropertyManager()->GetNode(CommandLineProperties[i])) {
       cerr << endl << "  No property by the name " << CommandLineProperties[i] << endl;
-      goto quit;
+      delete FDMExec;
+      exit(-1);
     } else {
       FDMExec->SetPropertyValue(CommandLineProperties[i], CommandLinePropertyValues[i]);
     }
@@ -550,9 +551,6 @@ int real_main(int argc, char* argv[])
     }
 
   }
-
-  
-quit:
 
   // PRINT ENDING CLOCK TIME
   time(&tod);

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -454,10 +454,20 @@ int real_main(int argc, char* argv[])
   // Dump the simulation state (position, orientation, etc.)
   FDMExec->GetPropagate()->DumpState();
   
-  if (FDMExec->GetIC()->NeedTrim()) {
-    trimmer = new JSBSim::FGTrim( FDMExec );
+  // Perform trim if requested via the initialization file
+  JSBSim::TrimMode icTrimRequested = (JSBSim::TrimMode)FDMExec->GetIC()->TrimRequested();
+  if (icTrimRequested != JSBSim::TrimMode::tNone) {
+    trimmer = new JSBSim::FGTrim( FDMExec, icTrimRequested );
     try {
+      // If PullUp requested then we need to pass in target Nlf
+      if (icTrimRequested == JSBSim::TrimMode::tPullup)
+        trimmer->SetTargetNlf(FDMExec->GetIC()->GetTargetNlfIC());
+
       trimmer->DoTrim();
+
+      if (FDMExec->GetDebugLevel() > 0)
+        trimmer->Report();
+
       delete trimmer;
     } catch (string& msg) {
       cerr << endl << msg << endl << endl;

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -460,10 +460,6 @@ int real_main(int argc, char* argv[])
   if (icTrimRequested != JSBSim::TrimMode::tNone) {
     trimmer = new JSBSim::FGTrim( FDMExec, icTrimRequested );
     try {
-      // If PullUp requested then we need to pass in target Nlf
-      if (icTrimRequested == JSBSim::TrimMode::tPullup)
-        trimmer->SetTargetNlf(FDMExec->GetIC()->GetTargetNlfIC());
-
       trimmer->DoTrim();
 
       if (FDMExec->GetDebugLevel() > 0)

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -53,6 +53,7 @@ INCLUDES
 #include "models/FGAircraft.h"
 #include "models/FGAccelerations.h"
 #include "input_output/FGXMLFileRead.h"
+#include "FGTrim.h"
 
 using namespace std;
 
@@ -148,7 +149,7 @@ void FGInitialCondition::InitializeIC(void)
   lastAltitudeSet = setasl;
   lastLatitudeSet = setgeoc;
   enginesRunning = 0;
-  needTrim = 0;
+  trimRequested = TrimMode::tNone;
 }
 
 //******************************************************************************
@@ -979,6 +980,27 @@ bool FGInitialCondition::LoadLatitude(Element* position_el)
 
 //******************************************************************************
 
+void FGInitialCondition::SetTrimRequest(std::string& trim)
+{
+  std::string& trimOption = to_lower(trim);
+  if (trimOption == "1")
+    trimRequested = TrimMode::tGround;  // For backwards compatabiity
+  else if (trimOption == "longitudinal")
+    trimRequested = TrimMode::tLongitudinal;
+  else if (trimOption == "full")
+    trimRequested = TrimMode::tFull;
+  else if (trimOption == "ground")
+    trimRequested = TrimMode::tGround;
+  else if (trimOption == "pullup")
+    trimRequested = TrimMode::tPullup;
+  else if (trimOption == "custom")
+    trimRequested = TrimMode::tCustom;
+  else if (trimOption == "turn")
+    trimRequested = TrimMode::tTurn;
+}
+
+//******************************************************************************
+
 bool FGInitialCondition::Load_v1(Element* document)
 {
   bool result = true;
@@ -1047,7 +1069,7 @@ bool FGInitialCondition::Load_v1(Element* document)
   if (document->FindElement("targetNlf"))
     SetTargetNlfIC(document->FindElementValueAsNumber("targetNlf"));
   if (document->FindElement("trim"))
-    needTrim = document->FindElementValueAsNumber("trim");
+    SetTrimRequest(document->FindElementValue("trim"));
 
   // Refer to Stevens and Lewis, 1.5-14a, pg. 49.
   // This is the rotation rate of the "Local" frame, expressed in the local frame.

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -980,7 +980,7 @@ bool FGInitialCondition::LoadLatitude(Element* position_el)
 
 //******************************************************************************
 
-void FGInitialCondition::SetTrimRequest(std::string& trim)
+void FGInitialCondition::SetTrimRequest(std::string trim)
 {
   std::string& trimOption = to_lower(trim);
   if (trimOption == "1")

--- a/src/initialization/FGInitialCondition.h
+++ b/src/initialization/FGInitialCondition.h
@@ -164,7 +164,7 @@ CLASS DOCUMENTATION
    - mach (mach)
    - vground (ground speed, ft/sec)
    - running (-1 for all engines, 0 for no engines, 1 ... n for specific engines)
-   - trim (0 for no trim, 1 for ground trim)
+   - trim (0 for no trim, 1 for ground trim, 'Longitudinal', 'Full', 'Ground', 'Pullup', 'Custom', 'Turn')
 
    <h3>Properties</h3>
    @property ic/vc-kts (read/write) Calibrated airspeed initial condition in knots
@@ -679,8 +679,8 @@ public:
   bool IsEngineRunning(unsigned int n) const { return (enginesRunning & (1 << n)) != 0; }
   
   /** Does initialization file call for trim ?
-      @return true if initialization file (version 1) called for trim. */
-  bool NeedTrim(void) const { return needTrim == 0 ? false : true; }
+      @return Trim type, if any requested (version 1). */
+  int TrimRequested(void) const { return trimRequested; }
 
   void bind(FGPropertyManager* pm);
 
@@ -701,7 +701,7 @@ private:
   altitudeset lastAltitudeSet;
   latitudeset lastLatitudeSet;
   unsigned int enginesRunning;
-  int needTrim;
+  int trimRequested;
 
   FGFDMExec *fdmex;
   FGAtmosphere* Atmosphere;
@@ -721,6 +721,7 @@ private:
   void calcThetaBeta(double alfa, const FGColumnVector3& _vt_NED);
   double ComputeGeodAltitude(double geodLatitude);
   bool LoadLatitude(Element* position_el);
+  void SetTrimRequest(std::string& trim);
   void Debug(int from);
 };
 }

--- a/src/initialization/FGInitialCondition.h
+++ b/src/initialization/FGInitialCondition.h
@@ -721,7 +721,7 @@ private:
   void calcThetaBeta(double alfa, const FGColumnVector3& _vt_NED);
   double ComputeGeodAltitude(double geodLatitude);
   bool LoadLatitude(Element* position_el);
-  void SetTrimRequest(std::string& trim);
+  void SetTrimRequest(std::string trim);
   void Debug(int from);
 };
 }

--- a/src/initialization/FGTrim.cpp
+++ b/src/initialization/FGTrim.cpp
@@ -76,7 +76,7 @@ FGTrim::FGTrim(FGFDMExec *FDMExec,TrimMode tt)
   gamma_fallback=false;
   mode=tt;
   xlo=xhi=alo=ahi=0.0;
-  targetNlf=1.0;
+  targetNlf=fgic.GetTargetNlfIC();
   debug_axis=tAll;
   SetMode(tt);
   if (debug_lvl & 2) cout << "Instantiated: FGTrim" << endl;


### PR DESCRIPTION
Currently the `<trim>` element in an initialization file can only be used to specify `0 - no trim` or `1 - ground trim`. This pull requests adds support for all the currently supported trim types to be specified and maintains backwards compatibility.

`- trim (0 for no trim, 1 for ground trim, 'Longitudinal', 'Full', 'Ground', 'Pullup', 'Custom', 'Turn') `