### PR TITLE
Add ic/targetNlf property.

### DIFF
--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -1509,6 +1509,11 @@ void FGInitialCondition::bind(FGPropertyManager* PropertyManager)
                        true);
   PropertyManager->Tie("ic/geod-alt-ft", &position,
                        &FGLocation::GetGeodAltitude);
+
+  PropertyManager->Tie("ic/targetNlf", this,
+                       &FGInitialCondition::GetTargetNlfIC,
+                       &FGInitialCondition::SetTargetNlfIC,
+                       true);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Consistency with other ic elements. Will also allow scripts to calculate and set a `targetNlf` via `ic/targetNlf` before executing a trim operation.