### PR TITLE
Add warning messages for inconsistent gravity settings.

### DIFF
--- a/src/models/FGInertial.cpp
+++ b/src/models/FGInertial.cpp
@@ -107,6 +107,12 @@ bool FGInertial::Load(Element* el)
 
   GroundCallback->SetEllipse(a, b);
 
+  // Messages to warn the user about possible inconsistencies.
+  if (a != b && J2 == 0.0)
+    cout << "Gravitational constant J2 is null for a non-spherical planet." << endl;
+  if (a == b && J2 != 0.0)
+    cout << "Gravitational constant J2 is non-zero for a spherical planet." << endl;
+
   Debug(2);
 
   return true;
@@ -217,11 +223,31 @@ void FGInertial::SetAltitudeAGL(FGLocation& location, double altitudeAGL)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+void FGInertial::SetGravityType(int gt)
+{
+  // Messages to warn the user about possible inconsistencies.
+  switch (gt)
+  {
+  case eGravType::gtStandard: 
+    if (a != b)
+      cout << "Set standard gravity for a non-spherical planet" << endl;
+    break;
+  case eGravType::gtWGS84:
+    if (J2 == 0.0)
+      cout << "Set WGS84 with a null gravitational constant J2." << endl;
+  }
+
+  gravType = gt;
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 void FGInertial::bind(void)
 {
   PropertyManager->Tie("inertial/sea-level-radius_ft", &in.Position,
                        &FGLocation::GetSeaLevelRadius);
-  PropertyManager->Tie("simulation/gravity-model", &gravType);
+  PropertyManager->Tie("simulation/gravity-model", this, &FGInertial::GetGravityType,
+                       &FGInertial::SetGravityType);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGInertial.cpp
+++ b/src/models/FGInertial.cpp
@@ -230,11 +230,11 @@ void FGInertial::SetGravityType(int gt)
   {
   case eGravType::gtStandard: 
     if (a != b)
-      cout << "Set standard gravity for a non-spherical planet" << endl;
+      cout << "Warning: Standard gravity model has been set for a non-spherical planet" << endl;
     break;
   case eGravType::gtWGS84:
     if (J2 == 0.0)
-      cout << "Set WGS84 with a null gravitational constant J2." << endl;
+      cout << "Warning: WGS84 gravity model has been set without specifying the J2 gravitational constant." << endl;
   }
 
   gravType = gt;

--- a/src/models/FGInertial.h
+++ b/src/models/FGInertial.h
@@ -149,6 +149,22 @@ public:
   */
   void SetGroundCallback(FGGroundCallback* gc) { GroundCallback.reset(gc); }
 
+  /// These define the indices use to select the gravitation models.
+  enum eGravType {
+    /// Evaluate gravity using Newton's classical formula assuming the Earth is
+    /// spherical
+    gtStandard,
+    /// Evaluate gravity using WGS84 formulas that take the Earth oblateness
+    /// into account
+    gtWGS84
+  };
+
+  /// Get the gravity type.
+  int GetGravityType(void) const { return gravType; }
+
+  /// Set the gravity type.
+  void SetGravityType(int gt);
+
   /** Transform matrix from the local horizontal frame to earth centered.
       The local frame is the NED (North-East-Down) frame. Since the Down
       direction depends on the gravity so is the local frame.
@@ -185,16 +201,6 @@ public:
   bool Load(Element* el) override;
 
 private:
-  /// These define the indices use to select the gravitation models.
-  enum eGravType {
-    /// Evaluate gravity using Newton's classical formula assuming the Earth is
-    /// spherical
-    gtStandard,
-    /// Evaluate gravity using WGS84 formulas that take the Earth oblateness
-    /// into account
-    gtWGS84
-  };
-
   // Standard gravity (9.80665 m/s^2) in ft/s^2 which is the gravity at 45 deg.
   // of latitude (see ISA 1976 and Steven & Lewis)
   // It includes the centripetal acceleration.


### PR DESCRIPTION
As per the discussion in issue #184, this PR adds warnings when the user select gravity settings that are not entirely consistent with the planet shape (spherical vs non-spherical).