### PR TITLE
Abassign patch 1

### DIFF
--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -57,6 +57,7 @@ INCLUDES
 #include "models/flight_control/FGWaypoint.h"
 #include "models/flight_control/FGAngles.h"
 #include "models/flight_control/FGDistributor.h"
+#include "models/flight_control/FGLinearActuator.h"
 
 #include "FGFCSChannel.h"
 
@@ -578,6 +579,8 @@ bool FGFCS::Load(Element* document)
           newChannel->Add(new FGAngles(this, component_element));
         } else if (component_element->GetName() == string("distributor")) {
           newChannel->Add(new FGDistributor(this, component_element));
+        } else if (component_element->GetName() == string("linear_actuator")) {
+          newChannel->Add(new FGLinear_Actuator(this, component_element));
         } else {
           cerr << "Unknown FCS component: " << component_element->GetName() << endl;
         }

--- a/src/models/flight_control/FGLinearActuator.cpp
+++ b/src/models/flight_control/FGLinearActuator.cpp
@@ -1,252 +1,286 @@
-/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- * 
- * Module:       FGLinearActuator.cpp
- * Author:       Adriano Bassignana
- * Date started: 2019-01-03
- * 
- * ------------- Copyright (C) 2000 -------------
- * 
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
- * details.
- * 
- * You should have received a copy of the GNU Lesser General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA  02111-1307, USA.
- * 
- * Further information about the GNU Lesser General Public License can also be found on
- * the world wide web at http://www.gnu.org.
- * 
- * FUNCTIONAL DESCRIPTION
- * --------------------------------------------------------------------------------
- * 
- * HISTORY
- * --------------------------------------------------------------------------------
- * 
- * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- * COMMENTS, REFERENCES,  and NOTES
- * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- * 
- * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- * INCLUDES
- * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
-
-#include "FGLinearActuator.h"
-#include "input_output/FGXMLElement.h"
-#include <iostream>
-
-using namespace std;
-
-namespace JSBSim {
-    
-    /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-     * CLASS IMPLEMENTATION
-     * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
-    
-    FGLinear_Actuator::FGLinear_Actuator(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
-    {
-        initialized = 1;
-        versus = 0.0;
-        isSetProperty = false;
-        isResetProperty = false;
-        direction = 0;
-        countSpin = 0;
-        input_prec = 0.0;
-        module = 1.0;
-        rate = 0.3;
-        minRate = -0.3;
-        maxRate = 0.3;
-        lag = 0.0;
-        lagPrevius = 0.0;
-        gain = 1.0;
+ /* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  * 
+  * Module:       FGLinearActuator.cpp
+  * Author:       Adriano Bassignana
+  * Date started: 2019-01-03
+  * 
+  * ------------- Copyright (C) 2000 -------------
+  * 
+  * This program is free software; you can redistribute it and/or modify it under
+  * the terms of the GNU Lesser General Public License as published by the Free Software
+  * Foundation; either version 2 of the License, or (at your option) any later
+  * version.
+  * 
+  * This program is distributed in the hope that it will be useful, but WITHOUT
+  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+  * details.
+  * 
+  * You should have received a copy of the GNU Lesser General Public License along with
+  * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+  * Place - Suite 330, Boston, MA  02111-1307, USA.
+  * 
+  * Further information about the GNU Lesser General Public License can also be found on
+  * the world wide web at http://www.gnu.org.
+  * 
+  * FUNCTIONAL DESCRIPTION
+  * --------------------------------------------------------------------------------
+  * 
+  * HISTORY
+  * --------------------------------------------------------------------------------
+  * 
+  * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  * COMMENTS, REFERENCES,  and NOTES
+  * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  * 
+  * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  * INCLUDES
+  * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+ 
+ #include "FGLinearActuator.h"
+ #include "input_output/FGXMLElement.h"
+ #include "math/FGParameterValue.h"
+ #include <iostream>
+ 
+ #ifndef DEBUG
+ #define DEBUG 0
+ #endif
+ 
+ using namespace std;
+ 
+ namespace JSBSim {
+     
+     /* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+      * CLASS IMPLEMENTATION
+      * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+     
+     FGLinear_Actuator::FGLinear_Actuator(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
+     {
+         
+         if (element->FindElement("set")) {
+             isSetProperty = true;
+             setProperty = PropertyManager->CreatePropertyObject<double>(element->FindElementValue("set"));
+         }
+         if (element->FindElement("reset")) {
+             isResetProperty = true;
+             resetProperty = PropertyManager->CreatePropertyObject<double>(element->FindElementValue("reset"));
+         }
+         
+         ptrVersus = nullptr;
+         if (element->FindElement("versus")) {
+             string property_string = element->FindElementValue("versus");
+             ptrVersus = new FGParameterValue(property_string, PropertyManager);
+             double setVersus = ptrVersus->GetValue();
+             if (ptrVersus->IsConstant()) {
+                 if (setVersus >= 0.5) {
+                     versus = 1;
+                 } else if (setVersus <= -0.5) {
+                     versus = -1;
+                 }
+             }
+         } else versus = 0;
+         
+         ptrBias = nullptr;
+         if (element->FindElement("bias")) {
+             string property_string = element->FindElementValue("bias");
+             ptrBias = new FGParameterValue(property_string, PropertyManager);
+             bias = ptrBias->GetValue();
+         } else bias = 0;
+         
+         if (element->FindElement("module")) module = element->FindElementValueAsNumber("module");
+         if (element->FindElement("hysteresis")) hysteresis = element->FindElementValueAsNumber("hysteresis");
+         
+         if (element->FindElement("lag")) lag = element->FindElementValueAsNumber("lag");
+         if (lag > 0.0) {
+             double denom = 2.00 + dt*lag;
+             ca = dt * lag / denom;
+             cb = (2.00 - dt * lag) / denom;
+         }
+         
+         if (element->FindElement("rate")) {
+             rate = element->FindElementValueAsNumber("rate");
+             if (rate <= 0 or rate > 1.0) rate = 0.5;
+             minRate = -(rate);
+             maxRate = rate;
+         } else {
+             rate = 0.3;
+             minRate = -0.3;
+             maxRate = 0.3;
+         }
+         
+         if (element->FindElement("gain")) gain = element->FindElementValueAsNumber("gain");
+         
+         FGFCSComponent::bind();
+         
+         Debug(0);
+     }
+     
+     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     
+     FGLinear_Actuator::~FGLinear_Actuator()
+     {
+         Debug(1);
+     }
+     
+     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     
+     bool FGLinear_Actuator::Run(void )
+     {
+         #if DEBUG == 1
+         bool isOutputChange = false;
+         #endif
         
-        if (element->FindElement("set")) {
-            setProperty = PropertyManager->CreatePropertyObject<double>(element->FindElementValue("set"));
-            isSetProperty = true;
-        }
-        if (element->FindElement("reset")) {
-            resetProperty = PropertyManager->CreatePropertyObject<double>(element->FindElementValue("reset"));
-            isResetProperty = true;
-        }
-
-        if (element->FindElement("versus")) versus = element->FindElementValueAsNumber("versus");
-        if (element->FindElement("lag")) lag = element->FindElementValueAsNumber("lag");
-        if (element->FindElement("module")) module = element->FindElementValueAsNumber("module");
-        if (element->FindElement("rate")) {
-            rate = element->FindElementValueAsNumber("rate");
-            if (rate <= 0 or rate > 1.0) rate = 0.5;
-            minRate = -(rate);
-            maxRate = rate;
-        }
-        if (element->FindElement("gain")) gain = element->FindElementValueAsNumber("gain");
-        
-        FGFCSComponent::bind();
-        
-        Debug(0);
-    }
-    
-    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    
-    FGLinear_Actuator::~FGLinear_Actuator()
-    {
-        Debug(1);
-    }
-    
-    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    
-    bool FGLinear_Actuator::Run(void )
-    {
-        Input = InputNodes[0]->getDoubleValue();
-        if (initialized) {
-            input_prec = Input;
-            initialized = 0;
-            std::cerr << "FGLinear_Actuator Cicle_zero " << InputNodes[0]->GetNameWithSign() << std::endl;
-            return true;
-        }
-        
-        Output = 0.0;
-        
-        set = 1.0;
-        reset = 0.0;
-        
-        if (isSetProperty) set = setProperty;
-        if (isResetProperty) reset = resetProperty;
-            
-        if (set > 0 ) {
-            
-            double input_delta = Input - input_prec;
-            
-            if ((versus < 0.0 and input_delta > 0.0) or (versus  > 0.0 and input_delta < 0.0)) {
-                input_delta = 0.0;
-            }
-            input_prec = Input;
-            
-            if (input_delta != 0.0) {
-                if (input_delta <= (module * maxRate) and input_delta >= (module * minRate)) {
-                    if (input_delta > 0.0) {
-                        direction = 1;
-                        //cout << "FGLinear_Actuator::Run" << InputNodes[0]->GetNameWithSign() << " direction + " << direction << endl;
-                    } else if (input_delta < 0.0) {
-                        direction = -1;
-                        //cout << "FGLinear_Actuator::Run" << InputNodes[0]->GetNameWithSign() << " direction - " << direction << endl;
-                    }
-                }
-                
-                if (direction != 0) {
-                    if (input_delta >= (module * maxRate) or input_delta <= (module * minRate)) {
-                        if (direction > 0) {
-                            countSpin++;
-                            cout << "FGLinear_Actuator::Run" << InputNodes[0]->GetNameWithSign() << " countSpin++ " << countSpin << " maxRate " << maxRate << " minRate " << minRate << endl;
-                            direction = 0;
-                        } else if (direction < 0) {
-                            countSpin--;
-                            cout << "FGLinear_Actuator::Run" << InputNodes[0]->GetNameWithSign() << " countSpin-- " << countSpin << " maxRate " << maxRate << " minRate " << minRate << endl;
-                            direction = 0;
-                        }
-                    }
-                }
-                
-            }
-        } else {
-            Input = input_prec;
-        }
-        
-        if (reset > 0) {
-            Input = 0.0;
-            countSpin = 0.0;
-        }
-        
-        Output = gain * (Input + module*countSpin);
-        Lag();
-        Clip();
-        if (IsOutput) SetOutput();
-        
-        return true;
-    }
-    
-    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    
-    void FGLinear_Actuator::Lag(void)
-    {
-        // "Output" on the right side of the "=" is the current frame input
-        // for this Lag filter
-        double input = Output;
-        
-        if (lag > 0.0) {
-            if (lag == lagPrevius) {
-                Output = ca * (input + previousLagInput) + previousLagOutput * cb;
-            } else {
-                double denom = 2.00 + dt*lag;
-                ca = dt * lag / denom;
-                cb = (2.00 - dt * lag) / denom;
-                previousLagInput = 0.0;
-                previousLagOutput = 0.0;
-                lagPrevius = lag;
-            }
-            
-            previousLagInput = input;
-            previousLagOutput = Output;
-        }
-    }
-    
-    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    //    The bitmasked value choices are as follows:
-    //    unset: In this case (the default) JSBSim would only print
-    //       out the normally expected messages, essentially echoing
-    //       the config files as they are read. If the environment
-    //       variable is not set, debug_lvl is set to 1 internally
-    //    0: This requests JSBSim not to output any messages
-    //       whatsoever.
-    //    1: This value explicity requests the normal JSBSim
-    //       startup messages
-    //    2: This value asks for a message to be printed out when
-    //       a class is instantiated
-    //    4: When this value is set, a message is displayed when a
-    //       FGModel object executes its Run() method
-    //    8: When this value is set, various runtime state variables
-    //       are printed out periodically
-    //    16: When set various parameters are sanity checked and
-    //       a message is printed out when they go out of bounds
-    
-    void FGLinear_Actuator::Debug(int from)
-    {
-        if (debug_lvl <= 0) return;
-        
-        if (debug_lvl & 1) { // Standard console startup message output
-            if (from == 0) { // Constructor
-                cout << "      INPUT: " << InputNodes[0]->GetNameWithSign() << endl;
-                cout << "     module: " << module << endl;
-                if (direction != 0.0) cout << " direction: " << direction << endl;
-                cout << "       rate: " << rate << endl;
-                if (versus != 0.0) cout << "     versus: " << versus << endl;
-                cout << "  countSpin: " << countSpin << endl;
-                if (lag != 0.0)  cout  << "       Lag: " << lag << endl;
-                if (gain != 0.0)  cout << "      Gain: " << gain << endl;
-                for (auto node: OutputNodes)
-                    cout << "     OUTPUT: " << node->GetName() << endl;
-            }
-        }
-        if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-            if (from == 0) cout << "Instantiated: FGLinear_Actuator" << endl;
-            if (from == 1) cout << "Destroyed:    FGLinear_Actuator" << endl;
-        }
-        if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
-        }
-        if (debug_lvl & 8 ) { // Runtime state variables
-        }
-        if (debug_lvl & 16) { // Sanity checking
-        }
-        if (debug_lvl & 64) {
-            if (from == 0) { // Constructor
-            }
-        }
-    }
-    
-} //namespace JSBSim
-
+         if (isSetProperty) set = abs(setProperty) >= 0.5;
+         if (isResetProperty) reset = abs(resetProperty) >= 0.5;
+         
+         if (reset) {
+             input_mem = 0.0;
+             countSpin = 0;
+             direction = 0;
+             Output = 0.0;
+             input_lost = 0.0;
+         } else {
+             if (set) {
+                 Input = InputNodes[0]->getDoubleValue() - input_lost;
+                 double input_delta = Input - input_mem;
+                 if (abs(input_delta) >= hysteresis) {
+                     if (ptrVersus && !ptrVersus->IsConstant()) {
+                         double setVersus = ptrVersus->GetValue();
+                         if (setVersus >= 0.5) {
+                             versus = 1;
+                         } else if (setVersus <= -0.5) {
+                             versus = -1;
+                         } else versus = 0;
+                     }
+                     if (input_delta <= (module * maxRate) and input_delta >= (module * minRate)) {
+                         if (input_delta > 0.0) {
+                             direction = 1;
+                             #if DEBUG == 1
+                             cout << "FGLinear_Actuator::Run " << InputNodes[0]->GetNameWithSign() << " direction + : " << direction << " countSpin: " << countSpin << " versus: " << versus << " input delta: " << input_delta << endl;
+                             #endif
+                         } else if (input_delta < 0.0) {
+                             direction = -1;
+                             #if DEBUG == 1
+                             cout << "FGLinear_Actuator::Run " << InputNodes[0]->GetNameWithSign() << " direction - : " << direction << " countSpin: " << countSpin << " versus: " << versus << " input delta: " << input_delta << endl;
+                             #endif
+                         }
+                     }
+                     if ((versus == 0) || (versus == direction)) {
+                         #if DEBUG == 1
+                         cout << "FGLinear_Actuator::Run " << InputNodes[0]->GetNameWithSign() << " Input: " << Input << " versus: " << versus << " input_mem: " << input_mem;
+                         #endif
+                         input_mem = Input;
+                         #if DEBUG == 1
+                         isOutputChange = true;
+                         cout << " -> " << input_mem   << " input lost: " << input_lost << "(" << Input + input_lost << ") input_delta: " << input_delta << " module: " << module << endl;
+                         #endif
+                         if (direction != 0) {
+                             if (input_delta >= (module * maxRate) or input_delta <= (module * minRate)) {
+                                 if (direction > 0) {
+                                     countSpin++;
+                                     #if DEBUG == 1
+                                     cout << "FGLinear_Actuator::Run " << InputNodes[0]->GetNameWithSign() << " countSpin++ : " << countSpin << " maxRate: " << maxRate << " minRate: " << minRate << endl;
+                                     #endif
+                                     direction = 0;
+                                 } else if (direction < 0) {
+                                     countSpin--;
+                                     #if DEBUG == 1
+                                     cout << "FGLinear_Actuator::Run " << InputNodes[0]->GetNameWithSign() << " countSpin-- : " << countSpin << " maxRate: " << maxRate << " minRate: " << minRate << endl;
+                                     #endif
+                                     direction = 0;
+                                 }
+                             }
+                         }
+                     } else if ((versus != 0) && (direction != 0) && (versus != direction)) {
+                         input_lost += input_delta;
+                     }
+                 }
+             }
+             Output = gain * (bias + input_mem + module*countSpin);
+             #if DEBUG == 1
+             if (isOutputChange) {
+                    cout << "FGLinear_Actuator::Run " << InputNodes[0]->GetNameWithSign() << " Output : " << Output << " Input: " << Input << " input_mem: " << input_mem << " countSpin: " << countSpin << endl;
+             }
+             #endif
+         }
+         
+         if (lag > 0.0) {
+             double input = Output; 
+             Output = ca * (input + previousLagInput) + previousLagOutput * cb;
+             #if DEBUG == 1
+             if (isOutputChange) {
+                    cout << "FGLinear_Actuator::Run LAG " << InputNodes[0]->GetNameWithSign() << " Output : " << Output << " previousLagInput: " << previousLagInput << " previousLagOutput: " << previousLagOutput << endl;
+             }
+             #endif
+             previousLagInput = input;
+             previousLagOutput = Output;
+         }
+         
+         Clip();
+         if (IsOutput) SetOutput();
+         
+         return true;
+     }
+     
+     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     //    The bitmasked value choices are as follows:
+     //    unset: In this case (the default) JSBSim would only print
+     //       out the normally expected messages, essentially echoing
+     //       the config files as they are read. If the environment
+     //       variable is not set, debug_lvl is set to 1 internally
+     //    0: This requests JSBSim not to output any messages
+     //       whatsoever.
+     //    1: This value explicity requests the normal JSBSim
+     //       startup messages
+     //    2: This value asks for a message to be printed out when
+     //       a class is instantiated
+     //    4: When this value is set, a message is displayed when a
+     //       FGModel object executes its Run() method
+     //    8: When this value is set, various runtime state variables
+     //       are printed out periodically
+     //    16: When set various parameters are sanity checked and
+     //       a message is printed out when they go out of bounds
+     
+     void FGLinear_Actuator::Debug(int from)
+     {
+         if (debug_lvl <= 0) return;
+         
+         if (debug_lvl & 1) { // Standard console startup message output
+             if (from == 0) { // Constructor                 
+                 cout << "      INPUT: " << InputNodes[0]->GetNameWithSign() << endl;
+                 cout << "  input_mem: " << input_mem << endl;
+                 cout << "       bias: " << bias << endl;
+                 cout << "     module: " << module << endl;
+                 cout << " hysteresis: " << hysteresis << endl;
+                 cout << "       rate: " << rate << endl;
+                 cout << "     versus: " << versus << endl;
+                 cout << "  direction: " << direction << endl;
+                 cout << "  countSpin: " << countSpin << endl;
+                 cout << "        Lag: " << lag << endl;
+                 cout << "       Gain: " << gain << endl;
+                 cout << "        set: " << set << endl;
+                 cout << "      reset: " << reset << endl;
+                 for (auto node: OutputNodes)
+                     cout << "     OUTPUT: " << node->GetName() << endl;
+             }
+         }
+         if (debug_lvl & 2 ) { // Instantiation/Destruction notification
+             if (from == 0) cout << "Instantiated: FGLinear_Actuator" << endl;
+             if (from == 1) cout << "Destroyed:    FGLinear_Actuator" << endl;
+         }
+         if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
+         }
+         if (debug_lvl & 8 ) { // Runtime state variables
+         }
+         if (debug_lvl & 16) { // Sanity checking
+         }
+         if (debug_lvl & 64) {
+             if (from == 0) { // Constructor
+             }
+         }
+     }
+     
+ }
+ 
+ 
+ 

--- a/src/models/flight_control/FGLinearActuator.cpp
+++ b/src/models/flight_control/FGLinearActuator.cpp
@@ -1,0 +1,252 @@
+/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ * 
+ * Module:       FGLinearActuator.cpp
+ * Author:       Adriano Bassignana
+ * Date started: 2019-01-03
+ * 
+ * ------------- Copyright (C) 2000 -------------
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place - Suite 330, Boston, MA  02111-1307, USA.
+ * 
+ * Further information about the GNU Lesser General Public License can also be found on
+ * the world wide web at http://www.gnu.org.
+ * 
+ * FUNCTIONAL DESCRIPTION
+ * --------------------------------------------------------------------------------
+ * 
+ * HISTORY
+ * --------------------------------------------------------------------------------
+ * 
+ * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ * COMMENTS, REFERENCES,  and NOTES
+ * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ * 
+ * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ * INCLUDES
+ * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+#include "FGLinearActuator.h"
+#include "input_output/FGXMLElement.h"
+#include <iostream>
+
+using namespace std;
+
+namespace JSBSim {
+    
+    /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     * CLASS IMPLEMENTATION
+     * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+    
+    FGLinear_Actuator::FGLinear_Actuator(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
+    {
+        initialized = 1;
+        versus = 0.0;
+        isSetProperty = false;
+        isResetProperty = false;
+        direction = 0;
+        countSpin = 0;
+        input_prec = 0.0;
+        module = 1.0;
+        rate = 0.3;
+        minRate = -0.3;
+        maxRate = 0.3;
+        lag = 0.0;
+        lagPrevius = 0.0;
+        gain = 1.0;
+        
+        if (element->FindElement("set")) {
+            setProperty = PropertyManager->CreatePropertyObject<double>(element->FindElementValue("set"));
+            isSetProperty = true;
+        }
+        if (element->FindElement("reset")) {
+            resetProperty = PropertyManager->CreatePropertyObject<double>(element->FindElementValue("reset"));
+            isResetProperty = true;
+        }
+
+        if (element->FindElement("versus")) versus = element->FindElementValueAsNumber("versus");
+        if (element->FindElement("lag")) lag = element->FindElementValueAsNumber("lag");
+        if (element->FindElement("module")) module = element->FindElementValueAsNumber("module");
+        if (element->FindElement("rate")) {
+            rate = element->FindElementValueAsNumber("rate");
+            if (rate <= 0 or rate > 1.0) rate = 0.5;
+            minRate = -(rate);
+            maxRate = rate;
+        }
+        if (element->FindElement("gain")) gain = element->FindElementValueAsNumber("gain");
+        
+        FGFCSComponent::bind();
+        
+        Debug(0);
+    }
+    
+    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    FGLinear_Actuator::~FGLinear_Actuator()
+    {
+        Debug(1);
+    }
+    
+    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    bool FGLinear_Actuator::Run(void )
+    {
+        Input = InputNodes[0]->getDoubleValue();
+        if (initialized) {
+            input_prec = Input;
+            initialized = 0;
+            std::cerr << "FGLinear_Actuator Cicle_zero " << InputNodes[0]->GetNameWithSign() << std::endl;
+            return true;
+        }
+        
+        Output = 0.0;
+        
+        set = 1.0;
+        reset = 0.0;
+        
+        if (isSetProperty) set = setProperty;
+        if (isResetProperty) reset = resetProperty;
+            
+        if (set > 0 ) {
+            
+            double input_delta = Input - input_prec;
+            
+            if ((versus < 0.0 and input_delta > 0.0) or (versus  > 0.0 and input_delta < 0.0)) {
+                input_delta = 0.0;
+            }
+            input_prec = Input;
+            
+            if (input_delta != 0.0) {
+                if (input_delta <= (module * maxRate) and input_delta >= (module * minRate)) {
+                    if (input_delta > 0.0) {
+                        direction = 1;
+                        //cout << "FGLinear_Actuator::Run" << InputNodes[0]->GetNameWithSign() << " direction + " << direction << endl;
+                    } else if (input_delta < 0.0) {
+                        direction = -1;
+                        //cout << "FGLinear_Actuator::Run" << InputNodes[0]->GetNameWithSign() << " direction - " << direction << endl;
+                    }
+                }
+                
+                if (direction != 0) {
+                    if (input_delta >= (module * maxRate) or input_delta <= (module * minRate)) {
+                        if (direction > 0) {
+                            countSpin++;
+                            cout << "FGLinear_Actuator::Run" << InputNodes[0]->GetNameWithSign() << " countSpin++ " << countSpin << " maxRate " << maxRate << " minRate " << minRate << endl;
+                            direction = 0;
+                        } else if (direction < 0) {
+                            countSpin--;
+                            cout << "FGLinear_Actuator::Run" << InputNodes[0]->GetNameWithSign() << " countSpin-- " << countSpin << " maxRate " << maxRate << " minRate " << minRate << endl;
+                            direction = 0;
+                        }
+                    }
+                }
+                
+            }
+        } else {
+            Input = input_prec;
+        }
+        
+        if (reset > 0) {
+            Input = 0.0;
+            countSpin = 0.0;
+        }
+        
+        Output = gain * (Input + module*countSpin);
+        Lag();
+        Clip();
+        if (IsOutput) SetOutput();
+        
+        return true;
+    }
+    
+    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    void FGLinear_Actuator::Lag(void)
+    {
+        // "Output" on the right side of the "=" is the current frame input
+        // for this Lag filter
+        double input = Output;
+        
+        if (lag > 0.0) {
+            if (lag == lagPrevius) {
+                Output = ca * (input + previousLagInput) + previousLagOutput * cb;
+            } else {
+                double denom = 2.00 + dt*lag;
+                ca = dt * lag / denom;
+                cb = (2.00 - dt * lag) / denom;
+                previousLagInput = 0.0;
+                previousLagOutput = 0.0;
+                lagPrevius = lag;
+            }
+            
+            previousLagInput = input;
+            previousLagOutput = Output;
+        }
+    }
+    
+    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    //    The bitmasked value choices are as follows:
+    //    unset: In this case (the default) JSBSim would only print
+    //       out the normally expected messages, essentially echoing
+    //       the config files as they are read. If the environment
+    //       variable is not set, debug_lvl is set to 1 internally
+    //    0: This requests JSBSim not to output any messages
+    //       whatsoever.
+    //    1: This value explicity requests the normal JSBSim
+    //       startup messages
+    //    2: This value asks for a message to be printed out when
+    //       a class is instantiated
+    //    4: When this value is set, a message is displayed when a
+    //       FGModel object executes its Run() method
+    //    8: When this value is set, various runtime state variables
+    //       are printed out periodically
+    //    16: When set various parameters are sanity checked and
+    //       a message is printed out when they go out of bounds
+    
+    void FGLinear_Actuator::Debug(int from)
+    {
+        if (debug_lvl <= 0) return;
+        
+        if (debug_lvl & 1) { // Standard console startup message output
+            if (from == 0) { // Constructor
+                cout << "      INPUT: " << InputNodes[0]->GetNameWithSign() << endl;
+                cout << "     module: " << module << endl;
+                if (direction != 0.0) cout << " direction: " << direction << endl;
+                cout << "       rate: " << rate << endl;
+                if (versus != 0.0) cout << "     versus: " << versus << endl;
+                cout << "  countSpin: " << countSpin << endl;
+                if (lag != 0.0)  cout  << "       Lag: " << lag << endl;
+                if (gain != 0.0)  cout << "      Gain: " << gain << endl;
+                for (auto node: OutputNodes)
+                    cout << "     OUTPUT: " << node->GetName() << endl;
+            }
+        }
+        if (debug_lvl & 2 ) { // Instantiation/Destruction notification
+            if (from == 0) cout << "Instantiated: FGLinear_Actuator" << endl;
+            if (from == 1) cout << "Destroyed:    FGLinear_Actuator" << endl;
+        }
+        if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
+        }
+        if (debug_lvl & 8 ) { // Runtime state variables
+        }
+        if (debug_lvl & 16) { // Sanity checking
+        }
+        if (debug_lvl & 64) {
+            if (from == 0) { // Constructor
+            }
+        }
+    }
+    
+} //namespace JSBSim
+

--- a/src/models/flight_control/FGLinearActuator.h
+++ b/src/models/flight_control/FGLinearActuator.h
@@ -1,0 +1,229 @@
+/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ * 
+ * Header:  FGLinearActuator.h
+ * Author:  Adriano Bassignana
+ * Date started: 2019-01-02
+ * 
+ * ------------- Copyright (C)  -------------
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place - Suite 330, Boston, MA  02111-1307, USA.
+ * 
+ * Further information about the GNU Lesser General Public License can also be found on
+ * the world wide web at http://www.gnu.org.
+ * 
+ * HISTORY
+ * --------------------------------------------------------------------------------
+ * 
+ * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ * SENTRY
+ * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+#ifndef FGLINEARACTUATOR_H
+#define FGLINEARACTUATOR_H
+
+/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ * INCLUDES
+ * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+#include "FGFCSComponent.h"
+#include "simgear/props/propertyObject.hxx"
+
+/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ * FORWARD DECLARATIONS
+ * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+namespace JSBSim {
+    
+    class Element;
+    
+    /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     * CLASS DOCUMENTATION
+     * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+    
+    /** Models a flight control system summing component.
+     *    linear actuators typically operate by conversion of rotary motion into linear motion.
+     *    The linear_actuator component is decrobed in the Wikipedia link:
+     *    https://en.wikipedia.org/wiki/Linear_actuator
+     *    Converts a rotation into a linear movement or a multiturn rotation.
+     *    For the conversion it is necessary to declare a module
+     *    that is defined by the difference of the maximum and minimum value Input.
+     *    List of parameters:
+     * 
+     *    input: Value to be transformed
+     *    module: Difference of the maximum and minimum value Input, default is 1.0
+     *    versus: Direction of rotation if fixed. The versus allows to obtain a kinematism
+     *      similar to the escapement of a clock. The default value is 0.0 If the value
+     *      is zero, the verse is automatically obtained according to variation of
+     *      the input data.
+     *      If set to a value> 0 the verse is increasing, ie the output changes only
+     *      if the Input value is greater than the previous one.
+     *      If set to a negative value, the output changes only if the next value
+     *      is lower than the previous one.
+     *      With this parameter allows to easily obtain a "step counter".
+     *    rate: To define when the rotation is complete, the differential criterion is used.
+     *      For example, if the rotation is clockwise and the module is 360, the revolution
+     *      will be complete when the input value changes from 360 to 0.
+     *      When this happens a counter increases the output of the value of the module.
+     *      As a way the system keeps track of the number of rotations.
+     *      Rate defines the sensitivity of the system.
+     *      If a difficulty in determining the rotation is observed during the tests,
+     *      this parameter must be modified with a positive value not exceeding 1.
+     *      The default value is 0.3
+     *    set: If the value is greater than zero, the output changes according to the input.
+     *      If its value is zero, the output remains constant (the system stores the data).
+     *      The use of this parameter allows to simulate the behavior of a servomechanism
+     *      that is blocked, for example due to a power failure.
+     *    Reset: When high, the output returns to zero.
+     *    Lag: Activate a lag filter on exit.
+     *    Gain: Apply a multiplication coefficient of the output value.
+     *    Clipto: Clips the output. The clipping is applied after the gain and lag.
+     *    Output: Output value following the following rule:
+     *      Output = gain * (Input + module*countSpin)
+     *      CountSpin is the number of complete rotations
+     * 
+     *    The form of the linear_actuator component specification is:
+     * 
+     * @code
+     *    <linear_actuator name="{string}">
+     *      <input> {property name} </input>
+     *      <module> value </module>
+     *      <versus> value|property </versus>
+     *      <rate> value </rate>
+     *      <set> {property name | value} </set>
+     *      <reset> {property name | value} </reset>
+     *      <lag> number </lag>
+     *      <gain> value|property </gain>
+     *      <clipto>
+     *         <min> {value} </min>
+     *         <max> {value} </max>
+     *      </clipto>
+     *      <output> {property name} </output>
+     *    </linear_actuator>
+     * @endcode
+     *
+     * Mechanical counter:
+     * 
+     * It is the typical mechanism used to count the kilometers traveled by a car,
+     * for example the value of the digit changes quickly at the beginning of the km.
+     * Module 10 indicates that the count goes from 0 to 9 after one complete revolution.
+     * 
+     * @code
+     * 
+     *   <linear_actuator name="systems/gauges/PHI/indicator/digit3AW">
+     *      <input>systems/gauges/PHI/indicator/digit3A</input>
+     *      <module>10</module>
+     *      <rate>0.2</rate>
+     *      <lag>8.0</lag>
+     *  </linear_actuator>
+     * 
+     * @endcode
+     * 
+     * The gyrocompass from a rotation with a value from 0 to 259 degrees.
+     * When it returns to zero, if it is made more realistic by means of an actuator,
+     * there is a jump of the disk which performs a complete rotation of 360 °.
+     * By activating a linear actuator followed by an actuator
+     * it is possible to obtain a very realistic result.
+     * 
+     * @code
+     * 
+     * <linear_actuator name="gyrocompass-magnetic-deg-linear">
+     *      <input>gyrocompass-magnetic-deg</input>
+     *      <module>360</module>
+     *  </linear_actuator>
+     * 
+     *  <actuator name="gyrocompass-magnetic-deg-linear-actuator">
+     *      <input>gyrocompass-magnetic-deg-linear</input>
+     *      <lag>2.0</lag>
+     *      <rate_limit>100</rate_limit>
+     *      <bias>0.1</bias>
+     *      <deadband_width>1</deadband_width>
+     *      <hysteresis_width>0.5</hysteresis_width>
+     *  </actuator>
+     * 
+     * @endcode
+     * 
+     * Count steps with memory:
+     * If you use a button or switch to advance a mechanism, we can build a step counter.
+     * In this case the module is 1 and the rate 1. The verse is positive (increasing).
+     *
+     * @code
+     * 
+     *  <linear_actuator name="switch-increase-summer">
+     *      <input>switch-increase-trigger</input>
+     *      <set>switch-increase-operative</set>
+     *      <module>1</module>
+     *      <rate>1</rate>
+     *      <versus>1</versus>
+     *      <lag>8.0</lag>
+     *      <gain>1.0</gain>
+     *  </linear_actuator>
+     *  
+     * @endcode
+     * 
+     * 
+     * <pre>
+     *    Notes:
+     * </pre>
+     * 
+     *    @author Adriano Bassignana
+     */
+    
+    /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     * CLASS DECLARATION
+     * %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+    
+    class FGLinear_Actuator : public FGFCSComponent
+    {
+    public:
+        /** Constructor.
+         *      @param fcs a pointer to the parent FGFCS object.
+         *      @param element a pointer to the configuration file node. */
+        FGLinear_Actuator(FGFCS* fcs, Element* element);
+        /// Destructor
+        ~FGLinear_Actuator();
+        
+        /// The execution method for this FCS component.
+        bool Run(void);
+        
+    private:
+        
+        simgear::PropertyObject<double> setProperty;
+        bool isSetProperty;
+        double set;
+        simgear::PropertyObject<double> resetProperty;
+        bool isResetProperty;
+        double reset;
+        
+        int initialized;
+        int direction;
+        int countSpin;
+        
+        double lagProperty;
+        double lagPrevius;
+        double versus;
+        double input_prec;
+        double module, rate, minRate, maxRate;
+        double previousLagInput;
+        double previousLagOutput;
+        double gain;
+        double lag;
+        double ca; // lag filter coefficient "a"
+        double cb; // lag filter coefficient "b"
+        
+        void Lag(void);
+        void Debug(int from);
+    };
+}
+#endif


### PR DESCRIPTION
The testing of the module did not give me any problems, it was compiled directly for the development version of FGFS. Compared to the previous version, it has been introduced the possibility to vary the limitation in the direction of rotation (versus) and has been optimized. A bias has been introduced (which can be fixed or linked to a parameter) useful for managing tools that use offset commands. Honestly the name bias I used it as typical of an electronic control system, but for a linear actuator I think it is better to use the name "offset". In this phase of development it seems useful to me that others give advice in order to avoid the use of names not coherent with the function. There is also a hysteresis parameter (currently fixed) which allows to obtain an operation in steps typical of the step-motor or the escapement of the clocks. Something of the kind is also present in the classic actuator (which is often placed after this type of actuator), but this value operates on the input data and not in the output data. The hysteresis module allows the module to operate only if an input is large enough to exceed the hysteresis value. The use of hysteresis can lead to a considerable reduction in workload due to this module. An example is the use of the module to manage the gyrocompasses that have microvariations that can be blocked by the hysteresis without ever losing the consistency of the system. I think that another code of GSBSim could be reviewed in this logic avoiding an excessive use of the Execrete parameter.
For the output there is always the lag and the clip, theoretically these two parameters could be not inserted and left to a possible subsequent actuator module, but it is often convenient to have it and more compact the code. The code currently contains the bebug prints that can be activated / deactivated during the compilation of the code itself, will be removed in the final version, however some of these prints take place only in the case of effective mofification of the output.