### PR TITLE
Correct sign for load factor - GetNlf()

### DIFF
--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -276,7 +276,7 @@ void FGAuxiliary::UpdateWindMatrices(void)
 double FGAuxiliary::GetNlf(void) const
 {
   if (in.Mass != 0)
-    return (-in.vFw(3))/(in.Mass*slugtolb);
+    return (in.vFw(3))/(in.Mass*slugtolb);
   else
     return 0.;
 }


### PR DESCRIPTION
Fix incorrect sign in `FGAuxiliary::GetNlf()` which fixes the sign reported by the property `forces/load-factor` and also fixes the **pullup** trim option which calls `FGAuxiliary::GetNlf()` from `FGTrimAxis::getState()`.