### PR TITLE
Allow functions to specify they return non-const values

### DIFF
--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -74,9 +74,10 @@ class aFunc: public FGFunction
 {
 public:
   aFunc(const func_t& _f, FGFDMExec* fdmex, Element* el,
-        const string& prefix, FGPropertyValue* v)
+        const string& prefix, FGPropertyValue* v, bool constForConstParams=true)
     : FGFunction(fdmex->GetPropertyManager()), f(_f)
   {
+    this->constForConstParams = constForConstParams;
     Load(el, v, fdmex, prefix);
     CheckMinArguments(el, Nmin);
     CheckMaxArguments(el, Nmax);
@@ -518,12 +519,12 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
       auto f = [](const decltype(Parameters)& p)->double {
                  return GaussianRandomNumber();
                };
-      Parameters.push_back(new aFunc<decltype(f), 0>(f, fdmex, element, Prefix, var));
+      Parameters.push_back(new aFunc<decltype(f), 0>(f, fdmex, element, Prefix, var, false));
     } else if (operation == "urandom") {
       auto f = [](const decltype(Parameters)& p)->double {
                  return -1.0 + (((double)rand()/double(RAND_MAX))*2.0);
                };
-      Parameters.push_back(new aFunc<decltype(f), 0>(f, fdmex, element, Prefix, var));
+      Parameters.push_back(new aFunc<decltype(f), 0>(f, fdmex, element, Prefix, var, false));
     } else if (operation == "switch") {
       string ctxMsg = element->ReadFrom();
       auto f = [ctxMsg](const decltype(Parameters)& p)->double {
@@ -802,12 +803,14 @@ FGFunction::~FGFunction()
 
 bool FGFunction::IsConstant(void) const
 {
-  for (auto p: Parameters) {
-    if (!p->IsConstant())
-      return false;
-  }
-
-  return true;
+  if (constForConstParams) {
+    for (auto p: Parameters) {
+      if (!p->IsConstant())
+        return false;
+    }
+    return true;
+  } else
+    return false;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/math/FGFunction.h
+++ b/src/math/FGFunction.h
@@ -735,7 +735,7 @@ public:
   /// Default constructor.
   FGFunction()
     : cached(false), cachedValue(-HUGE_VAL), pNode(nullptr), pCopyTo(nullptr),
-      PropertyManager(nullptr) {}
+      PropertyManager(nullptr), constForConstParams(true) {}
 
   explicit FGFunction(FGPropertyManager* pm)
     : FGFunction()
@@ -797,6 +797,8 @@ protected:
   bool cached;
   double cachedValue;
   std::vector <FGParameter_ptr> Parameters;
+
+  bool constForConstParams;
 
   void Load(Element* element, FGPropertyValue* var, FGFDMExec* fdmex,
             const std::string& prefix="");

--- a/src/math/FGFunction.h
+++ b/src/math/FGFunction.h
@@ -735,7 +735,7 @@ public:
   /// Default constructor.
   FGFunction()
     : cached(false), cachedValue(-HUGE_VAL), pNode(nullptr), pCopyTo(nullptr),
-      PropertyManager(nullptr), constForConstParams(true) {}
+      PropertyManager(nullptr) {}
 
   explicit FGFunction(FGPropertyManager* pm)
     : FGFunction()
@@ -797,8 +797,6 @@ protected:
   bool cached;
   double cachedValue;
   std::vector <FGParameter_ptr> Parameters;
-
-  bool constForConstParams;
 
   void Load(Element* element, FGPropertyValue* var, FGFDMExec* fdmex,
             const std::string& prefix="");


### PR DESCRIPTION
Add the ability for functions to specify that they return non-const values even if all their input parameters are const or if they don't take any input parameters.

This is to fix the issue with the `random` and `urandom` functions return a single const value every time they were invoked - https://github.com/JSBSim-Team/jsbsim/issues/219