### PR TITLE
FGTURBINE: StartN1 / StartN2 values patch

### DIFF
--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -70,7 +70,7 @@ FGTurbine::FGTurbine(FGFDMExec* exec, Element *el, int engine_number, struct Inp
   Augmented = AugMethod = Injected = 0;
   BypassRatio = BleedDemand = 0.0;
   IdleThrustLookup = MilThrustLookup = MaxThrustLookup = InjectionLookup = 0;
-  N1_spinup = 1.0; N2_spinup = 3.0;
+  N1_spinup = 1.0; N2_spinup = 3.0; StartN1 = 5.21; StartN2 = 25.18;
   InjectionTime = 30.0;
   InjectionTimer = InjWaterNorm = 0.0;
   EPR = 1.0;
@@ -281,8 +281,8 @@ double FGTurbine::SpinUp(void)
 {
   Running = false;
   FuelFlow_pph = 0.0;
-  N2 = Seek(&N2, 25.18, N2_spinup, N2/2.0);
-  N1 = Seek(&N1, 5.21, N1_spinup, N1/2.0);
+  N2 = Seek(&N2, StartN2, N2_spinup, N2/2.0);
+  N1 = Seek(&N1, StartN1, N1_spinup, N1/2.0);
   EGT_degC = Seek(&EGT_degC, in.TAT_c, 11.7, 7.3);
   OilPressure_psi = N2 * 0.62;
   OilTemp_degK = Seek(&OilTemp_degK, in.TAT_c + 273.0, 0.2, 0.2);
@@ -448,6 +448,10 @@ bool FGTurbine::Load(FGFDMExec* exec, Element *el)
     TSFC = el->FindElementValueAsNumber("tsfc");
   if (el->FindElement("atsfc"))
     ATSFC = el->FindElementValueAsNumber("atsfc");
+  if (el->FindElement("startn1"))
+    StartN1 = el->FindElementValueAsNumber("startn1");
+  if (el->FindElement("startn2"))
+    StartN2 = el->FindElementValueAsNumber("startn2");
   if (el->FindElement("idlen1"))
     IdleN1 = el->FindElementValueAsNumber("idlen1");
   if (el->FindElement("idlen2"))

--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -70,7 +70,7 @@ FGTurbine::FGTurbine(FGFDMExec* exec, Element *el, int engine_number, struct Inp
   Augmented = AugMethod = Injected = 0;
   BypassRatio = BleedDemand = 0.0;
   IdleThrustLookup = MilThrustLookup = MaxThrustLookup = InjectionLookup = 0;
-  N1_spinup = 1.0; N2_spinup = 3.0; StartN1 = 5.21; StartN2 = 25.18; N1_start = 1.4; N2_start = 2.0; 
+  N1_spinup = 1.0; N2_spinup = 3.0; StartN1 = 5.21; StartN2 = 25.18; N1_start_rate = 1.4; N2_start_rate = 2.0; 
   InjectionTime = 30.0;
   InjectionTimer = InjWaterNorm = 0.0;
   EPR = 1.0;
@@ -299,8 +299,8 @@ double FGTurbine::Start(void)
   if ((N2 > 15.0) && !Starved) {       // minimum 15% N2 needed for start
     Cranking = true;                   // provided for sound effects signal
     if (N2 < IdleN2) {
-      N2 = Seek(&N2, IdleN2, N2_start, N2/2.0);
-      N1 = Seek(&N1, IdleN1, N1_start, N1/2.0);
+      N2 = Seek(&N2, IdleN2, N2_start_rate, N2/2.0);
+      N1 = Seek(&N1, IdleN1, N1_start_rate, N1/2.0);
       EGT_degC = Seek(&EGT_degC, in.TAT_c + 363.1, 21.3, 7.3);
       FuelFlow_pph = IdleFF * N2 / IdleN2;
       OilPressure_psi = N2 * 0.62;
@@ -464,10 +464,10 @@ bool FGTurbine::Load(FGFDMExec* exec, Element *el)
     N1_spinup = el->FindElementValueAsNumber("n1spinup");
   if (el->FindElement("n2spinup"))
     N2_spinup = el->FindElementValueAsNumber("n2spinup");
-  if (el->FindElement("n1start"))
-    N1_start = el->FindElementValueAsNumber("n1start");
-  if (el->FindElement("n2start"))
-    N2_start = el->FindElementValueAsNumber("n2start");
+  if (el->FindElement("n1startrate"))
+    N1_start_rate = el->FindElementValueAsNumber("n1startrate");
+  if (el->FindElement("n2startrate"))
+    N2_start_rate = el->FindElementValueAsNumber("n2startrate");
   if (el->FindElement("augmented"))
     Augmented = (int)el->FindElementValueAsNumber("augmented");
   if (el->FindElement("augmethod"))

--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -70,7 +70,7 @@ FGTurbine::FGTurbine(FGFDMExec* exec, Element *el, int engine_number, struct Inp
   Augmented = AugMethod = Injected = 0;
   BypassRatio = BleedDemand = 0.0;
   IdleThrustLookup = MilThrustLookup = MaxThrustLookup = InjectionLookup = 0;
-  N1_spinup = 1.0; N2_spinup = 3.0; StartN1 = 5.21; StartN2 = 25.18;
+  N1_spinup = 1.0; N2_spinup = 3.0; StartN1 = 5.21; StartN2 = 25.18; N1_start = 1.4; N2_start = 2.0; 
   InjectionTime = 30.0;
   InjectionTimer = InjWaterNorm = 0.0;
   EPR = 1.0;
@@ -299,8 +299,8 @@ double FGTurbine::Start(void)
   if ((N2 > 15.0) && !Starved) {       // minimum 15% N2 needed for start
     Cranking = true;                   // provided for sound effects signal
     if (N2 < IdleN2) {
-      N2 = Seek(&N2, IdleN2, 2.0, N2/2.0);
-      N1 = Seek(&N1, IdleN1, 1.4, N1/2.0);
+      N2 = Seek(&N2, IdleN2, N2_start, N2/2.0);
+      N1 = Seek(&N1, IdleN1, N1_start, N1/2.0);
       EGT_degC = Seek(&EGT_degC, in.TAT_c + 363.1, 21.3, 7.3);
       FuelFlow_pph = IdleFF * N2 / IdleN2;
       OilPressure_psi = N2 * 0.62;
@@ -464,6 +464,10 @@ bool FGTurbine::Load(FGFDMExec* exec, Element *el)
     N1_spinup = el->FindElementValueAsNumber("n1spinup");
   if (el->FindElement("n2spinup"))
     N2_spinup = el->FindElementValueAsNumber("n2spinup");
+  if (el->FindElement("n1start"))
+    N1_start = el->FindElementValueAsNumber("n1start");
+  if (el->FindElement("n2start"))
+    N2_start = el->FindElementValueAsNumber("n2start");
   if (el->FindElement("augmented"))
     Augmented = (int)el->FindElementValueAsNumber("augmented");
   if (el->FindElement("augmethod"))

--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -281,7 +281,7 @@ double FGTurbine::SpinUp(void)
 {
   Running = false;
   FuelFlow_pph = 0.0;
-  N2 = Seek(&N2, IgnitionN1, N2_spinup, N2/2.0);
+  N2 = Seek(&N2, IgnitionN2, N2_spinup, N2/2.0);
   N1 = Seek(&N1, IgnitionN1, N1_spinup, N1/2.0);
   EGT_degC = Seek(&EGT_degC, in.TAT_c, 11.7, 7.3);
   OilPressure_psi = N2 * 0.62;

--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -70,7 +70,7 @@ FGTurbine::FGTurbine(FGFDMExec* exec, Element *el, int engine_number, struct Inp
   Augmented = AugMethod = Injected = 0;
   BypassRatio = BleedDemand = 0.0;
   IdleThrustLookup = MilThrustLookup = MaxThrustLookup = InjectionLookup = 0;
-  N1_spinup = 1.0; N2_spinup = 3.0; StartN1 = 5.21; StartN2 = 25.18; N1_start_rate = 1.4; N2_start_rate = 2.0; 
+  N1_spinup = 1.0; N2_spinup = 3.0; IgnitionN1 = 5.21; IgnitionN2 = 25.18; N1_start_rate = 1.4; N2_start_rate = 2.0; 
   InjectionTime = 30.0;
   InjectionTimer = InjWaterNorm = 0.0;
   EPR = 1.0;
@@ -281,8 +281,8 @@ double FGTurbine::SpinUp(void)
 {
   Running = false;
   FuelFlow_pph = 0.0;
-  N2 = Seek(&N2, StartN2, N2_spinup, N2/2.0);
-  N1 = Seek(&N1, StartN1, N1_spinup, N1/2.0);
+  N2 = Seek(&N2, IgnitionN1, N2_spinup, N2/2.0);
+  N1 = Seek(&N1, IgnitionN1, N1_spinup, N1/2.0);
   EGT_degC = Seek(&EGT_degC, in.TAT_c, 11.7, 7.3);
   OilPressure_psi = N2 * 0.62;
   OilTemp_degK = Seek(&OilTemp_degK, in.TAT_c + 273.0, 0.2, 0.2);
@@ -448,10 +448,10 @@ bool FGTurbine::Load(FGFDMExec* exec, Element *el)
     TSFC = el->FindElementValueAsNumber("tsfc");
   if (el->FindElement("atsfc"))
     ATSFC = el->FindElementValueAsNumber("atsfc");
-  if (el->FindElement("startn1"))
-    StartN1 = el->FindElementValueAsNumber("startn1");
-  if (el->FindElement("startn2"))
-    StartN2 = el->FindElementValueAsNumber("startn2");
+  if (el->FindElement("ignitionn1"))
+    IgnitionN1 = el->FindElementValueAsNumber("ignitionn1");
+  if (el->FindElement("ignitionn2"))
+    IgnitionN1 = el->FindElementValueAsNumber("ignitionn2");
   if (el->FindElement("idlen1"))
     IdleN1 = el->FindElementValueAsNumber("idlen1");
   if (el->FindElement("idlen2"))

--- a/src/models/propulsion/FGTurbine.h
+++ b/src/models/propulsion/FGTurbine.h
@@ -89,8 +89,8 @@ CLASS DOCUMENTATION
   <bleed> {number} </bleed>
   <tsfc> {number} </tsfc>
   <atsfc> {number} </atsfc>
-  <startn1> {number} </startn1>
-  <startn2> {number} </startn2>
+  <ignitionn1> {number} </ignitionn1>
+  <ignitionn2> {number} </ignitionn2>
   <idlen1> {number} </idlen1>
   <idlen2> {number} </idlen2>
   <n1spinup> {number} </n1spinup>
@@ -115,14 +115,14 @@ CLASS DOCUMENTATION
   bleed       - Thrust reduction factor due to losses (0.0 to 1.0).
   tsfc        - Thrust-specific fuel consumption at cruise, lbm/hr/lbf
   atsfc       - Afterburning TSFC, lbm/hr/lbf
-  startn1     - Fan rotor rpm (% of max) while starting
-  startn2     - Core rotor rpm (% of max) while starting
+  ignitionn1  - Fan rotor rpm (% of max) while starting
+  ignitionn2  - Core rotor rpm (% of max) while starting
   idlen1      - Fan rotor rpm (% of max) at idle
   idlen2      - Core rotor rpm (% of max) at idle
-  n1spinup    - Fan rotor rpm starter acceleration to startn1 value (default 1.0)
-  n2spinup    - Core rotor rpm starter acceleration to startn2 value (default 3.0)
-  n1startrate - Fan rotor rpm time taken to accelerate from startn1 to idlen1 value (default 1.4)
-  n2startrate - Core rotor rpm time taken to accelerate to startn2 idlen2 value (default 2.0)
+  n1spinup    - Fan rotor rpm starter acceleration to ignitionn1 value (default 1.0)
+  n2spinup    - Core rotor rpm starter acceleration to ignitionn2 value (default 3.0)
+  n1startrate - Fan rotor rpm time taken to accelerate from ignitionn1 to idlen1 value (default 1.4)
+  n2startrate - Core rotor rpm time taken to accelerate to ignitionn2 idlen2 value (default 2.0)
   maxn1       - Fan rotor rpm (% of max) at full throttle 
   maxn2       - Core rotor rpm (% of max) at full throttle
   augmented
@@ -246,8 +246,8 @@ private:
   double ATSFC;            ///< Augmented TSFC (lbm/hr/lbf)
   double IdleN1;           ///< Idle N1
   double IdleN2;           ///< Idle N2
-  double StartN1;           ///< Start N1
-  double StartN2;           ///< Start N2
+  double IgnitionN1;       ///< Ignition N1
+  double IgnitionN2;       ///< Ignition N2
   double N1;               ///< N1
   double N2;               ///< N2
   double N2norm;           ///< N2 normalized (0=idle, 1=max)
@@ -258,8 +258,8 @@ private:
   double N2_factor;        ///< factor to tie N2 and throttle
   double ThrottlePos;      ///< FCS-supplied throttle position - modified for local use!
   double AugmentCmd;       ///< modulated afterburner command (0.0 to 1.0)
-  double N1_spinup;        ///< N1 spin up rate from starter (per second)
-  double N2_spinup;        ///< N2 spin up rate from starter (per second)
+  double N1_spinup;        ///< N1 spin up rate from pneumatic starter (per second)
+  double N2_spinup;        ///< N2 spin up rate from pneumatic starter (per second)
   double N1_start_rate;    ///< N1 spin up rate from ignition (per second)
   double N2_start_rate;    ///< N2 spin up rate from ignition (per second)
   bool Stalled;            ///< true if engine is compressor-stalled

--- a/src/models/propulsion/FGTurbine.h
+++ b/src/models/propulsion/FGTurbine.h
@@ -89,6 +89,8 @@ CLASS DOCUMENTATION
   <bleed> {number} </bleed>
   <tsfc> {number} </tsfc>
   <atsfc> {number} </atsfc>
+  <startn1> {number} </startn1>
+  <startn2> {number} </startn2>
   <idlen1> {number} </idlen1>
   <idlen2> {number} </idlen2>
   <n1spinup> {number} </n1spinup>
@@ -111,10 +113,12 @@ CLASS DOCUMENTATION
   bleed       - Thrust reduction factor due to losses (0.0 to 1.0).
   tsfc        - Thrust-specific fuel consumption at cruise, lbm/hr/lbf
   atsfc       - Afterburning TSFC, lbm/hr/lbf
+  startn1     - Fan rotor rpm (% of max) while starting
+  startn2     - Core rotor rpm (% of max) while starting
   idlen1      - Fan rotor rpm (% of max) at idle
   idlen2      - Core rotor rpm (% of max) at idle
-  n1spinup    - Fan rotor rpm starter acceleration (default 1.0)
-  n2spinup    - Core rotor rpm starter acceleration (default 3.0)
+  n1spinup    - Fan rotor rpm starter acceleration to startn1 value (default 1.0)
+  n2spinup    - Core rotor rpm starter acceleration to startn2 value (default 3.0)
   maxn1       - Fan rotor rpm (% of max) at full throttle 
   maxn2       - Core rotor rpm (% of max) at full throttle
   augmented
@@ -238,6 +242,8 @@ private:
   double ATSFC;            ///< Augmented TSFC (lbm/hr/lbf)
   double IdleN1;           ///< Idle N1
   double IdleN2;           ///< Idle N2
+  double StartN1;           ///< Start N1
+  double StartN2;           ///< Start N2
   double N1;               ///< N1
   double N2;               ///< N2
   double N2norm;           ///< N2 normalized (0=idle, 1=max)

--- a/src/models/propulsion/FGTurbine.h
+++ b/src/models/propulsion/FGTurbine.h
@@ -66,8 +66,8 @@ CLASS DOCUMENTATION
 <P>
     - STARTING (on ground):
       -# Set the control FGEngine::Starter to true.  The engine will spin up to
-         a maximum of about %25 N2 (%5.2 N1).  This simulates the action of a
-         pneumatic starter.
+         a maximum of about %25 N2 (%5.2 N1). This value may be changed using the <startnX> parameter.
+		 This simulates the action of a pneumatic starter.
       -# After reaching %15 N2 set the control FGEngine::Cutoff to false. If fuel
          is available the engine will now accelerate to idle.  The starter will
          automatically be set to false after the start cycle.
@@ -78,7 +78,7 @@ CLASS DOCUMENTATION
       -# Place the control FGEngine::Cutoff to false.
 <P>
     Ignition is assumed to be on anytime the Cutoff control is set to false,
-    therefore a seperate ignition system is not modeled.
+    therefore a separate ignition system is not modeled.
 
 <h3>Configuration File Format:</h3>
 @code
@@ -95,8 +95,8 @@ CLASS DOCUMENTATION
   <idlen2> {number} </idlen2>
   <n1spinup> {number} </n1spinup>
   <n2spinup> {number} </n2spinup>
-  <n1start> {number} </n1start>
-  <n2start> {number} </n2start>
+  <n1startrate> {number} </n1startrate>
+  <n2startrate> {number} </n2startrate>
   <maxn1> {number} </maxn1>
   <maxn2> {number} </maxn2>
   <augmented> {0 | 1} </augmented>
@@ -121,8 +121,8 @@ CLASS DOCUMENTATION
   idlen2      - Core rotor rpm (% of max) at idle
   n1spinup    - Fan rotor rpm starter acceleration to startn1 value (default 1.0)
   n2spinup    - Core rotor rpm starter acceleration to startn2 value (default 3.0)
-  n1start     - Fan rotor rpm time taken to accelerate to idlen1 value (default 1.4)
-  n2start     - Core rotor rpm time taken to accelerate to idlen2 value (default 2.0)
+  n1startrate - Fan rotor rpm time taken to accelerate from startn1 to idlen1 value (default 1.4)
+  n2startrate - Core rotor rpm time taken to accelerate to startn2 idlen2 value (default 2.0)
   maxn1       - Fan rotor rpm (% of max) at full throttle 
   maxn2       - Core rotor rpm (% of max) at full throttle
   augmented
@@ -260,8 +260,8 @@ private:
   double AugmentCmd;       ///< modulated afterburner command (0.0 to 1.0)
   double N1_spinup;        ///< N1 spin up rate from starter (per second)
   double N2_spinup;        ///< N2 spin up rate from starter (per second)
-  double N1_start;    ///< N1 spin up rate from ignition (per second)
-  double N2_start;    ///< N2 spin up rate from ignition (per second)
+  double N1_start_rate;    ///< N1 spin up rate from ignition (per second)
+  double N2_start_rate;    ///< N2 spin up rate from ignition (per second)
   bool Stalled;            ///< true if engine is compressor-stalled
   bool Seized;             ///< true if inner spool is seized
   bool Overtemp;           ///< true if EGT exceeds limits

--- a/src/models/propulsion/FGTurbine.h
+++ b/src/models/propulsion/FGTurbine.h
@@ -95,6 +95,8 @@ CLASS DOCUMENTATION
   <idlen2> {number} </idlen2>
   <n1spinup> {number} </n1spinup>
   <n2spinup> {number} </n2spinup>
+  <n1start> {number} </n1start>
+  <n2start> {number} </n2start>
   <maxn1> {number} </maxn1>
   <maxn2> {number} </maxn2>
   <augmented> {0 | 1} </augmented>
@@ -119,6 +121,8 @@ CLASS DOCUMENTATION
   idlen2      - Core rotor rpm (% of max) at idle
   n1spinup    - Fan rotor rpm starter acceleration to startn1 value (default 1.0)
   n2spinup    - Core rotor rpm starter acceleration to startn2 value (default 3.0)
+  n1start     - Fan rotor rpm time taken to accelerate to idlen1 value (default 1.4)
+  n2start     - Core rotor rpm time taken to accelerate to idlen2 value (default 2.0)
   maxn1       - Fan rotor rpm (% of max) at full throttle 
   maxn2       - Core rotor rpm (% of max) at full throttle
   augmented
@@ -256,6 +260,8 @@ private:
   double AugmentCmd;       ///< modulated afterburner command (0.0 to 1.0)
   double N1_spinup;        ///< N1 spin up rate from starter (per second)
   double N2_spinup;        ///< N2 spin up rate from starter (per second)
+  double N1_start;    ///< N1 spin up rate from ignition (per second)
+  double N2_start;    ///< N2 spin up rate from ignition (per second)
   bool Stalled;            ///< true if engine is compressor-stalled
   bool Seized;             ///< true if inner spool is seized
   bool Overtemp;           ///< true if EGT exceeds limits


### PR DESCRIPTION
Hi,
I have a small patch allowing aircraft developers to change the value to which the starter rotates the fan before ignition starts, allowing them to change it from 5% / 25% giving more control over startup time on turbine engines. I will create another patch soon to add a similar n1spinup value between this value and idlen1.

I did not test it, as I am on Windows, and compilation is a bit more difficult... it _should_ work, but might not!
There is also no sanity check, so you could have some crazy number: e.g. it trying to spin up to 100% if you set startn1 to that in the xml. But I think JSBSIM is "garbage in, garbage out"? 😄  

 
Edit: I have now added a value n1start / n2start which allows the user to control the time between the values I added previously and idle n1 / n2.

So, overall I added:
 
  ```
<startnX> {number} </startnX> added
  <nXspinup> {number} </nXspinup> adjusted: time between 0% and startnX%
  <nXstart> {number} </nXstart> added, time between startnX% and idlenX%
```
where X is equal to 1 or 2.

I realise the similarity between startnX and nXstart might confuse some users, any suggestions as to what to change the names to?


Also, you might like to squash these commits - I am using the web interface until I can start compiling.

Thanks!