### PR TITLE
Clean up virtual methods.

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -721,7 +721,7 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the metrics element. This element is REQUIRED.
     element = document->FindElement("metrics");
     if (element) {
-      result = ((FGAircraft*)Models[eAircraft])->Load(element);
+      result = Models[eAircraft]->Load(element);
       if (!result) {
         cerr << endl << "Aircraft metrics element has problems in file " << aircraftCfgFileName << endl;
         return result;
@@ -734,7 +734,7 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the mass_balance element. This element is REQUIRED.
     element = document->FindElement("mass_balance");
     if (element) {
-      result = ((FGMassBalance*)Models[eMassBalance])->Load(element);
+      result = Models[eMassBalance]->Load(element);
       if (!result) {
         cerr << endl << "Aircraft mass_balance element has problems in file " << aircraftCfgFileName << endl;
         return result;
@@ -747,7 +747,7 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the ground_reactions element. This element is REQUIRED.
     element = document->FindElement("ground_reactions");
     if (element) {
-      result = ((FGGroundReactions*)Models[eGroundReactions])->Load(element);
+      result = Models[eGroundReactions]->Load(element);
       if (!result) {
         cerr << endl << element->ReadFrom()
              << "Aircraft ground_reactions element has problems in file "
@@ -762,7 +762,7 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the external_reactions element. This element is OPTIONAL.
     element = document->FindElement("external_reactions");
     if (element) {
-      result = ((FGExternalReactions*)Models[eExternalReactions])->Load(element);
+      result = Models[eExternalReactions]->Load(element);
       if (!result) {
         cerr << endl << "Aircraft external_reactions element has problems in file " << aircraftCfgFileName << endl;
         return result;
@@ -772,7 +772,7 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the buoyant_forces element. This element is OPTIONAL.
     element = document->FindElement("buoyant_forces");
     if (element) {
-      result = ((FGBuoyantForces*)Models[eBuoyantForces])->Load(element);
+      result = Models[eBuoyantForces]->Load(element);
       if (!result) {
         cerr << endl << "Aircraft buoyant_forces element has problems in file " << aircraftCfgFileName << endl;
         return result;
@@ -782,19 +782,20 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the propulsion element. This element is OPTIONAL.
     element = document->FindElement("propulsion");
     if (element) {
-      result = ((FGPropulsion*)Models[ePropulsion])->Load(element);
+      auto propulsion = static_cast<FGPropulsion*>(Models[ePropulsion]);
+      result = propulsion->Load(element);
       if (!result) {
         cerr << endl << "Aircraft propulsion element has problems in file " << aircraftCfgFileName << endl;
         return result;
       }
-      for (unsigned int i=0; i<((FGPropulsion*)Models[ePropulsion])->GetNumEngines(); i++)
+      for (unsigned int i=0; i < propulsion->GetNumEngines(); i++)
         ((FGFCS*)Models[eSystems])->AddThrottle();
     }
 
     // Process the system element[s]. This element is OPTIONAL, and there may be more than one.
     element = document->FindElement("system");
     while (element) {
-      result = ((FGFCS*)Models[eSystems])->Load(element);
+      result = Models[eSystems]->Load(element);
       if (!result) {
         cerr << endl << "Aircraft system element has problems in file " << aircraftCfgFileName << endl;
         return result;
@@ -805,7 +806,7 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the autopilot element. This element is OPTIONAL.
     element = document->FindElement("autopilot");
     if (element) {
-      result = ((FGFCS*)Models[eSystems])->Load(element);
+      result = Models[eSystems]->Load(element);
       if (!result) {
         cerr << endl << "Aircraft autopilot element has problems in file " << aircraftCfgFileName << endl;
         return result;
@@ -815,7 +816,7 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the flight_control element. This element is OPTIONAL.
     element = document->FindElement("flight_control");
     if (element) {
-      result = ((FGFCS*)Models[eSystems])->Load(element);
+      result = Models[eSystems]->Load(element);
       if (!result) {
         cerr << endl << "Aircraft flight_control element has problems in file " << aircraftCfgFileName << endl;
         return result;
@@ -825,7 +826,7 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the aerodynamics element. This element is OPTIONAL, but almost always expected.
     element = document->FindElement("aerodynamics");
     if (element) {
-      result = ((FGAerodynamics*)Models[eAerodynamics])->Load(element);
+      result = Models[eAerodynamics]->Load(element);
       if (!result) {
         cerr << endl << "Aircraft aerodynamics element has problems in file " << aircraftCfgFileName << endl;
         return result;

--- a/src/input_output/FGInputSocket.h
+++ b/src/input_output/FGInputSocket.h
@@ -66,21 +66,21 @@ public:
   FGInputSocket(FGFDMExec* fdmex);
 
   /** Destructor. */
-  ~FGInputSocket();
+  ~FGInputSocket() override;
 
   /** Init the input directives from an XML file.
       @param element XML Element that is pointing to the input directives
   */
-  bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /** Initializes the instance. This method basically opens the socket to which
       inputs will be directed.
       @result true if the execution succeeded.
    */
-  bool InitModel(void);
+  bool InitModel(void) override;
 
   /// Generates the input.
-  void Read(bool Holding);
+  void Read(bool Holding) override;
 
 protected:
 

--- a/src/input_output/FGInputType.cpp
+++ b/src/input_output/FGInputType.cpp
@@ -72,7 +72,7 @@ void FGInputType::SetIdx(unsigned int idx)
 bool FGInputType::Load(Element* element)
 {
   // Perform base class Load.
-  if(!FGModel::Load(element, true))
+  if(!FGModel::Upload(element, true))
     return false;
 
   // no common attributes yet (see FGOutputType for example

--- a/src/input_output/FGInputType.h
+++ b/src/input_output/FGInputType.h
@@ -79,7 +79,7 @@ public:
   FGInputType(FGFDMExec* fdmex);
 
   /// Destructor
-  virtual ~FGInputType();
+  ~FGInputType() override;
 
   /** Set the idx for this input instance
       @param idx ID of the input instance that is constructed
@@ -92,7 +92,7 @@ public:
   virtual bool Load(Element* el);
 
   /// Init the input model according to its configitation.
-  virtual bool InitModel(void);
+  bool InitModel(void) override;
 
   /** Executes the input directives (implement the FGModel interface).
       This method checks that the current time step matches the input
@@ -100,7 +100,7 @@ public:
       generation and finally the "post" functions.
       @result false if no error.
    */
-  bool Run(bool Holding);
+  bool Run(bool Holding) override;
 
   /** Generate the input. This is a pure method so it must be implemented by
       the classes that inherits from FGInputType. The Read name may not be
@@ -132,7 +132,7 @@ protected:
   unsigned int InputIdx;
   bool enabled;
 
-  void Debug(int from);
+  void Debug(int from) override;
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/input_output/FGInputType.h
+++ b/src/input_output/FGInputType.h
@@ -89,7 +89,7 @@ public:
   /** Init the input directives from an XML file (implement the FGModel interface).
       @param element XML Element that is pointing to the input directives
   */
-  virtual bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /// Init the input model according to its configitation.
   bool InitModel(void) override;

--- a/src/input_output/FGOutputFG.h
+++ b/src/input_output/FGOutputFG.h
@@ -66,15 +66,15 @@ public:
   /// Constructor
   FGOutputFG(FGFDMExec* fdmex);
 
-  virtual void Print(void);
+  void Print(void) override;
 
   /** Evaluate the output directives from an XML file.
       @param element XML Element that is pointing to the output directives
   */
-  virtual bool Load(Element*);
+  bool Load(Element*) override;
 
 protected:
-  virtual void PrintHeaders(void) {};
+  void PrintHeaders(void) override {};
 
 private:
 

--- a/src/input_output/FGOutputFile.h
+++ b/src/input_output/FGOutputFile.h
@@ -107,7 +107,7 @@ public:
   /** Generate the output. This is a pure method so it must be implemented by
       the classes that inherits from FGOutputFile.
    */
-  void Print(void) = 0;
+  void Print(void) override = 0;
 
 protected:
   SGPath Filename;

--- a/src/input_output/FGOutputFile.h
+++ b/src/input_output/FGOutputFile.h
@@ -74,18 +74,18 @@ public:
   FGOutputFile(FGFDMExec* fdmex);
 
   /// Destructor : closes the file.
-  virtual ~FGOutputFile() { CloseFile(); }
+  ~FGOutputFile() override { CloseFile(); }
 
   /** Init the output directives from an XML file.
       @param element XML Element that is pointing to the output directives
   */
-  bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /** Initializes the instance. This method basically opens the file to which
       outputs will be directed.
       @result true if the execution succeeded.
    */
-  bool InitModel(void);
+  bool InitModel(void) override;
   /** Reset the output prior to a restart of the simulation. This method should
       be called when the simulation is restarted with, for example, new initial
       conditions. The current file is closed and reopened with a new name. The
@@ -93,13 +93,13 @@ public:
       constructor or SetOutputName() and is appended with an underscore _ and
       an ID that is incremented at each call to this method.
   */
-  void SetStartNewOutput(void);
+  void SetStartNewOutput(void) override;
   /** Overwrites the name identifier under which the output will be logged.
       For this method to take effect, it must be called prior to
       FGFDMExec::RunIC(). If it is called after, it will not take effect before
       the next call to SetStartNewOutput().
       @param name new name */
-  void SetOutputName(const std::string& fname) {
+  void SetOutputName(const std::string& fname) override {
     Name = (FDMExec->GetRootDir()/fname).utf8Str();
     runID_postfix = -1;
     Filename = SGPath();

--- a/src/input_output/FGOutputSocket.h
+++ b/src/input_output/FGOutputSocket.h
@@ -70,7 +70,7 @@ public:
   FGOutputSocket(FGFDMExec* fdmex);
 
   /** Destructor. */
-  ~FGOutputSocket();
+  ~FGOutputSocket() override;
 
   /** Overwrites the name identifier under which the output will be logged.
       This method is taken into account if it is called before
@@ -80,20 +80,20 @@ public:
                   hostname could be an ip, port a numerical value and
                   proto should be UDP or TCP (the default if omitted)
   */
-  virtual void SetOutputName(const std::string& name);
+  void SetOutputName(const std::string& name) override;
 
   /** Init the output directives from an XML file.
       @param element XML Element that is pointing to the output directives
   */
-  virtual bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /** Initializes the instance. This method basically opens the socket to which
       outputs will be directed.
       @result true if the execution succeeded.
    */
-  bool InitModel(void);
+  bool InitModel(void) override;
   /// Generates the output.
-  void Print(void);
+  void Print(void) override;
 
   /** Outputs a status thru the socket. This method issues a message prepended
       by the string "<STATUS>" to the socket.

--- a/src/input_output/FGOutputTextFile.h
+++ b/src/input_output/FGOutputTextFile.h
@@ -77,17 +77,17 @@ public:
   /** Init the output directives from an XML file.
       @param element XML Element that is pointing to the output directives
   */
-  virtual bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /// Generates the output to the text file.
-  virtual void Print(void);
+  void Print(void) override;
 
 protected:
   std::string delimeter;
   sg_ofstream datafile;
 
-  virtual bool OpenFile(void);
-  virtual void CloseFile(void) { if (datafile.is_open()) datafile.close(); }
+  bool OpenFile(void) override;
+  void CloseFile(void) override { if (datafile.is_open()) datafile.close(); }
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/input_output/FGOutputType.h
+++ b/src/input_output/FGOutputType.h
@@ -135,7 +135,7 @@ public:
   /** Init the output directives from an XML file (implement the FGModel interface).
       @param element XML Element that is pointing to the output directives
   */
-  virtual bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /// Init the output model according to its configitation.
   bool InitModel(void) override;

--- a/src/input_output/FGOutputType.h
+++ b/src/input_output/FGOutputType.h
@@ -96,7 +96,7 @@ public:
   FGOutputType(FGFDMExec* fdmex);
 
   /// Destructor
-  virtual ~FGOutputType();
+  ~FGOutputType() override;
 
   /** Set the idx for this output instance
       @param idx ID of the output instance that is constructed
@@ -138,7 +138,7 @@ public:
   virtual bool Load(Element* el);
 
   /// Init the output model according to its configitation.
-  virtual bool InitModel(void);
+  bool InitModel(void) override;
 
   /** Executes the output directives (implement the FGModel interface).
       This method checks that the current time step matches the output
@@ -209,7 +209,7 @@ protected:
   FGExternalReactions* ExternalReactions;
   FGBuoyantForces* BuoyantForces;
 
-  void Debug(int from);
+  void Debug(int from) override;
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/input_output/FGUDPInputSocket.h
+++ b/src/input_output/FGUDPInputSocket.h
@@ -66,10 +66,10 @@ public:
   /** Reads the property names from an XML file.
       @param element The root XML Element of the input file.
   */
-  bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /// Reads the socket and updates properties accordingly.
-  void Read(bool Holding);
+  void Read(bool Holding) override;
 
 protected:
 

--- a/src/models/FGAerodynamics.cpp
+++ b/src/models/FGAerodynamics.cpp
@@ -329,7 +329,7 @@ bool FGAerodynamics::Load(Element *document)
   Name = "Aerodynamics Model: " + document->GetAttributeValue("name");
 
   // Perform base class Pre-Load
-  if (!FGModel::Load(document, true))
+  if (!FGModel::Upload(document, true))
     return false;
 
   DetermineAxisSystem(document); // Determine if Lift/Side/Drag, etc. is used.

--- a/src/models/FGAerodynamics.h
+++ b/src/models/FGAerodynamics.h
@@ -136,7 +136,7 @@ public:
       have found the aerodynamics keyword in the configuration file.
       @param element pointer to the current XML element for aerodynamics parameters.
       @return true if successful */
-  bool Load(Element* element);
+  bool Load(Element* element) override;
 
   /** Gets the total aerodynamic force vector.
       @return a force vector reference. */

--- a/src/models/FGAerodynamics.h
+++ b/src/models/FGAerodynamics.h
@@ -118,9 +118,9 @@ public:
       @param Executive a pointer to the parent executive object */
   FGAerodynamics(FGFDMExec* Executive);
   /// Destructor
-  ~FGAerodynamics();
+  ~FGAerodynamics() override;
 
-  bool InitModel(void);
+  bool InitModel(void) override;
 
   /** Runs the Aerodynamics model; called by the Executive
       Can pass in a value indicating if the executive is directing the simulation to Hold.
@@ -129,14 +129,14 @@ public:
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
       @return false if no error */
-  bool Run(bool Holding);
+  bool Run(bool Holding) override;
 
   /** Loads the Aerodynamics model.
       The Load function for this class expects the XML parser to
       have found the aerodynamics keyword in the configuration file.
       @param element pointer to the current XML element for aerodynamics parameters.
       @return true if successful */
-  virtual bool Load(Element* element);
+  bool Load(Element* element);
 
   /** Gets the total aerodynamic force vector.
       @return a force vector reference. */
@@ -283,7 +283,7 @@ private:
   void bind(void);
   void BuildStabilityTransformMatrices(void);
 
-  void Debug(int from);
+  void Debug(int from) override;
 };
 
 } // namespace JSBSim

--- a/src/models/FGAircraft.cpp
+++ b/src/models/FGAircraft.cpp
@@ -118,7 +118,7 @@ bool FGAircraft::Load(Element* el)
   string element_name;
   Element* element;
 
-  if (!FGModel::Load(el, true)) return false;
+  if (!FGModel::Upload(el, true)) return false;
 
   if (el->FindElement("wingarea"))
     WingArea = el->FindElementValueAsNumberConvertTo("wingarea", "FT2");

--- a/src/models/FGAircraft.h
+++ b/src/models/FGAircraft.h
@@ -124,7 +124,7 @@ public:
       The executive calls this method to load the aircraft into JSBSim.
       @param el a pointer to the element tree
       @return true if successful */
-  bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /** Gets the aircraft name
       @return the name of the aircraft as a string type */

--- a/src/models/FGAircraft.h
+++ b/src/models/FGAircraft.h
@@ -106,7 +106,7 @@ public:
   FGAircraft(FGFDMExec *Executive);
 
   /// Destructor
-  ~FGAircraft();
+  ~FGAircraft() override;
 
   /** Runs the Aircraft model; called by the Executive
       Can pass in a value indicating if the executive is directing the simulation to Hold.
@@ -116,15 +116,15 @@ public:
                      "Resume" command to be given.
       @see JSBSim.cpp documentation
       @return false if no error */
-  bool Run(bool Holding);
+  bool Run(bool Holding) override;
 
-  bool InitModel(void);
+  bool InitModel(void) override;
 
   /** Loads the aircraft.
       The executive calls this method to load the aircraft into JSBSim.
       @param el a pointer to the element tree
       @return true if successful */
-  virtual bool Load(Element* el);
+  bool Load(Element* el);
 
   /** Gets the aircraft name
       @return the name of the aircraft as a string type */
@@ -164,9 +164,6 @@ public:
 
   void SetWingArea(double S) {WingArea = S;}
 
-  void bind(void);
-  void unbind(void);
-
   struct Inputs {
     FGColumnVector3 AeroForce;
     FGColumnVector3 PropForce;
@@ -193,7 +190,9 @@ private:
   double lbarh,lbarv,vbarh,vbarv;
   std::string AircraftName;
 
-  void Debug(int from);
+  void bind(void);
+  void unbind(void);
+  void Debug(int from) override;
 };
 
 } // namespace JSBSim

--- a/src/models/FGBuoyantForces.cpp
+++ b/src/models/FGBuoyantForces.cpp
@@ -117,7 +117,7 @@ bool FGBuoyantForces::Load(Element *document)
   Debug(2);
 
   // Perform base class Pre-Load
-  if (!FGModel::Load(document, true))
+  if (!FGModel::Upload(document, true))
     return false;
 
   gas_cell_element = document->FindElement("gas_cell");

--- a/src/models/FGBuoyantForces.h
+++ b/src/models/FGBuoyantForces.h
@@ -103,9 +103,9 @@ public:
       @param Executive a pointer to the parent executive object */
   FGBuoyantForces(FGFDMExec* Executive);
   /// Destructor
-  ~FGBuoyantForces();
+  ~FGBuoyantForces() override;
 
-  bool InitModel(void);
+  bool InitModel(void) override;
 
   /** Runs the Buoyant forces model; called by the Executive
       Can pass in a value indicating if the executive is directing the simulation to Hold.
@@ -114,14 +114,14 @@ public:
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
       @return false if no error */
-  bool Run(bool Holding);
+  bool Run(bool Holding) override;
 
   /** Loads the Buoyant forces model.
       The Load function for this class expects the XML parser to
       have found the Buoyant_forces keyword in the configuration file.
       @param element pointer to the current XML element for Buoyant forces parameters.
       @return true if successful */
-  virtual bool Load(Element* element);
+  bool Load(Element* element);
 
   /** Gets the total Buoyant force vector.
       @return a force vector in lbs. */
@@ -181,7 +181,7 @@ private:
 
   void bind(void);
 
-  void Debug(int from);
+  void Debug(int from) override;
 };
 
 } // namespace JSBSim

--- a/src/models/FGBuoyantForces.h
+++ b/src/models/FGBuoyantForces.h
@@ -121,7 +121,7 @@ public:
       have found the Buoyant_forces keyword in the configuration file.
       @param element pointer to the current XML element for Buoyant forces parameters.
       @return true if successful */
-  bool Load(Element* element);
+  bool Load(Element* element) override;
 
   /** Gets the total Buoyant force vector.
       @return a force vector in lbs. */

--- a/src/models/FGExternalReactions.cpp
+++ b/src/models/FGExternalReactions.cpp
@@ -58,7 +58,7 @@ FGExternalReactions::FGExternalReactions(FGFDMExec* fdmex) : FGModel(fdmex)
 bool FGExternalReactions::Load(Element* el)
 {
   // Call the base class Load() function to load interface properties.
-  if (!FGModel::Load(el, true))
+  if (!FGModel::Upload(el, true))
     return false;
 
   Debug(2);

--- a/src/models/FGExternalReactions.h
+++ b/src/models/FGExternalReactions.h
@@ -130,9 +130,9 @@ public:
       Within the destructor the Forces and interface_properties vectors are
       cleared out and the items pointed to are deleted.
   */
-  ~FGExternalReactions(void);
+  ~FGExternalReactions(void) override;
 
-  bool InitModel(void);
+  bool InitModel(void) override;
 
   /** Sum all the constituent forces for this cycle.
       Can pass in a value indicating if the executive is directing the simulation to Hold.
@@ -141,7 +141,7 @@ public:
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
       @return true always.  */
-  bool Run(bool Holding);
+  bool Run(bool Holding) override;
   
   /** Loads the external forces from the XML configuration file.
       If the external_reactions section is encountered in the vehicle configuration
@@ -149,7 +149,7 @@ public:
       a FGExternalForce object will be instantiated for each force definition.
       @param el a pointer to the XML element holding the external reactions definition.
   */
-  virtual bool Load(Element* el);
+  bool Load(Element* el);
 
   /** Retrieves the total forces defined in the external reactions.
       @return the total force in pounds.
@@ -171,7 +171,7 @@ private:
   FGColumnVector3 vTotalMoments;
 
   void bind(void);
-  void Debug(int from);
+  void Debug(int from) override;
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGExternalReactions.h
+++ b/src/models/FGExternalReactions.h
@@ -149,7 +149,7 @@ public:
       a FGExternalForce object will be instantiated for each force definition.
       @param el a pointer to the XML element holding the external reactions definition.
   */
-  bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /** Retrieves the total forces defined in the external reactions.
       @return the total force in pounds.

--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -482,7 +482,7 @@ bool FGFCS::Load(Element* document)
   }
 
   // Load interface properties from document
-  if (!FGModel::Load(document, true))
+  if (!FGModel::Upload(document, true))
     return false;
 
   Name += document->GetAttributeValue("name");

--- a/src/models/FGFCS.h
+++ b/src/models/FGFCS.h
@@ -192,9 +192,9 @@ public:
       @param Executive a pointer to the parent executive object */
   FGFCS(FGFDMExec*);
   /// Destructor
-  ~FGFCS();
+  ~FGFCS() override;
 
-  bool InitModel(void);
+  bool InitModel(void) override;
 
   /** Runs the Flight Controls model; called by the Executive
       Can pass in a value indicating if the executive is directing the simulation to Hold.
@@ -203,7 +203,7 @@ public:
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
       @return false if no error */
-  bool Run(bool Holding);
+  bool Run(bool Holding) override;
 
   /// @name Pilot input command retrieval
   //@{
@@ -536,7 +536,7 @@ public:
       Load() is called from FGFDMExec.
       @param el pointer to the Element instance
       @return true if succesful */
-  virtual bool Load(Element* el);
+  bool Load(Element* el);
 
   SGPath FindFullPathName(const SGPath& path) const;
 
@@ -573,7 +573,7 @@ private:
   Channels SystemChannels;
   void bind(void);
   void bindThrottle(unsigned int);
-  void Debug(int from);
+  void Debug(int from) override;
 };
 }
 

--- a/src/models/FGFCS.h
+++ b/src/models/FGFCS.h
@@ -538,7 +538,7 @@ public:
       @return true if succesful */
   bool Load(Element* el);
 
-  SGPath FindFullPathName(const SGPath& path) const;
+  SGPath FindFullPathName(const SGPath& path) const override;
 
   void AddThrottle(void);
   double GetDt(void) const;

--- a/src/models/FGFCS.h
+++ b/src/models/FGFCS.h
@@ -536,7 +536,7 @@ public:
       Load() is called from FGFDMExec.
       @param el pointer to the Element instance
       @return true if succesful */
-  bool Load(Element* el);
+  bool Load(Element* el) override;
 
   SGPath FindFullPathName(const SGPath& path) const override;
 

--- a/src/models/FGGroundReactions.cpp
+++ b/src/models/FGGroundReactions.cpp
@@ -152,7 +152,7 @@ bool FGGroundReactions::Load(Element* document)
   Debug(2);
 
   // Perform base class Pre-Load
-  if (!FGModel::Load(document, true))
+  if (!FGModel::Upload(document, true))
     return false;
 
   unsigned int numContacts = document->GetNumElements("contact");

--- a/src/models/FGGroundReactions.h
+++ b/src/models/FGGroundReactions.h
@@ -91,7 +91,7 @@ public:
                      "Resume" command to be given.
       @return false if no error */
   bool Run(bool Holding) override;
-  bool Load(Element* el);
+  bool Load(Element* el) override;
   const FGColumnVector3& GetForces(void) const {return vForces;}
   double GetForces(int idx) const {return vForces(idx);}
   const FGColumnVector3& GetMoments(void) const {return vMoments;}

--- a/src/models/FGGroundReactions.h
+++ b/src/models/FGGroundReactions.h
@@ -80,9 +80,9 @@ class FGGroundReactions : public FGModel, public FGSurface
 {
 public:
   FGGroundReactions(FGFDMExec*);
-  ~FGGroundReactions(void);
+  ~FGGroundReactions(void) override;
 
-  bool InitModel(void);
+  bool InitModel(void) override;
   /** Runs the Ground Reactions model; called by the Executive
       Can pass in a value indicating if the executive is directing the simulation to Hold.
       @param Holding if true, the executive has been directed to hold the sim from 
@@ -90,8 +90,8 @@ public:
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
       @return false if no error */
-  bool Run(bool Holding);
-  virtual bool Load(Element* el);
+  bool Run(bool Holding) override;
+  bool Load(Element* el);
   const FGColumnVector3& GetForces(void) const {return vForces;}
   double GetForces(int idx) const {return vForces(idx);}
   const FGColumnVector3& GetMoments(void) const {return vMoments;}
@@ -130,7 +130,7 @@ private:
   double DsCmd;
 
   void bind(void);
-  void Debug(int from);
+  void Debug(int from) override;
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGInput.h
+++ b/src/models/FGInput.h
@@ -85,13 +85,13 @@ class FGInput : public FGModel
 {
 public:
   FGInput(FGFDMExec*);
-  ~FGInput();
+  ~FGInput() override;
 
   /** Load the input directives and adds a new input instance to the Input
       Manager list.
       @param el XMLElement that is pointing to the input directives
       @result true if the execution succeeded. */
-  bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /** Initializes the instance. This method is called by FGFDMExec::RunIC().
       This is were the initialization of all classes derived from FGInputType
@@ -99,7 +99,7 @@ public:
       to FGFDMExec::RunIC() so that the initialization process can be executed
       properly.
       @result true if the execution succeeded. */
-  bool InitModel(void);
+  bool InitModel(void) override;
 
   /** Runs the Input model; called by the Executive
       Can pass in a value indicating if the executive is directing the simulation to Hold.
@@ -108,7 +108,7 @@ public:
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
       @return false if no error */
-  bool Run(bool Holding);
+  bool Run(bool Holding) override;
 
   /** Adds a new input instance to the Input Manager. The definition of the
       new input instance is read from a file.
@@ -147,7 +147,7 @@ private:
   std::vector<FGInputType*> InputTypes;
   bool enabled;
 
-  void Debug(int from);
+  void Debug(int from) override;
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -133,7 +133,7 @@ bool FGMassBalance::Load(Element* document)
   Name = "Mass Properties Model: " + document->GetAttributeValue("name");
 
   // Perform base class Pre-Load
-  if (!FGModel::Load(document, true))
+  if (!FGModel::Upload(document, true))
     return false;
 
   SetAircraftBaseInertias(ReadInertiaMatrix(document));

--- a/src/models/FGMassBalance.h
+++ b/src/models/FGMassBalance.h
@@ -111,7 +111,7 @@ public:
   explicit FGMassBalance(FGFDMExec*);
   ~FGMassBalance();
 
-  bool Load(Element* el);
+  bool Load(Element* el) override;
   bool InitModel(void) override;
   /** Runs the Mass Balance model; called by the Executive
       Can pass in a value indicating if the executive is directing the

--- a/src/models/FGModel.cpp
+++ b/src/models/FGModel.cpp
@@ -107,7 +107,7 @@ SGPath FGModel::FindFullPathName(const SGPath& path) const
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-bool FGModel::Load(Element* el, bool preLoad)
+bool FGModel::Upload(Element* el, bool preLoad)
 {
   FGModelLoader ModelLoader(this);
   Element* document = ModelLoader.Open(el);

--- a/src/models/FGModel.h
+++ b/src/models/FGModel.h
@@ -102,12 +102,14 @@ protected:
   unsigned int rate;
   std::string Name;
 
-  /** Loads this model.
+  /** Uploads this model in memory.
+      Uploads the model in memory if its contents are contained in a separate
+      file.
       @param el      a pointer to the element
       @param preLoad true if model functions and local properties must be
                      preloaded.
       @return true if model is successfully loaded*/
-  bool Load(Element* el, bool preLoad);
+  bool Upload(Element* el, bool preLoad);
 
   virtual void Debug(int from);
 

--- a/src/models/FGModel.h
+++ b/src/models/FGModel.h
@@ -95,6 +95,7 @@ public:
   void SetPropertyManager(FGPropertyManager *fgpm) { PropertyManager=fgpm;}
   virtual SGPath FindFullPathName(const SGPath& path) const;
   const std::string& GetName(void) { return Name; }
+  virtual bool Load(Element* el) { return true; }
 
 protected:
   unsigned int exe_ctr;
@@ -106,7 +107,7 @@ protected:
       @param preLoad true if model functions and local properties must be
                      preloaded.
       @return true if model is successfully loaded*/
-  virtual bool Load(Element* el, bool preLoad);
+  bool Load(Element* el, bool preLoad);
 
   virtual void Debug(int from);
 

--- a/src/models/FGOutput.cpp
+++ b/src/models/FGOutput.cpp
@@ -236,7 +236,7 @@ bool FGOutput::Load(Element* document, const SGPath& dir)
   includePath = dir;
 
   // Perform base class Pre-Load
-  if (!FGModel::Load(document, false))
+  if (!FGModel::Upload(document, false))
     return false;
 
   size_t idx = OutputTypes.size();

--- a/src/models/FGOutput.h
+++ b/src/models/FGOutput.h
@@ -195,7 +195,7 @@ public:
       @param el XMLElement that is pointing to the output directives
       @param dir optional directory path to load included files from
       @result true if the execution succeeded. */
-  virtual bool Load(Element* el, const SGPath& dir = SGPath());
+  bool Load(Element* el, const SGPath& dir = SGPath());
   /** Load the output directives and adds a new output instance to the Output
       Manager list. Unlike the Load() method, the new output instance is not
       generated from output directives read in a XML file but from a list of

--- a/src/models/FGPropulsion.cpp
+++ b/src/models/FGPropulsion.cpp
@@ -365,7 +365,7 @@ bool FGPropulsion::Load(Element* el)
   Name = "Propulsion Model: " + el->GetAttributeValue("name");
 
   // Perform base class Pre-Load
-  if (!FGModel::Load(el, true))
+  if (!FGModel::Upload(el, true))
     return false;
 
   // Process tank definitions first to establish the number of fuel tanks

--- a/src/models/FGPropulsion.h
+++ b/src/models/FGPropulsion.h
@@ -102,7 +102,7 @@ public:
   /// Constructor
   FGPropulsion(FGFDMExec*);
   /// Destructor
-  ~FGPropulsion();
+  ~FGPropulsion() override;
 
   /** Executes the propulsion model.
       The initial plan for the FGPropulsion class calls for Run() to be executed,
@@ -113,15 +113,15 @@ public:
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
       @return false if no error */
-  bool Run(bool Holding);
+  bool Run(bool Holding) override;
 
-  bool InitModel(void);
+  bool InitModel(void) override;
 
   /** Loads the propulsion system (engine[s] and tank[s]).
       Characteristics of the propulsion system are read in from the config file.
       @param el pointer to an XML element that contains the engine information.
       @return true if successfully loaded, otherwise false */
-  virtual bool Load(Element* el);
+  bool Load(Element* el);
 
   /// Retrieves the number of engines defined for the aircraft.
   unsigned int GetNumEngines(void) const {return (unsigned int)Engines.size();}
@@ -221,7 +221,7 @@ private:
   bool ReadingEngine;
 
   void bind();
-  void Debug(int from);
+  void Debug(int from) override;
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGPropulsion.h
+++ b/src/models/FGPropulsion.h
@@ -121,7 +121,7 @@ public:
       Characteristics of the propulsion system are read in from the config file.
       @param el pointer to an XML element that contains the engine information.
       @return true if successfully loaded, otherwise false */
-  bool Load(Element* el);
+  bool Load(Element* el) override;
 
   /// Retrieves the number of engines defined for the aircraft.
   unsigned int GetNumEngines(void) const {return (unsigned int)Engines.size();}

--- a/src/models/FGPropulsion.h
+++ b/src/models/FGPropulsion.h
@@ -173,7 +173,7 @@ public:
   const FGColumnVector3& GetTanksMoment(void);
   double GetTanksWeight(void) const;
 
-  SGPath FindFullPathName(const SGPath& path) const;
+  SGPath FindFullPathName(const SGPath& path) const override;
   inline int GetActiveEngine(void) const {return ActiveEngine;}
   inline bool GetFuelFreeze(void) const {return FuelFreeze;}
 

--- a/src/models/propulsion/FGEngine.h
+++ b/src/models/propulsion/FGEngine.h
@@ -142,7 +142,7 @@ public:
   };
 
   FGEngine(int engine_number, struct Inputs& input);
-  virtual ~FGEngine();
+  ~FGEngine() override;
 
   enum EngineType {etUnknown, etRocket, etPiston, etTurbine, etTurboprop, etElectric};
 
@@ -241,7 +241,7 @@ protected:
 
   std::vector <int> SourceTanks;
 
-  virtual bool Load(FGFDMExec *exec, Element *el);
+  bool Load(FGFDMExec *exec, Element *el);
   void Debug(int from);
 };
 }


### PR DESCRIPTION
* Fix some warnings from the clang compiler about hidden methods.
* Use C++11 `override` wherever possible
* Renamed `FGModel::Load()` to `FGModel::Upload()` since it is an helper method to load models.