### PR TITLE
Tweak tolerances for portable WGS84 tests

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -142,7 +142,7 @@ jobs:
         uses: actions/upload-artifact@v1
         if: failure()
         with:
-          name: Windows.logs
+          name: Windows_MinGW32.logs
           path: build/Testing/Temporary
 
   Windows-MSVC:
@@ -233,7 +233,7 @@ jobs:
         uses: actions/upload-artifact@v1
         if: failure()
         with:
-          name: Windows.logs
+          name: Windows_MSVC.logs
           path: logs
 
     # Release files

--- a/tests/TestInitialConditions.py
+++ b/tests/TestInitialConditions.py
@@ -226,7 +226,7 @@ class TestInitialConditions(JSBSimTestCase):
                 if abs(csv_value - 360.0) <= 1E-8:
                     csv_value = 0.0
             self.assertAlmostEqual(value, csv_value, delta=1E-7,
-                                   msg="In %s: %s should be %f but found %f" % (f, var['tag'], value, csv_value))
+                                   msg="In {}: {} should be {} but found {}".format(f, var['tag'], value, csv_value))
 
     def GetVariables(self, lat_tag):
         vars = [{'tag': 'longitude', 'unit': convtodeg, 'default_unit': 'RAD',

--- a/tests/TestInitialConditions.py
+++ b/tests/TestInitialConditions.py
@@ -221,7 +221,7 @@ class TestInitialConditions(JSBSimTestCase):
                 continue
 
             value = var['value']
-            csv_value = ref[var['CSV_header']][0]
+            csv_value = float(ref[var['CSV_header']][0])
             if var['tag'] == 'psi':
                 if abs(csv_value - 360.0) <= 1E-8:
                     csv_value = 0.0

--- a/tests/TestInitialConditions.py
+++ b/tests/TestInitialConditions.py
@@ -20,7 +20,7 @@
 # this program; if not, see <http://www.gnu.org/licenses/>
 #
 
-import os, math, shutil, gc
+import os, math, shutil
 import xml.etree.ElementTree as et
 import pandas as pd
 from JSBSim_utils import append_xml, ExecuteUntil, JSBSimTestCase, RunTest
@@ -225,7 +225,6 @@ class TestInitialConditions(JSBSimTestCase):
             if var['tag'] == 'psi':
                 if abs(csv_value - 360.0) <= 1E-8:
                     csv_value = 0.0
-            print('==Test== In {}: {} should be {} but found {}'.format(f, var['tag'], value, csv_value))
             self.assertAlmostEqual(value, csv_value, delta=1E-7,
                                    msg="In {}: {} should be {} but found {}".format(f, var['tag'], value, csv_value))
 
@@ -320,11 +319,6 @@ class TestInitialConditions(JSBSimTestCase):
 
                     self.CheckICValues(self.GetVariables(latitude_tag),
                                        'IC%d' % (i,), fdm, position_tag)
-
-                    # Kill the fdm so that Windows do not block further access to BallOut.csv
-                    fdm = None
-                    self.delete_fdm()
-                    gc.collect()
 
     def test_set_initial_geodetic_latitude(self):
         script_path = self.sandbox.path_to_jsbsim_file('scripts',

--- a/tests/TestInitialConditions.py
+++ b/tests/TestInitialConditions.py
@@ -313,6 +313,7 @@ class TestInitialConditions(JSBSimTestCase):
                     fdm = self.create_fdm()
                     fdm.load_model('ball')
                     fdm.set_output_directive(Output_file)
+                    fdm.set_output_filename(0, 'BallOutput{}.csv'.format((i+1)*(latitude_pos+1))
                     fdm.set_output_filename(1, 'check_csv_values.csv')
                     fdm.load_ic('IC.xml', False)
                     fdm.run_ic()

--- a/tests/TestInitialConditions.py
+++ b/tests/TestInitialConditions.py
@@ -20,7 +20,7 @@
 # this program; if not, see <http://www.gnu.org/licenses/>
 #
 
-import os, math, shutil
+import os, math, shutil, gc
 import xml.etree.ElementTree as et
 import pandas as pd
 from JSBSim_utils import append_xml, ExecuteUntil, JSBSimTestCase, RunTest
@@ -313,7 +313,6 @@ class TestInitialConditions(JSBSimTestCase):
                     fdm = self.create_fdm()
                     fdm.load_model('ball')
                     fdm.set_output_directive(Output_file)
-                    fdm.set_output_filename(0, 'BallOutput{}.csv'.format((i+1)*(latitude_pos+1)))
                     fdm.set_output_filename(1, 'check_csv_values.csv')
                     fdm.load_ic('IC.xml', False)
                     fdm.run_ic()
@@ -324,6 +323,7 @@ class TestInitialConditions(JSBSimTestCase):
                     # Kill the fdm so that Windows do not block further access to BallOut.csv
                     fdm = None
                     self.delete_fdm()
+                    gc.collect()
 
     def test_set_initial_geodetic_latitude(self):
         script_path = self.sandbox.path_to_jsbsim_file('scripts',

--- a/tests/TestInitialConditions.py
+++ b/tests/TestInitialConditions.py
@@ -225,6 +225,7 @@ class TestInitialConditions(JSBSimTestCase):
             if var['tag'] == 'psi':
                 if abs(csv_value - 360.0) <= 1E-8:
                     csv_value = 0.0
+            print('==Test== In {}: {} should be {} but found {}'.format(f, var['tag'], value, csv_value))
             self.assertAlmostEqual(value, csv_value, delta=1E-7,
                                    msg="In {}: {} should be {} but found {}".format(f, var['tag'], value, csv_value))
 

--- a/tests/TestInitialConditions.py
+++ b/tests/TestInitialConditions.py
@@ -313,7 +313,7 @@ class TestInitialConditions(JSBSimTestCase):
                     fdm = self.create_fdm()
                     fdm.load_model('ball')
                     fdm.set_output_directive(Output_file)
-                    fdm.set_output_filename(0, 'BallOutput{}.csv'.format((i+1)*(latitude_pos+1))
+                    fdm.set_output_filename(0, 'BallOutput{}.csv'.format((i+1)*(latitude_pos+1)))
                     fdm.set_output_filename(1, 'check_csv_values.csv')
                     fdm.load_ic('IC.xml', False)
                     fdm.run_ic()

--- a/tests/TestInitialConditions.py
+++ b/tests/TestInitialConditions.py
@@ -320,6 +320,10 @@ class TestInitialConditions(JSBSimTestCase):
                     self.CheckICValues(self.GetVariables(latitude_tag),
                                        'IC%d' % (i,), fdm, position_tag)
 
+                    # Kill the fdm so that Windows do not block further access to BallOut.csv
+                    fdm = None
+                    self.delete_fdm()
+
     def test_set_initial_geodetic_latitude(self):
         script_path = self.sandbox.path_to_jsbsim_file('scripts',
                                                        '737_cruise.xml')

--- a/tests/unit_tests/FGInitialConditionTest.h
+++ b/tests/unit_tests/FGInitialConditionTest.h
@@ -83,8 +83,14 @@ public:
 
           TS_ASSERT_DELTA(ic.GetLongitudeDegIC(), lon, epsilon*100.);
           TS_ASSERT_DELTA(ic.GetLongitudeRadIC(), lon*M_PI/180., epsilon);
+          // For some reasons, MinGW32 and MSVC are less accurate than other platforms.
+#if defined(_MSC_VER) || defined(__MINGW32__)
+          TS_ASSERT_DELTA(ic.GetAltitudeASLFtIC()/asl, 1.0, 4E-8);
+          TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC()/asl, 1.0, 4E-8);
+#else
           TS_ASSERT_DELTA(ic.GetAltitudeASLFtIC()/asl, 1.0, 2E-8);
           TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC()/asl, 1.0, 2E-8);
+#endif
           TS_ASSERT_DELTA(ic.GetLatitudeDegIC(), lat, epsilon*10.);
           TS_ASSERT_DELTA(ic.GetLatitudeRadIC(), lat*M_PI/180., epsilon);
         }
@@ -125,8 +131,8 @@ public:
           TS_ASSERT_DELTA(ic.GetLongitudeDegIC(), lon, epsilon*100.);
           TS_ASSERT_DELTA(ic.GetLongitudeRadIC(), lon*M_PI/180., epsilon);
           TS_ASSERT_DELTA(ic.GetAltitudeASLFtIC()/(agl+2000.), 1.0, 2E-8);
-          // For some reasons, MinGW32 is less accurate than other platforms.
-#ifdef __MINGW32__
+          // For some reasons, MinGW32 and MSVC are less accurate than other platforms.
+#if defined(_MSC_VER) || defined(__MINGW32__)
           TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC()/agl, 1.0, 4E-8);
 #else
           TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC()/agl, 1.0, 2E-8);

--- a/tests/unit_tests/FGInitialConditionTest.h
+++ b/tests/unit_tests/FGInitialConditionTest.h
@@ -100,7 +100,7 @@ public:
           TS_ASSERT_DELTA(ic.GetLongitudeRadIC(), lon*M_PI/180., epsilon);
           TS_ASSERT_DELTA(ic.GetAltitudeASLFtIC()/asl, 1.0, 2E-8);
           TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC()/asl, 1.0, 2E-8);
-          TS_ASSERT_DELTA(ic.GetLatitudeDegIC(), lat, epsilon*10.);
+          TS_ASSERT_DELTA(ic.GetLatitudeDegIC(), lat, epsilon*100.);
           TS_ASSERT_DELTA(ic.GetLatitudeRadIC(), lat*M_PI/180., epsilon);
         }
       }


### PR DESCRIPTION
- Fixed name collision between the logs of MingW32 build and MSVC build.
- Force the conversion to float in TestInitialConditions since it was not automatically done in Windows.