### PR TITLE
Implementation of option 4 from issue #181

### DIFF
--- a/src/math/FGCondition.cpp
+++ b/src/math/FGCondition.cpp
@@ -102,15 +102,11 @@ FGCondition::FGCondition(Element* element, FGPropertyManager* PropertyManager)
     }
 
     if (tagName == "or") {
-      string status = condition_element->GetAttributeValue("status");
-      if (status != "verified") {
-        cerr << condition_element->ReadFrom() << fgred << highint
-             << "Detected usage of the tag <or>." << endl
-             << "WARNING: the meaning of this tag has been recently modified." << endl
-             << "Please check that it is currently properly used." << endl
-             << "To disable this warning message add the attribute status=\"verified\" to the <or> element."
-             << reset << endl;
-      }
+      cerr << condition_element->ReadFrom() << fgred << highint
+           << "Detected usage of the tag <or>." << endl
+           << "WARNING: the meaning of this tag has been recently modified." << endl
+           << "Please check that it is currently properly used." << endl
+           << reset << endl;
     }
 
     conditions.push_back(new FGCondition(condition_element, PropertyManager));

--- a/tests/TestSwitch.py
+++ b/tests/TestSwitch.py
@@ -35,6 +35,7 @@ class TestSwitch(JSBSimTestCase):
         self.assertEqual(fdm['test/compare'], -1.0)
         self.assertEqual(fdm['test/interval'], 0.0)
         self.assertEqual(fdm['test/group'], -1.0)
+        self.assertEqual(fdm['test/and'], -1.0)
 
         fdm['test/input'] = 0.0
         fdm.run()
@@ -43,6 +44,7 @@ class TestSwitch(JSBSimTestCase):
         self.assertEqual(fdm['test/compare'], -1.0)
         self.assertEqual(fdm['test/interval'], 0.0)
         self.assertEqual(fdm['test/group'], -1.0)
+        self.assertEqual(fdm['test/and'], -1.0)
 
         fdm['test/input'] = 0.1
         fdm.run()
@@ -51,6 +53,7 @@ class TestSwitch(JSBSimTestCase):
         self.assertEqual(fdm['test/compare'], -1.0)
         self.assertEqual(fdm['test/interval'], 1.0)
         self.assertEqual(fdm['test/group'], 0.56)
+        self.assertEqual(fdm['test/and'], 0.56)
 
         fdm['test/input'] = 0.2
         fdm.run()
@@ -59,6 +62,7 @@ class TestSwitch(JSBSimTestCase):
         self.assertEqual(fdm['test/compare'], 1.0)
         self.assertEqual(fdm['test/interval'], 2.0)
         self.assertEqual(fdm['test/group'], -1.0)
+        self.assertEqual(fdm['test/and'], -1.0)
 
         fdm['test/input'] = 0.235
         fdm.run()
@@ -67,29 +71,35 @@ class TestSwitch(JSBSimTestCase):
         self.assertEqual(fdm['test/compare'], 1.0)
         self.assertEqual(fdm['test/interval'], 2.0)
         self.assertEqual(fdm['test/group'], 0.56)
+        self.assertEqual(fdm['test/and'], 0.56)
 
         fdm['test/input'] = -1.5
         fdm['test/reference'] = -0.5
         fdm.run()
         self.assertEqual(fdm['test/compare'], -1.0)
         self.assertEqual(fdm['test/group'], -1.0)
+        self.assertEqual(fdm['test/and'], -1.0)
 
         fdm['test/input'] = 0.0
         fdm.run()
         self.assertEqual(fdm['test/compare'], 1.0)
         self.assertEqual(fdm['test/group'], -1.0)
+        self.assertEqual(fdm['test/and'], -1.0)
 
         fdm['test/input'] = 0.2
         fdm.run()
         self.assertEqual(fdm['test/compare'], 1.0)
         self.assertEqual(fdm['test/group'], 0.56)
+        self.assertEqual(fdm['test/and'], 0.56)
 
         fdm['test/input'] = 0.235
         fdm.run()
         self.assertEqual(fdm['test/compare'], 1.0)
         self.assertEqual(fdm['test/group'], 0.56)
+        self.assertEqual(fdm['test/and'], 0.56)
 
     # Regression test to reproduce GitHub issue #176
+    # Also test the new tag <or>
     def test_nested(self):
         tripod = FlightModel(self, 'tripod')
         tripod.include_system_test_file('switch.xml')
@@ -99,31 +109,37 @@ class TestSwitch(JSBSimTestCase):
         fdm['test/input'] = 30
         fdm.run()
         self.assertEqual(fdm['test/nested'], 0)
+        self.assertEqual(fdm['test/or'], 0)
 
         fdm['test/reference'] = 180
         fdm['test/input'] = 30
         fdm.run()
         self.assertEqual(fdm['test/nested'], 25)
+        self.assertEqual(fdm['test/or'], 25)
 
         fdm['test/reference'] = 180
         fdm['test/input'] = 25
         fdm.run()
         self.assertEqual(fdm['test/nested'], 0)
+        self.assertEqual(fdm['test/or'], 0)
 
         fdm['test/reference'] = 210
         fdm['test/input'] = 25
         fdm.run()
         self.assertEqual(fdm['test/nested'], 20)
+        self.assertEqual(fdm['test/or'], 20)
 
         fdm['test/reference'] = 210
         fdm['test/input'] = 30
         fdm.run()
         self.assertEqual(fdm['test/nested'], 20)
+        self.assertEqual(fdm['test/or'], 20)
 
         fdm['test/reference'] = 210
         fdm['test/input'] = 15
         fdm.run()
         self.assertEqual(fdm['test/nested'], 0)
+        self.assertEqual(fdm['test/or'], 0)
 
 
 RunTest(TestSwitch)

--- a/tests/switch.xml
+++ b/tests/switch.xml
@@ -81,5 +81,34 @@
         test/input == 30
       </test>
     </switch>
+    <!-- Test the "and" keyword -->
+    <switch name="test/and">
+      <default value="0.56"/>
+      <test value="-1.0" logic="OR">
+        <and>
+          test/input le 0.0
+        </and>
+        <and>
+          test/input gt 0.1
+          test/input le test/reference
+        </and>
+      </test>
+    </switch>
+    <!-- Test the "or" keyword -->
+    <switch name="test/or">
+      <default value="0"/>
+      <test logic="AND" value="20">
+        test/reference GT 203
+        <or status="verified">
+          test/input == 25
+          test/input == 30
+        </or>
+      </test>
+      <test logic="AND" value="25">
+        test/reference GT 170
+        test/reference LT 203
+        test/input == 30
+      </test>
+    </switch>
   </channel>
 </system>


### PR DESCRIPTION
Following the problem raised by @Zaretto in issue #181, this PR adds the tags `<and>` and `<or>` and issue a warning message when the latter is used.

This is a proposal implementation while waiting for the discussion on FlightGear mailing list to come to a conclusion.