### PR TITLE
Modify some includes

### DIFF
--- a/src/simgear/xml/xmlparse.c
+++ b/src/simgear/xml/xmlparse.c
@@ -14,7 +14,7 @@
 #elif defined(MACOS_CLASSIC)
 #include "macconfig.h"
 #elif defined(HAVE_EXPAT_CONFIG_H)
-#include <expat_config.h>
+#include "expat_config.h"
 #endif /* ndef COMPILED_FROM_DSP */
 
 #include "expat.h"

--- a/src/simgear/xml/xmlrole.c
+++ b/src/simgear/xml/xmlrole.c
@@ -10,7 +10,7 @@
 #include "macconfig.h"
 #else
 #ifdef HAVE_EXPAT_CONFIG_H
-#include <expat_config.h>
+#include "expat_config.h"
 #endif
 #endif /* ndef COMPILED_FROM_DSP */
 

--- a/src/simgear/xml/xmltok.c
+++ b/src/simgear/xml/xmltok.c
@@ -10,7 +10,7 @@
 #include "macconfig.h"
 #else
 #ifdef HAVE_EXPAT_CONFIG_H
-#include <expat_config.h>
+#include "expat_config.h"
 #endif
 #endif /* ndef COMPILED_FROM_DSP */
 


### PR DESCRIPTION
Change `#include <expat_config.h>` to `#include "expat_config.h"` to be able to compile under mingw and macOS.