### PR TITLE
Build & deploy portable Linux Python packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ before_install:
   - cmake -DCMAKE_INSTALL_PREFIX=~/ -DINSTALL_PYTHON_MODULE=ON -DCPACK_GENERATOR=DEB -DBUILD_SHARED_LIBS=$USE_SYSTEM_EXPAT -DSYSTEM_EXPAT=$USE_SYSTEM_EXPAT ..
   - make -j2
   - python python/setup.py sdist
-  - python python/setup.py build_scripts
-  - python python/setup.py bdist_wheel
+  - python python/setup.py bdist_wheel --build-number=$TRAVIS_BUILD_NUMBER
 install:
   - pip install jsbsim --no-index -f python/dist
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/src

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,14 +57,17 @@ after_success:
   - sh ../doc/build_docs.sh
 # Run the C++ unit tests coverage
   - sh ../tests/unit_tests/test_coverage.sh
-# Build the manylinux2010 wheel binary packages 
+# Build Linux portable Python packages.
   - |
-    if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$USE_SYSTEM_EXPAT" = "OFF" ]; then
-      docker pull quay.io/pypa/manylinux2010_x86_64
+    if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ] && [ "$USE_SYSTEM_EXPAT" = "OFF" ]; then
+      # Clean up the existing build files
       rm -f CMakeCache.txt
+      make clean
+      # Install the Docker build environment
+      docker pull quay.io/pypa/manylinux2010_x86_64
       cp ../python/build-wheels.sh .
       chmod +x build-wheels.sh
-      make clean
+      # Build the manylinux1 wheel binary packages
       docker run --rm -v $PWD/..:/io quay.io/pypa/manylinux2010_x86_64 /io/build/build-wheels.sh
       ls python/dist/
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ before_install:
   - python python/setup.py build_scripts
   - python python/setup.py bdist_wheel --skip-build
 install:
-  - docker pull quay.io/pypa/manylinux2010_x86_64
   - pip install jsbsim --no-index -f python/dist
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/src
 script:
@@ -58,6 +57,13 @@ after_success:
   - sh ../doc/build_docs.sh
  # Run the C++ unit tests coverage
   - sh ../tests/unit_tests/test_coverage.sh
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$USE_SYSTEM_EXPAT" = "OFF" ]; then
+      docker pull quay.io/pypa/manylinux2010_x86_64
+      cp ../python/build-wheels.sh .
+      docker run --rm -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/build-wheels.sh
+      ls python/dist/
+    fi
 
 # If the build fails, the tests log will be uploaded to a gist under my account
 # (bcoconni) so that they can be deleted when irrelevant. The output of the

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - make -j2
   - python python/setup.py sdist
   - python python/setup.py build_scripts
-  - python python/setup.py bdist_wheel --skip-build
+  - python python/setup.py bdist_wheel
 install:
   - pip install jsbsim --no-index -f python/dist
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/src

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 dist:
   - xenial
+sudo:
+  - required
+services:
+  - docker
 python:
   - "2.7"
   - "3.6"
@@ -34,7 +38,8 @@ before_install:
   - python python/setup.py build_scripts
   - python python/setup.py bdist_wheel --skip-build
 install:
-  - pip install python/dist/JSBSim*.whl
+  - docker pull quay.io/pypa/manylinux2010_x86_64
+  - pip install jsbsim --no-index -f python/dist
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/src
 script:
 # Check that the Python module has been correctly installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,11 @@ script:
   - python -c "import jsbsim;fdm=jsbsim.FGFDMExec('.', None);print(jsbsim.FGAircraft.__doc__)"
   - pip uninstall jsbsim --yes
   - ctest -j2
-  - if [ "$USE_SYSTEM_EXPAT" = "OFF" ]; then pip install python/dist/JSBSim-*.tar.gz; fi
-  - if [ "$USE_SYSTEM_EXPAT" = "OFF" ]; then python -c "import jsbsim;fdm=jsbsim.FGFDMExec('.', None)"; fi
+  - |
+    if [ "$USE_SYSTEM_EXPAT" = "OFF" ]; then
+      pip install python/dist/JSBSim-*.tar.gz
+      python -c "import jsbsim;fdm=jsbsim.FGFDMExec('.', None);print(jsbsim.FGAircraft.__doc__)"
+    fi
 after_success:
   - cpack
   - export TRAVIS_TAG=Rolling-release-v2019

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,14 @@ after_success:
     if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ] && [ "$USE_SYSTEM_EXPAT" = "OFF" ]; then
       # Clean up the existing build files
       rm -f CMakeCache.txt
+      rm -f python/dist/*.whl
       make clean
       # Install the Docker build environment
       docker pull quay.io/pypa/manylinux2010_x86_64
       cp ../python/build-wheels.sh .
       chmod +x build-wheels.sh
       # Build the manylinux1 wheel binary packages
-      docker run --rm -v $PWD/..:/io quay.io/pypa/manylinux2010_x86_64 /io/build/build-wheels.sh
+      docker run --rm -v $PWD/..:/io quay.io/pypa/manylinux1_x86_64 /io/build/build-wheels.sh
       ls python/dist/
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ after_success:
       cp ../python/build-wheels.sh .
       chmod +x build-wheels.sh
       # Build the manylinux1 wheel binary packages
-      docker run --rm -v $PWD/..:/io quay.io/pypa/manylinux1_x86_64 /io/build/build-wheels.sh
+      docker run --rm -v $PWD/..:/io quay.io/pypa/manylinux2010_x86_64 /io/build/build-wheels.sh
       ls python/dist/
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ deploy:
       secure: FHMLgbuRTSznrfMSpb3/nJIECKS0v8VFHUfC99ZpMBjZR4kxptDSPchpHzLFlrytzl1+H62w1iWChx5RYaH1MW8a/ejCUWYO0IjO6hLtG72nMJeDIBC2JzLnKN7cLqMrgEHKW7XmK3CtXGa/tXxu+KEvmbwskv3TOWGUokdUB3EI0vTLjjCQBW05VK7oSBq+7Jl4zGJumWwALP5EK7DC7McPXpLlkw5zdga+LQVcg8aDPrNwgF5kaH03b7TagYgiG2OFb4FAPvfz70RWeCRB7QQn1jOGULZ3PHz8EnNOfyBqGJ0flDyAfZcwJNY1OONW9ELnOctvzdmmU2P+KGuK4cJuzI59aRVQrwcSnnl26DU/95Hev4mdCIlPz798C3TfZu+U36uzGMurQJjE7Fg59N4WnqubhWKWu/7qRhn1uttdPm5sIcVAPpshKm8uzlsTLLMTNUMj5ZIimVbFV2lz0PbDWPnbHxHeDKgaVkIjTQy4e1XZH7IhjIVODG2PK1TnWS/6RRTBUVXxwup7Tj8HhVbLjrfPs2qLDJv70sRyKUgAqqKdGkr/7Es52y1i/io3BJqiIOpJBM5Wyzk37NCAlX4WCoqJZQbKKRQ9hH5baZaxlpz28Hc0tbAqfwFOwAOonf1+s7MBM896EoAtdKpr0Z0F/ra9ePQezTbtQhvws3g=
     file_glob: true
     file:
-      - "python/dist/JSBSim*.whl"
+      - "python/dist/JSBSim*-manylinux1_x86_64.whl"
     skip_cleanup: true
     overwrite: true
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,10 +61,11 @@ after_success:
   - |
     if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$USE_SYSTEM_EXPAT" = "OFF" ]; then
       docker pull quay.io/pypa/manylinux2010_x86_64
+      rm -f CMakeCache.txt
       cp ../python/build-wheels.sh .
       chmod +x build-wheels.sh
       make clean
-      docker run --rm -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/build-wheels.sh
+      docker run --rm -v $PWD/..:/io quay.io/pypa/manylinux2010_x86_64 /io/build/build-wheels.sh
       ls python/dist/
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,14 @@ after_success:
   - export TRAVIS_TAG=Rolling-release-v2019
 # Build the C++ and Python API documentation
   - sh ../doc/build_docs.sh
- # Run the C++ unit tests coverage
+# Run the C++ unit tests coverage
   - sh ../tests/unit_tests/test_coverage.sh
+# Build the manylinux2010 wheel binary packages 
   - |
     if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$USE_SYSTEM_EXPAT" = "OFF" ]; then
       docker pull quay.io/pypa/manylinux2010_x86_64
       cp ../python/build-wheels.sh .
+      chmod +x build-wheels.sh
       docker run --rm -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/build-wheels.sh
       ls python/dist/
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ after_success:
       docker pull quay.io/pypa/manylinux2010_x86_64
       cp ../python/build-wheels.sh .
       chmod +x build-wheels.sh
+      make clean
       docker run --rm -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/build-wheels.sh
       ls python/dist/
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,7 @@ build_script:
 - cmake -G "Visual Studio 15 2017 Win64" ..
 - cmake --build . --config RelWithDebInfo
 - python python\setup.py sdist
-- python python\setup.py build_scripts
-- python python\setup.py bdist_wheel --config RelWithDebInfo
+- python python\setup.py bdist_wheel --config RelWithDebInfo --build-number=%APPVEYOR_BUILD_NUMBER%
 
 test_script:
 # Check that the Python module correctly installs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ build_script:
 
 test_script:
 # Check that the Python module correctly installs
-- pip install python\dist\JSBSim-1.1.0.dev1-cp37-cp37m-win_amd64.whl
+- pip install jsbsim --no-index -f python/dist
 - python -c "import jsbsim;fdm=jsbsim.FGFDMExec('.', None);print(jsbsim.FGAircraft.__doc__)"
 - pip uninstall jsbsim --yes
 - ctest -j2 -E TestInputSocket
@@ -60,7 +60,7 @@ artifacts:
 - path: build\utils\aeromatic++\RelWithDebInfo\aeromatic.exe
   name: Rolling_Release_x64_v2019
 
-- path: build\python\dist\JSBSim-1.1.0.dev1-cp37-cp37m-win_amd64.whl
+- path: build\python\dist\JSBSim-1.1.0.dev1-%APPVEYOR_BUILD_NUMBER%-cp37-cp37m-win_amd64.whl
   name: Rolling_Release_x64_v2019
 
 # Do not build on tags (GitHub and BitBucket)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ build_script:
 - cmake --build . --config RelWithDebInfo
 - python python\setup.py sdist
 - python python\setup.py build_scripts
-- python python\setup.py bdist_wheel --skip-build --config RelWithDebInfo
+- python python\setup.py bdist_wheel --config RelWithDebInfo
 
 test_script:
 # Check that the Python module correctly installs

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -2,6 +2,7 @@
 set -e -x
 
 # Compile C++ code
+cd io
 ls
 make
 #ctest

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 set -e -x
 
+# Compile C++ code
 make clean
 make
 ctest
 
+# Compile wheels
 for PYBIN in /opt/python/*/bin; do
     "${PYBIN}/pip" install -r cython numpy
     "${PYBIN}/python" python/setup.py build_scripts
     "${PYBIN}/python" python/setup.py bdist_wheel
 done
 
+# Bundle external shared libraries into the wheels
+for whl in python/dist/*.whl; do
+    auditwheel repair "$whl" --plat manylinux2010_x86_64 -w /io/python/dist
+done
+
+# Install packages and test
 for PYBIN in /opt/python/*/bin; do
     "${PYBIN}/pip" install jsbsim --no-index -f python/dist
     "${PYBIN}/python" -c "import jsbsim;fdm=jsbsim.FGFDMExec('.', None);print(jsbsim.FGAircraft.__doc__)"

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -3,7 +3,7 @@ set -e -x
 
 # Compile C++ code
 cd /io/build
-cmake ../..
+cmake ..
 make
 
 # Compile wheels

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -1,24 +1,22 @@
 #!/bin/bash
 set -e -x
 
-yum install -y cmake
-
 # Compile C++ code
-cd io
-ls
+cd /io/build
+cmake ../..
 make
-#ctest
 
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
-    "${PYBIN}/pip" install -r cython numpy
+    "${PYBIN}/pip" install cython numpy
     "${PYBIN}/python" python/setup.py build_scripts
+    "${PYBIN}/cython" --cplus python/jsbsim.pyx -o python/jsbsim.cxx
     "${PYBIN}/python" python/setup.py bdist_wheel
 done
 
 # Bundle external shared libraries into the wheels
 for whl in python/dist/*.whl; do
-    auditwheel repair "$whl" --plat manylinux2010_x86_64 -w /io/python/dist
+    auditwheel repair "$whl" --plat manylinux2010_x86_64 -w python/dist
 done
 
 # Install packages and test

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -22,5 +22,5 @@ done
 for PYBIN in /opt/python/*/bin; do
     "${PYBIN}/pip" install jsbsim --no-index -f python/dist
     "${PYBIN}/python" -c "import jsbsim;fdm=jsbsim.FGFDMExec('.', None);print(jsbsim.FGAircraft.__doc__)"
-    "${PYBIN}/JSBSim" ../scripts/c1721.xml
+    "${PYBIN}/JSBSim" -root=.. --script=scripts/c1721.xml
 done

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e -x
+
+make clean
+make
+ctest
+
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/pip" install -r cython numpy
+    "${PYBIN}/python" python/setup.py build_scripts
+    "${PYBIN}/python" python/setup.py bdist_wheel
+done
+
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/pip" install jsbsim --no-index -f python/dist
+    "${PYBIN}/python" -c "import jsbsim;fdm=jsbsim.FGFDMExec('.', None);print(jsbsim.FGAircraft.__doc__)"
+done

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -2,6 +2,7 @@
 set -e -x
 
 # Compile C++ code
+ls
 make
 #ctest
 

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -22,5 +22,5 @@ done
 for PYBIN in /opt/python/*/bin; do
     "${PYBIN}/pip" install jsbsim --no-index -f python/dist
     "${PYBIN}/python" -c "import jsbsim;fdm=jsbsim.FGFDMExec('.', None);print(jsbsim.FGAircraft.__doc__)"
-    "${PYBIN}/JSBSim" -root=.. --script=scripts/c1721.xml
+    "${PYBIN}/JSBSim" --root=.. --script=scripts/c1721.xml
 done

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -2,9 +2,8 @@
 set -e -x
 
 # Compile C++ code
-make clean
 make
-ctest
+#ctest
 
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -9,7 +9,6 @@ make
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     "${PYBIN}/pip" install cython numpy
-    "${PYBIN}/python" python/setup.py build_scripts
     "${PYBIN}/cython" --cplus python/jsbsim.pyx -o python/jsbsim.cxx
     "${PYBIN}/python" python/setup.py bdist_wheel
 done
@@ -23,4 +22,5 @@ done
 for PYBIN in /opt/python/*/bin; do
     "${PYBIN}/pip" install jsbsim --no-index -f python/dist
     "${PYBIN}/python" -c "import jsbsim;fdm=jsbsim.FGFDMExec('.', None);print(jsbsim.FGAircraft.__doc__)"
+    "${PYBIN}/JSBSim" ../scripts/c1721.xml
 done

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e -x
 
+yum install -y cmake
+
 # Compile C++ code
 cd io
 ls

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -113,8 +113,8 @@ else:
 
 # Check if the library exists and build the Python module accordingly.
 if compiler.find_library_file([library_path], 'JSBSim') and sys.argv[1]!='sdist':
-    # OK, the JSBSim library has already been compiled so let us it to build the
-    # Python module.
+    # OK, the JSBSim library has already been compiled so let's use it to build
+    # the Python module.
     ext_kwargs = { 'sources': ['${JSBSIM_CXX}'],
                    'include_dirs': ['src'],
                    'libraries': ['JSBSim'],

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -55,14 +55,15 @@ class InstallJSBSimModule(install_lib):
         # can be quite complicated).
         build_ext = self.get_finalized_command('build_ext')
         self.module_name = build_ext.get_ext_filename(build_ext.extensions[0].name)
+        self.module_fullpath = build_ext.get_ext_fullpath(build_ext.extensions[0].name)
 
     def install(self):
         if not os.path.exists(self.install_dir):
             log.info('creating {}'.format(self.install_dir))
             os.makedirs(self.install_dir)
 
-        self.copy_file(os.path.join('${BUILD_ROOT_PATH}', 'tests', self.module_name),
-                       os.path.join(self.install_dir, self.module_name))
+        self.copy_file(self.module_fullpath, os.path.join(self.install_dir,
+                                                          self.module_name))
 
         # When compiled with Microsoft Visual C++, the JSBSim Python module is
         # linked with the dynamically linked library msvcp140.dll which is not a
@@ -115,8 +116,7 @@ if compiler.find_library_file([library_path], 'JSBSim') and sys.argv[1]!='sdist'
     # OK, the JSBSim library has already been compiled so let us it to build the
     # Python module.
     ext_kwargs = { 'sources': ['${JSBSIM_CXX}'],
-                   'include_dirs': [os.path.join('${CMAKE_SOURCE_DIR}', 'src'),
-                                    os.path.join('${CMAKE_SOURCE_DIR}', 'python')],
+                   'include_dirs': ['src'],
                    'libraries': ['JSBSim'],
                    'library_dirs': [library_path],
                    'extra_compile_args': cpp11_compile_flag }


### PR DESCRIPTION
The build requires to use the docker image from the project [pypa/manylinux](https://github.com/pypa/manylinux) according to the example from [pypa/python-manylinux-demo](https://github.com/pypa/python-manylinux-demo).

The build process had to be updated to meet the specificity of the multiple platforms on which the Python package is built. The result is the deployment of manylinux1 packages as specified in [PEP 513](https://www.python.org/dev/peps/pep-0513).