### PR TITLE
Test JSBSim executable with Valgrind

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -36,17 +36,15 @@ jobs:
           mkdir build
           cd build
           cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON ..
-      - name: Test with Valgrind
-        run: |
-          cd build
-          make CFLAGS="-g" CXXFLAGS="-g" -j2
-          valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml ./src/JSBSim --root=.. scripts/Short_S23_3.xml --end-time=5.
-          valgrindci valgrind_Short_S23_3.xml --abort-on-errors
-          make clean
       - name: Build JSBSim
         run: |
           cd build
-          make -j2
+          make CFLAGS="-g -O2" CXXFLAGS="-g -O2" -j2
+      - name: Test with Valgrind
+        run: |
+          valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml ./src/JSBSim scripts/Short_S23_3.xml --end-time=5.
+          valgrindci valgrind_Short_S23_3.xml --abort-on-errors
+          make clean
       - name: Test JSBSim
         run: |
           cd build
@@ -89,13 +87,13 @@ jobs:
       - name: On failure - Display a summary of valgrind errors.
         if: failure()
         run: |
-          valgrindci build/valgrind_Short_S23_3.xml --number-of-errors --summary
+          valgrindci valgrind_Short_S23_3.xml --number-of-errors --summary
       - name: On failure - Upload Valgrind report
         uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: valgrind_Short_S23_3.xml
-          path: build/valgrind_Short_S23_3.xml
+          path: valgrind_Short_S23_3.xml
 
     # Release files
       - name: Release binaries

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -89,13 +89,13 @@ jobs:
       - name: On failure - Display a summary of valgrind errors.
         if: failure()
         run: |
-          valgrindci valgrind_Short_S23_3.xml --number-of-errors --summary
+          valgrindci build/valgrind_Short_S23_3.xml --number-of-errors --summary
       - name: On failure - Upload Valgrind report
         uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: valgrind_Short_S23_3.xml
-          path: ./valgrind_Short_S23_3.xml
+          path: build/valgrind_Short_S23_3.xml
 
     # Release files
       - name: Release binaries

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           cd build
           make CFLAGS="-g" CXXFLAGS="-g" -j2
-          valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml ./src/JSBSim scripts/Short_S23_3.xml --end-time=5.
+          valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml ./src/JSBSim --root=.. scripts/Short_S23_3.xml --end-time=5.
           valgrindci valgrind_Short_S23_3.xml --abort-on-errors
           make clean
       - name: Build JSBSim

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -14,6 +14,16 @@ jobs:
           python-version: '3.6'
       - name: Install Python packages
         run: pip install -U cython numpy pandas scipy wheel
+      - name: Checkout ValgrindCI
+        uses: actions/checkout@v2
+        with:
+          repository: bcoconni/ValgrindCI
+      - name: Install ValgrindCI
+        run: |
+          ls
+          cd ValgrindCI
+          python setup.py bdist_wheel
+          pip install valgrindci --no-index -f dist
       - name: Checkout JSBSim
         uses: actions/checkout@v1
       - name: Configure JSBSim
@@ -32,6 +42,7 @@ jobs:
       - name: Test with Valgrind
         run: |
           valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml ./build/src/JSBSim scripts/Short_S23_3.xml --end-time=5.
+          valgrindci valgrind_Short_S23_3.xml --abort-on-errors
       - name: Test JSBSim
         run: |
           cd build

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -21,13 +21,12 @@ jobs:
           path: valgrindci
       - name: Install ValgrindCI
         run: |
-          ls
           cd valgrindci
           pip install -r requirements.txt
           python setup.py bdist_wheel
           pip install valgrindci --no-index -f dist
       - name: Checkout JSBSim
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Configure JSBSim
         run: |
           # We don't want Doxygen to generate the HTML docs in this job (saves time)
@@ -84,8 +83,13 @@ jobs:
         with:
           name: Linux.logs
           path: logs
-      - name: Upload Valgrind report
+      - name: On failure - Display a summary of valgrind errors.
+        if: failure()
+        run: |
+          valgrind-ci valgrind_Short_S23_3.xml --number-of-errors --summary
+      - name: On failure - Upload Valgrind report
         uses: actions/upload-artifact@v1
+        if: failure()
         with:
           name: valgrind_Short_S23_3.xml
           path: ./valgrind_Short_S23_3.xml

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -42,7 +42,7 @@ jobs:
           make CFLAGS="-g -O2" CXXFLAGS="-g -O2" -j2
       - name: Test with Valgrind
         run: |
-          valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml ./src/JSBSim scripts/Short_S23_3.xml --end-time=5.
+          valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml build/src/JSBSim scripts/Short_S23_3.xml --end-time=5.
           valgrindci valgrind_Short_S23_3.xml --abort-on-errors
           make clean
       - name: Test JSBSim
@@ -93,7 +93,7 @@ jobs:
         if: failure()
         with:
           name: valgrind_Short_S23_3.xml
-          path: valgrind_Short_S23_3.xml
+          path: ./valgrind_Short_S23_3.xml
 
     # Release files
       - name: Release binaries

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -35,7 +35,7 @@ jobs:
           perl -i -pe 's/^(HAVE_DOT\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
           mkdir build
           cd build
-          cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON -DCMAKE_C_FLAGS_DEBUG="-g" -DCMAKE_CXX_FLAGS_DEBUG="-g" -DCMAKE_BUILD_TYPE=Debug ..
+          cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON -DCMAKE_C_FLAGS_DEBUG="-g -O2" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2" -DCMAKE_BUILD_TYPE=Debug ..
       - name: Build JSBSim
         run: |
           cd build
@@ -87,7 +87,7 @@ jobs:
       - name: On failure - Display a summary of valgrind errors.
         if: failure()
         run: |
-          valgrindci valgrind_Short_S23_3.xml --number-of-errors --summary
+          valgrindci valgrind_Short_S23_3.xml --number-of-errors --summary --source=.
       - name: On failure - Upload Valgrind report
         uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           ls
           cd valgrindci
+          pip install -r requirements.txt
           python setup.py bdist_wheel
           pip install valgrindci --no-index -f dist
       - name: Checkout JSBSim

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -24,7 +24,7 @@ jobs:
           cd valgrindci
           pip install -r requirements.txt
           python setup.py bdist_wheel
-          pip install valgrindci --no-index -f dist
+          pip install ValgrindCI --no-index -f dist
       - name: Checkout JSBSim
         uses: actions/checkout@v2
       - name: Configure JSBSim
@@ -43,7 +43,7 @@ jobs:
       - name: Test with Valgrind
         run: |
           valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml build/src/JSBSim scripts/Short_S23_3.xml --end-time=5.
-          valgrindci valgrind_Short_S23_3.xml --abort-on-errors
+          valgrind-ci valgrind_Short_S23_3.xml --abort-on-errors
       - name: Test JSBSim
         run: |
           cd build
@@ -86,7 +86,7 @@ jobs:
       - name: On failure - Display a summary of valgrind errors.
         if: failure()
         run: |
-          valgrindci valgrind_Short_S23_3.xml --number-of-errors --summary --source=.
+          valgrind-ci valgrind_Short_S23_3.xml --number-of-errors --summary --source=.
       - name: On failure - Upload Valgrind report
         uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -18,10 +18,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: bcoconni/ValgrindCI
+          path: valgrindci
       - name: Install ValgrindCI
         run: |
           ls
-          cd ValgrindCI
+          cd valgrindci
           python setup.py bdist_wheel
           pip install valgrindci --no-index -f dist
       - name: Checkout JSBSim

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ubuntu packages
-        run: sudo apt-get install doxygen cxxtest
+        run: sudo apt-get install doxygen cxxtest valgrind
       - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:
@@ -29,6 +29,9 @@ jobs:
         run: |
           cd build
           make -j2
+      - name: Test with Valgrind
+        run: |
+          valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml ./build/src/JSBSim scripts/Short_S23_3.xml --end-time=5.
       - name: Test JSBSim
         run: |
           cd build
@@ -68,6 +71,11 @@ jobs:
         with:
           name: Linux.logs
           path: logs
+      - name: Upload Valgrind report
+        uses: actions/upload-artifact@v1
+        with:
+          name: valgrind_Short_S23_3.xml
+          path: ./valgrind_Short_S23_3.xml
 
     # Release files
       - name: Release binaries

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build JSBSim
         run: |
           cd build
-          make CFLAGS="-g -O2" CXXFLAGS="-g -O2" -j2
+          make CFLAGS="-g" CXXFLAGS="-g" -j2
       - name: Test with Valgrind
         run: |
           valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml build/src/JSBSim scripts/Short_S23_3.xml --end-time=5.

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -44,7 +44,6 @@ jobs:
         run: |
           valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml build/src/JSBSim scripts/Short_S23_3.xml --end-time=5.
           valgrindci valgrind_Short_S23_3.xml --abort-on-errors
-          make clean
       - name: Test JSBSim
         run: |
           cd build

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -86,7 +86,7 @@ jobs:
       - name: On failure - Display a summary of valgrind errors.
         if: failure()
         run: |
-          valgrind-ci valgrind_Short_S23_3.xml --number-of-errors --summary
+          valgrindci valgrind_Short_S23_3.xml --number-of-errors --summary
       - name: On failure - Upload Valgrind report
         uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -36,14 +36,17 @@ jobs:
           mkdir build
           cd build
           cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON ..
+      - name: Test with Valgrind
+        run: |
+          cd build
+          make CFLAGS="-g" CXXFLAGS="-g" -j2
+          valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml ./src/JSBSim scripts/Short_S23_3.xml --end-time=5.
+          valgrindci valgrind_Short_S23_3.xml --abort-on-errors
+          make clean
       - name: Build JSBSim
         run: |
           cd build
           make -j2
-      - name: Test with Valgrind
-        run: |
-          valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml ./build/src/JSBSim scripts/Short_S23_3.xml --end-time=5.
-          valgrindci valgrind_Short_S23_3.xml --abort-on-errors
       - name: Test JSBSim
         run: |
           cd build

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -13,20 +13,9 @@ jobs:
         with:
           python-version: '3.6'
       - name: Install Python packages
-        run: pip install -U cython numpy pandas scipy wheel
-      - name: Checkout ValgrindCI
-        uses: actions/checkout@v2
-        with:
-          repository: bcoconni/ValgrindCI
-          path: valgrindci
-      - name: Install ValgrindCI
-        run: |
-          cd valgrindci
-          pip install -r requirements.txt
-          python setup.py bdist_wheel
-          pip install ValgrindCI --no-index -f dist
+        run: pip install -U cython numpy pandas scipy wheel valgrindci
       - name: Checkout JSBSim
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
       - name: Configure JSBSim
         run: |
           # We don't want Doxygen to generate the HTML docs in this job (saves time)

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -35,11 +35,11 @@ jobs:
           perl -i -pe 's/^(HAVE_DOT\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
           mkdir build
           cd build
-          cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON ..
+          cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON -DCMAKE_C_FLAGS_DEBUG="-g" -DCMAKE_CXX_FLAGS_DEBUG="-g" -DCMAKE_BUILD_TYPE=Debug ..
       - name: Build JSBSim
         run: |
           cd build
-          make CFLAGS="-g" CXXFLAGS="-g" -j2
+          make -j2
       - name: Test with Valgrind
         run: |
           valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml build/src/JSBSim scripts/Short_S23_3.xml --end-time=5.


### PR DESCRIPTION
This test is added following random failures of the test `CheckScripts` reported by our Continuous Integration workflow. The logs indicate a floating point exception while testing the script `Short_S23_3.xml`:
```
======================================================================
FAIL: testScripts (__main__.CheckScripts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/jsbsim/jsbsim/tests/CheckScripts.py", line 38, in testScripts
    fdm.run_ic()
fpectl.FloatingPointError: Caught signal SIGFPE in JSBSim

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/jsbsim/jsbsim/tests/CheckScripts.py", line 42, in testScripts
    self.fail("Script %s failed:\n%s" % (s, e.args[0]))
AssertionError: Script ../../../scripts/Short_S23_3.xml failed:
Caught signal SIGFPE in JSBSim

----------------------------------------------------------------------
```
Since this floating point exception is not always raised, the most probable explanation is a dangling pointer or an uninitialized variable. I ran the offending test with [`Valgrind`](https://valgrind.org) and it reported 2147 errors ! Almost of them being due to uninitialised variables or conditions depending on uninitialised variables (but no dangling pointers reported :smile: ).

So Valgrind confirmed that there is something wrong with variables initialization and I had to develop a tool ([`ValgrindCI`](https://github.com/bcoconni/ValgrindCI)) to try to make head or tail from this massive amount of errors. Long story short, the whole 2147 errors were due to one class containing uninitialised variables: `FGPiston`.

This PR only modifies the continuous integration workflow to run the script `Short_S23_3.xml` under Valgrind. **This test is purposely failing at this stage** in order to confirm that the coming push to `FGPiston` will fix all the errors reported by Valgrind.

It will remain to be seen if the fix on the `FGPiston` class will make the random floating point exception vanish...

---
**Note:** the CI workflow will now depend on another external Python package `ValgrindCI`. I have chosen this option to avoid cluttering JSBSim repository with loosely related code.