### PR TITLE
Changes to compile python extension directly with msvc 

### DIFF
--- a/src/simgear/misc/strutils.cxx
+++ b/src/simgear/misc/strutils.cxx
@@ -376,9 +376,9 @@ namespace simgear {
         vector<string> v1parts(split(v1, "."));
         vector<string> v2parts(split(v2, "."));
 
-        int lastPart = std::min(v1parts.size(), v2parts.size());
+        int lastPart = (std::min)(v1parts.size(), v2parts.size());
         if (maxComponents > 0) {
-            lastPart = std::min(lastPart, maxComponents);
+            lastPart = (std::min)(lastPart, maxComponents);
         }
 
         for (int part=0; part < lastPart; ++part) {

--- a/src/simgear/xml/easyxml.cxx
+++ b/src/simgear/xml/easyxml.cxx
@@ -19,7 +19,7 @@ INCLUDES
 #include <string.h>
 
 #include "easyxml.hxx"
-#include <expat.h>
+#include "expat.h"
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Change include `<expat.h>` in `'expat.h'` to prevent [file not found error](https://travis-ci.org/galleon/gym-jsbsim/jobs/599072729#L702) and change `std::min` in `(std::min)` to prevent [conflict error](https://travis-ci.org/galleon/gym-jsbsim/jobs/599116888#L776) compiling python extension directly under msvc with a setup.py as in https://github.com/galleon/gym-jsbsim/blob/new/setup.py.