### PR TITLE
Add ability to control spindown rate factor

### DIFF
--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -71,6 +71,7 @@ FGTurbine::FGTurbine(FGFDMExec* exec, Element *el, int engine_number, struct Inp
   BypassRatio = BleedDemand = 0.0;
   IdleThrustLookup = MilThrustLookup = MaxThrustLookup = InjectionLookup = 0;
   N1_spinup = 1.0; N2_spinup = 3.0; IgnitionN1 = 5.21; IgnitionN2 = 25.18; N1_start_rate = 1.4; N2_start_rate = 2.0; 
+  N1_spindown = 2.0; N2_spindown = 2.0;
   InjectionTime = 30.0;
   InjectionTimer = InjWaterNorm = 0.0;
   EPR = 1.0;
@@ -186,8 +187,8 @@ double FGTurbine::Off(void)
 {
   Running = false;
   FuelFlow_pph = Seek(&FuelFlow_pph, 0, 1000.0, 10000.0);
-  N1 = Seek(&N1, in.qbar/10.0, N1/2.0, N1/2.0);
-  N2 = Seek(&N2, in.qbar/15.0, N2/2.0, N2/2.0);
+  N1 = Seek(&N1, in.qbar/10.0, N1/2.0, N1/N1_spindown);
+  N2 = Seek(&N2, in.qbar/15.0, N2/2.0, N2/N2_spindown);
   EGT_degC = Seek(&EGT_degC, in.TAT_c, 11.7, 7.3);
   OilTemp_degK = Seek(&OilTemp_degK, in.TAT_c + 273.0, 0.2, 0.2);
   OilPressure_psi = N2 * 0.62;
@@ -468,6 +469,10 @@ bool FGTurbine::Load(FGFDMExec* exec, Element *el)
     N1_start_rate = el->FindElementValueAsNumber("n1startrate");
   if (el->FindElement("n2startrate"))
     N2_start_rate = el->FindElementValueAsNumber("n2startrate");
+  if (el->FindElement("n1spindown"))
+    N1_spindown = el->FindElementValueAsNumber("n1spindown");
+  if (el->FindElement("n2spindown"))
+    N2_spindown = el->FindElementValueAsNumber("n2spindown");
   if (el->FindElement("augmented"))
     Augmented = (int)el->FindElementValueAsNumber("augmented");
   if (el->FindElement("augmethod"))

--- a/src/models/propulsion/FGTurbine.h
+++ b/src/models/propulsion/FGTurbine.h
@@ -97,6 +97,8 @@ CLASS DOCUMENTATION
   <n2spinup> {number} </n2spinup>
   <n1startrate> {number} </n1startrate>
   <n2startrate> {number} </n2startrate>
+  <n1spindown> {number} </n1spindown>
+  <n2spindown> {number} </n2spindown>
   <maxn1> {number} </maxn1>
   <maxn2> {number} </maxn2>
   <augmented> {0 | 1} </augmented>
@@ -123,6 +125,8 @@ CLASS DOCUMENTATION
   n2spinup    - Core rotor rpm starter acceleration to ignitionn2 value (default 3.0)
   n1startrate - Fan rotor rpm time taken to accelerate from ignitionn1 to idlen1 value (default 1.4)
   n2startrate - Core rotor rpm time taken to accelerate to ignitionn2 idlen2 value (default 2.0)
+  n1spindown  - Factor used in calculation for fan rotor time to spool down to zero (default 2.0)
+  n2spindown  - Factor used in calculation for core rotor time to spool down to zero (default 2.0)
   maxn1       - Fan rotor rpm (% of max) at full throttle 
   maxn2       - Core rotor rpm (% of max) at full throttle
   augmented
@@ -262,6 +266,8 @@ private:
   double N2_spinup;        ///< N2 spin up rate from pneumatic starter (per second)
   double N1_start_rate;    ///< N1 spin up rate from ignition (per second)
   double N2_start_rate;    ///< N2 spin up rate from ignition (per second)
+  double N1_spindown;      ///< N1 spin down factor
+  double N2_spindown;      ///< N2 spin down factor
   bool Stalled;            ///< true if engine is compressor-stalled
   bool Seized;             ///< true if inner spool is seized
   bool Overtemp;           ///< true if EGT exceeds limits


### PR DESCRIPTION
Allows user to adjust spindown time by using n1spindown and n2spindown, which will be used as such:

```
N1rate = N1 / n1spindown
N2rate = N2 / n1spindown
```

If this pull request is accepted, I would like this to be in 2019.1 with the other changes if at all possible?