### PR TITLE
Fix the build of manylinux wheel packages

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -75,7 +75,7 @@ jobs:
           rm -f python/dist/*.whl
           make clean
           # Install the Docker build environment
-          docker pull quay.io/pypa/manylinux2010_x86_64
+          docker pull quay.io/pypa/manylinux2010_x86_64:2020-11-11-201fb79
           cp ../python/build-wheels.sh .
           chmod +x build-wheels.sh
           # Build the manylinux1 wheel binary packages

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -79,7 +79,7 @@ jobs:
           cp ../python/build-wheels.sh .
           chmod +x build-wheels.sh
           # Build the manylinux1 wheel binary packages
-          docker run --rm -e GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER -e GITHUB_SHA=$GITHUB_SHA -v $PWD/..:/io quay.io/pypa/manylinux2010_x86_64 /io/build/build-wheels.sh
+          docker run --rm -e GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER -e GITHUB_SHA=$GITHUB_SHA -v $PWD/..:/io quay.io/pypa/manylinux2010_x86_64:2020-11-11-201fb79 /io/build/build-wheels.sh
       - name: Test wheel package
         if: steps.ManyLinux.outcome == 'success'
         run: |


### PR DESCRIPTION
It seems that [CMake has been removed from the latest docker container for manylinux](https://quay.io/repository/pypa/manylinux2010_x86_64/manifest/sha256:a0958f05b2f7b8f009a8b2b99da40838ea27d7b6e98ae173924e45a8ac8db2a7?tab=packages).
This PR fixes the problem by forcing the use of [the last version (2020-11-11-201fb79) that was including CMake](https://quay.io/repository/pypa/manylinux2010_x86_64/manifest/sha256:bd777045e0b7ba6ba09845f5dd68a956d9cc3e7c014f8f4ffa6f50d6d2582751?tab=packages).

Fixes the build failure that occured in [C/C++ build #184](https://github.com/JSBSim-Team/jsbsim/actions/runs/400879511).