### PR TITLE
Enable code scanning and fix security warnings in the process

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,71 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+  schedule:
+    - cron: '0 9 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Override automatic language detection by changing the below list
+        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
+        language: ['cpp', 'python']
+        # Learn more...
+        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file. 
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -494,7 +494,7 @@ int real_main(int argc, char* argv[])
   time(&tod);
   struct tm local;
 #ifdef _MSC_VER
-  localtime_r(&local, &tod);
+  localtime_s(&local, &tod);
 #else
   localtime_r(&tod, &local);
 #endif
@@ -565,7 +565,7 @@ int real_main(int argc, char* argv[])
   // PRINT ENDING CLOCK TIME
   time(&tod);
 #ifdef _MSC_VER
-  localtime_r(&local, &tod);
+  localtime_s(&local, &tod);
 #else
   localtime_r(&tod, &local);
 #endif

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -492,7 +492,8 @@ int real_main(int argc, char* argv[])
   char s[100];
   time_t tod;
   time(&tod);
-  strftime(s, 99, "%A %B %d %Y %X", localtime(&tod));
+  struct tm local;
+  strftime(s, 99, "%A %B %d %Y %X", localtime_r(&tod, &local));
   cout << "Start: " << s << " (HH:MM:SS)" << endl;
 
   frame_duration = FDMExec->GetDeltaT();
@@ -558,7 +559,7 @@ int real_main(int argc, char* argv[])
 
   // PRINT ENDING CLOCK TIME
   time(&tod);
-  strftime(s, 99, "%A %B %d %Y %X", localtime(&tod));
+  strftime(s, 99, "%A %B %d %Y %X", localtime_r(&tod, &local));
   cout << "End: " << s << " (HH:MM:SS)" << endl;
 
   // CLEAN UP

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -493,7 +493,12 @@ int real_main(int argc, char* argv[])
   time_t tod;
   time(&tod);
   struct tm local;
-  strftime(s, 99, "%A %B %d %Y %X", localtime_r(&tod, &local));
+#ifdef _MSC_VER
+  localtime_r(&local, &tod);
+#else
+  localtime_r(&tod, &local);
+#endif
+  strftime(s, 99, "%A %B %d %Y %X", &local);
   cout << "Start: " << s << " (HH:MM:SS)" << endl;
 
   frame_duration = FDMExec->GetDeltaT();
@@ -559,7 +564,12 @@ int real_main(int argc, char* argv[])
 
   // PRINT ENDING CLOCK TIME
   time(&tod);
-  strftime(s, 99, "%A %B %d %Y %X", localtime_r(&tod, &local));
+#ifdef _MSC_VER
+  localtime_r(&local, &tod);
+#else
+  localtime_r(&tod, &local);
+#endif
+  strftime(s, 99, "%A %B %d %Y %X", &local);
   cout << "End: " << s << " (HH:MM:SS)" << endl;
 
   // CLEAN UP

--- a/src/models/flight_control/FGMagnetometer.cpp
+++ b/src/models/flight_control/FGMagnetometer.cpp
@@ -75,7 +75,11 @@ FGMagnetometer::FGMagnetometer(FGFCS* fcs, Element* element)
   time_t rawtime;
   time( &rawtime );
   struct tm ptm;
+  #ifdef _MSC_VER
+  gmtime_s(&ptm, &rawtime);
+  #else
   gmtime_r(&rawtime, &ptm);
+  #endif
 
   int year = ptm.tm_year;
   if(year>100)

--- a/src/models/flight_control/FGMagnetometer.cpp
+++ b/src/models/flight_control/FGMagnetometer.cpp
@@ -74,15 +74,16 @@ FGMagnetometer::FGMagnetometer(FGFCS* fcs, Element* element)
   //would be better to get the date from the sim if its simulated...
   time_t rawtime;
   time( &rawtime );
-  tm * ptm = gmtime ( &rawtime );
+  struct tm ptm;
+  gmtime_r(&rawtime, &ptm);
 
-  int year = ptm->tm_year;
+  int year = ptm.tm_year;
   if(year>100)
   {
     year-= 100;
   }
   //the months here are zero based TODO find out if the function expects 1s based
-  date = (yymmdd_to_julian_days(ptm->tm_year,ptm->tm_mon,ptm->tm_mday));//Julian 1950-2049 yy,mm,dd
+  date = (yymmdd_to_julian_days(ptm.tm_year, ptm.tm_mon, ptm.tm_mday)); //Julian 1950-2049 yy,mm,dd
   updateInertialMag();
 
   Debug(0);

--- a/utils/aeromatic++/Aircraft.cpp
+++ b/utils/aeromatic++/Aircraft.cpp
@@ -491,7 +491,7 @@ Aeromatic::write_XML()
 
     time(&t);
     struct tm ti;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
     localtime_s(&ti, &t);
 #else
     localtime_r(&t, &ti);

--- a/utils/aeromatic++/Aircraft.cpp
+++ b/utils/aeromatic++/Aircraft.cpp
@@ -490,14 +490,13 @@ Aeromatic::write_XML()
     time_t t;
 
     time(&t);
-#ifdef _MSC_VER
     struct tm ti;
+#ifdef _MSC_VER
     localtime_s(&ti, &t);
-    strftime(str, sizeof(str), "%d %b %Y", &ti);
 #else
-    struct tm *ti= localtime(&t);
-    strftime(str, sizeof(str), "%d %b %Y", ti);
+    localtime_r(&t, &ti);
 #endif
+    strftime(str, sizeof(str), "%d %b %Y", &ti);
 
     _dir = _subdir ? create_dir(_path, _name) : _path;
     if (_dir.empty()) {


### PR DESCRIPTION
[GitHub just released code scanning](https://github.blog/2020-09-30-code-scanning-is-now-available) which, on the bright side, helps open source projects finding their security holes and, on the dark side, exposes suddenly to the world (and without much prior warnings to the devs) security holes of a lot of open source projects.

Fortunately, JSBSim does not suffer from severe security holes although GitHub code scanning has detected 4 security warnings (which are also fixed by this PR so that they cannot be exploited from this release on).