### PR TITLE
Exclude TestInputSocket test for now on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ build_script:
 - call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 - cmake -G "Ninja" -DCMAKE_MAKE_PROGRAM="C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2017\COMMUNITY\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\Ninja\ninja.exe" -DCMAKE_BUILD_TYPE="RelWithDebInfo" ..
 - cmake --build . --config RelWithDebInfo 
-- ctest -j2
+- ctest -j2 -E TestInputSocket
 
 artifacts:
 - path: build\src\JSBSim.exe


### PR DESCRIPTION
Exclude it from AppVeyor for now until we figure out why 50% of the time the test hangs on AppVeyor which causes the build to fail after a 60min timeout.