### PR TITLE
Julia binding for JSBSim

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -9,7 +9,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
         expat: [ON, OFF]
         shared_libs: [ON, OFF]
         exclude:
@@ -48,10 +48,17 @@ jobs:
           perl -i -pe 's/^(GENERATE_HTML\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
           perl -i -pe 's/^(HAVE_DOT\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
       - name: Configure JSBSim
+        if: matrix.os != 'ubuntu-16.04'
         run: |
           mkdir build
           cd build
           cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON -DCMAKE_C_FLAGS_DEBUG="-g -O2" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2" -DCMAKE_BUILD_TYPE=Debug -DSYSTEM_EXPAT=${{matrix.expat}} -DBUILD_SHARED_LIBS=${{matrix.shared_libs}} ..
+      - name: Configure JSBSim (Ubuntu 16.04 LTS)
+        if: matrix.os == 'ubuntu-16.04'
+        run: |
+          mkdir build
+          cd build
+          cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON -DCMAKE_C_FLAGS_DEBUG="-g -O2" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2" -DCMAKE_BUILD_TYPE=Debug -DSYSTEM_EXPAT=${{matrix.expat}} -DBUILD_SHARED_LIBS=${{matrix.shared_libs}} -DBUILD_JULIA_PACKAGE=OFF ..
       - name: Build JSBSim
         working-directory: build
         run: make -j2

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -9,7 +9,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
         expat: [ON, OFF]
         shared_libs: [ON, OFF]
         exclude:

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -25,6 +25,7 @@ jobs:
             shared_libs: ON
     env:
       static_link: ${{ matrix.expat == 'OFF' && matrix.shared_libs == 'OFF' }}
+      skip_julia: ${{ matrix.os != 'ubuntu-18.04' }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Ubuntu packages
@@ -47,14 +48,14 @@ jobs:
           # Set GENERATE_HTML and HAVE_DOT to NO
           perl -i -pe 's/^(GENERATE_HTML\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
           perl -i -pe 's/^(HAVE_DOT\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
-      - name: Configure JSBSim
-        if: matrix.os != 'ubuntu-16.04'
+      - name: Configure JSBSim (with Julia)
+        if: ! env.skip_julia
         run: |
           mkdir build
           cd build
           cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON -DCMAKE_C_FLAGS_DEBUG="-g -O2" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2" -DCMAKE_BUILD_TYPE=Debug -DSYSTEM_EXPAT=${{matrix.expat}} -DBUILD_SHARED_LIBS=${{matrix.shared_libs}} ..
-      - name: Configure JSBSim (Ubuntu 16.04 LTS)
-        if: matrix.os == 'ubuntu-16.04'
+      - name: Configure JSBSim (without Julia)
+        if: env.skip_julia
         run: |
           mkdir build
           cd build
@@ -191,7 +192,8 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_INCLUDE_PATH="$(get-location)\..\cxxtest" ..
+          # Julia does not support MSVC
+          cmake -DCMAKE_INCLUDE_PATH="$(get-location)\..\cxxtest" -DBUILD_JULIA_PACKAGE=OFF ..
       - name: Build JSBSim
         working-directory: build
         run: cmake --build . --config RelWithDebInfo

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -48,18 +48,19 @@ jobs:
           # Set GENERATE_HTML and HAVE_DOT to NO
           perl -i -pe 's/^(GENERATE_HTML\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
           perl -i -pe 's/^(HAVE_DOT\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
-      - name: Configure JSBSim (with Julia)
-        if: ${{ !env.skip_julia }}
-        run: |
-          mkdir build
-          cd build
-          cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON -DCMAKE_C_FLAGS_DEBUG="-g -O2" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2" -DCMAKE_BUILD_TYPE=Debug -DSYSTEM_EXPAT=${{matrix.expat}} -DBUILD_SHARED_LIBS=${{matrix.shared_libs}} ..
       - name: Configure JSBSim (without Julia)
-        if: env.skip_julia
+        if: env.skip_julia == 'true'
+        id: WithoutJulia
         run: |
           mkdir build
           cd build
           cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON -DCMAKE_C_FLAGS_DEBUG="-g -O2" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2" -DCMAKE_BUILD_TYPE=Debug -DSYSTEM_EXPAT=${{matrix.expat}} -DBUILD_SHARED_LIBS=${{matrix.shared_libs}} -DBUILD_JULIA_PACKAGE=OFF ..
+      - name: Configure JSBSim (with Julia)
+        if: steps.WithoutJulia.outcome == 'skipped'
+        run: |
+          mkdir build
+          cd build
+          cmake -DCPACK_GENERATOR=DEB -DINSTALL_PYTHON_MODULE=ON -DCMAKE_C_FLAGS_DEBUG="-g -O2" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2" -DCMAKE_BUILD_TYPE=Debug -DSYSTEM_EXPAT=${{matrix.expat}} -DBUILD_SHARED_LIBS=${{matrix.shared_libs}} ..
       - name: Build JSBSim
         working-directory: build
         run: make -j2

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -49,7 +49,7 @@ jobs:
           perl -i -pe 's/^(GENERATE_HTML\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
           perl -i -pe 's/^(HAVE_DOT\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
       - name: Configure JSBSim (with Julia)
-        if: ! env.skip_julia
+        if: ${{ !env.skip_julia }}
         run: |
           mkdir build
           cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.8)
+cmake_minimum_required (VERSION 3.1)
 
 ################################################################################
 # Project description                                                          #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,16 @@ if (BUILD_PYTHON_MODULE)
 endif(BUILD_PYTHON_MODULE)
 
 ################################################################################
+# Build the Julia package                                                      #
+################################################################################
+
+option(BUILD_JULIA_MODULE "Set to ON to build the Julia package for JSBSim" ON)
+
+if(BUILD_JULIA_MODULE)
+  add_subdirectory(julia)
+endif(BUILD_JULIA_MODULE)
+
+################################################################################
 # Build the unit tests (needs CxxTest)                                         #
 ################################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,11 @@ endif(BUILD_PYTHON_MODULE)
 # Build the Julia package                                                      #
 ################################################################################
 
-option(BUILD_JULIA_MODULE "Set to ON to build the Julia package for JSBSim" ON)
+option(BUILD_JULIA_PACKAGE "Set to ON to build the Julia package for JSBSim" ON)
 
-if(BUILD_JULIA_MODULE)
+if(BUILD_JULIA_PACKAGE)
   add_subdirectory(julia)
-endif(BUILD_JULIA_MODULE)
+endif(BUILD_JULIA_PACKAGE)
 
 ################################################################################
 # Build the unit tests (needs CxxTest)                                         #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ endif(BUILD_PYTHON_MODULE)
 option(BUILD_JULIA_PACKAGE "Set to ON to build the Julia package for JSBSim" ON)
 
 if(BUILD_JULIA_PACKAGE)
+  enable_testing()
   add_subdirectory(julia)
 endif(BUILD_JULIA_PACKAGE)
 

--- a/julia/CMakeLists.txt
+++ b/julia/CMakeLists.txt
@@ -8,6 +8,8 @@ if (Julia_EXECUTABLE)
   find_package(JlCxx)
 
   include_directories(${CMAKE_SOURCE_DIR}/src)
+  set(CMAKE_CXX_STANDARD 14)
+
   add_library(JSBSimJL SHARED jsbsimjl.cpp)
   target_link_libraries(JSBSimJL libJSBSim JlCxx::cxxwrap_julia)
 

--- a/julia/CMakeLists.txt
+++ b/julia/CMakeLists.txt
@@ -1,0 +1,15 @@
+find_program(Julia_EXECUTABLE julia DOC "Julia executable")
+
+if (Julia_EXECUTABLE)
+  execute_process(COMMAND ${Julia_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/get_cxxwrap.jl)
+  execute_process(COMMAND ${Julia_EXECUTABLE} -e "using CxxWrap;print(CxxWrap.prefix_path())"
+                          OUTPUT_VARIABLE CXXWRAP_PREFIX_PATH)
+  set(JlCxx_DIR ${CXXWRAP_PREFIX_PATH}/lib/cmake/JlCxx)
+  find_package(JlCxx)
+
+  include_directories(${CMAKE_SOURCE_DIR}/src)
+  add_library(JSBSimJL SHARED jsbsimjl.cpp)
+  target_link_libraries(JSBSimJL libJSBSim JlCxx::cxxwrap_julia)
+
+  add_test(NAME TestJulia COMMAND ${Julia_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.jl)
+endif(Julia_EXECUTABLE)

--- a/julia/get_cxxwrap.jl
+++ b/julia/get_cxxwrap.jl
@@ -1,0 +1,6 @@
+# Make sure CxxWrap is installed
+try
+  using CxxWrap
+catch e
+  Pkg.add("CxxWrap")
+end

--- a/julia/get_cxxwrap.jl
+++ b/julia/get_cxxwrap.jl
@@ -1,4 +1,6 @@
 # Make sure CxxWrap is installed
+import Pkg
+
 try
   using CxxWrap
 catch e

--- a/julia/jsbsimjl.cpp
+++ b/julia/jsbsimjl.cpp
@@ -1,10 +1,40 @@
 #include <jlcxx/jlcxx.hpp>
 
-#include "simgear/misc/sg_path.hxx"
+#include "FGFDMExec.h"
+#include "initialization/FGInitialCondition.h"
+
+using namespace JSBSim;
 
 JLCXX_MODULE define_julia_module(jlcxx::Module& jsbsim)
 {
+  // SGPath
   jsbsim.add_type<SGPath>("SGPath")
     .constructor<const std::string&>()
     .method("str", &SGPath::str);
+
+  // FGPropertyManager
+  jsbsim.add_type<FGPropertyManager>("FGPropertyManager");
+
+  // FGFDMExec
+  auto FDMExec = jsbsim.add_type<FGFDMExec>("FGFDMExec");
+  FDMExec.constructor<FGPropertyManager*>()
+    .method("_SetRootDir", &FGFDMExec::SetRootDir)
+    .method("_GetRootDir", &FGFDMExec::GetRootDir)
+    .method("_SetAircraftPath", &FGFDMExec::SetAircraftPath)
+    .method("_SetEnginePath", &FGFDMExec::SetEnginePath)
+    .method("_SetSystemsPath", &FGFDMExec::SetSystemsPath)
+    // Resolves ambiguity between the overloaded methods FGFDMExec::LoadModel
+    // by static casting the pointer.
+    .method("_LoadModel", static_cast<bool (FGFDMExec::*)(const std::string&, bool)>(&FGFDMExec::LoadModel))
+    .method("RunIC", &FGFDMExec::RunIC)
+    .method("Run", &FGFDMExec::Run)
+    .method("GetPropertyValue", &FGFDMExec::GetPropertyValue);
+
+  // FGInitialCondition
+  jsbsim.add_type<FGInitialCondition>("FGInitialCondition")
+    .constructor<FGFDMExec*>()
+    .method("_Load", &FGInitialCondition::Load);
+
+  // FGFDMExec again (methods depending on other classes)
+  FDMExec.method("GetIC", &FGFDMExec::GetIC);
 }

--- a/julia/jsbsimjl.cpp
+++ b/julia/jsbsimjl.cpp
@@ -1,0 +1,10 @@
+#include <jlcxx/jlcxx.hpp>
+
+#include "simgear/misc/sg_path.hxx"
+
+JLCXX_MODULE define_julia_module(jlcxx::Module& jsbsim)
+{
+  jsbsim.add_type<SGPath>("SGPath")
+    .constructor<const std::string&>()
+    .method("str", &SGPath::str);
+}

--- a/julia/test.jl
+++ b/julia/test.jl
@@ -1,0 +1,9 @@
+using Test
+
+module JSBSim
+  using CxxWrap
+  @wrapmodule(joinpath(pwd(), "libJSBSimJL.so"))
+end
+
+path = JSBSim.SGPath("Hello world!")
+@test JSBSim.str(path) == "Hello world!"

--- a/julia/test.jl
+++ b/julia/test.jl
@@ -2,7 +2,7 @@ using Test
 
 module JSBSim
   using CxxWrap
-  @wrapmodule(joinpath(pwd(), "libJSBSimJL.so"))
+  @wrapmodule(joinpath(pwd(), "libJSBSimJL"))
 end
 
 path = JSBSim.SGPath("Hello world!")

--- a/julia/test.jl
+++ b/julia/test.jl
@@ -3,7 +3,50 @@ using Test
 module JSBSim
   using CxxWrap
   @wrapmodule(joinpath(pwd(), "libJSBSimJL"))
+  function SetRootDir(fdm::FGFDMExec, path::String)
+    _SetRootDir(fdm, SGPath(path))
+    SetAircraftPath(fdm, "aircraft")
+    SetEnginePath(fdm, "engine")
+    SetSystemsPath(fdm, "systems")
+  end
+  function GetRootDir(fdm::FGFDMExec)
+    str(_GetRootDir(fdm))
+  end
+  function SetAircraftPath(fdm::FGFDMExec, path::String)
+    _SetAircraftPath(fdm, SGPath(path))
+  end
+  function SetEnginePath(fdm::FGFDMExec, path::String)
+    _SetEnginePath(fdm, SGPath(path))
+  end
+  function SetSystemsPath(fdm::FGFDMExec, path::String)
+    _SetSystemsPath(fdm, SGPath(path))
+  end
+  function LoadModel(fdm::FGFDMExec, model::String, addModelToPath::Bool=true)
+    _LoadModel(fdm, model, addModelToPath)
+  end
+  function Load(ic::FGInitialCondition, path::String, useStoredPath::Bool)
+    _Load(ic, SGPath(path), useStoredPath)
+  end
+  function LoadIC(fdm::FGFDMExec, path::String, useStoredPath::Bool)
+    ic= GetIC(fdm)
+    Load(getindex(ic)[], path, useStoredPath)
+  end
 end
 
 path = JSBSim.SGPath("Hello world!")
 @test JSBSim.str(path) == "Hello world!"
+
+root_dir = joinpath(@__DIR__, "..")
+
+fdm = JSBSim.FGFDMExec()
+JSBSim.SetRootDir(fdm, root_dir)
+
+@test JSBSim.GetRootDir(fdm) == root_dir
+
+@test JSBSim.LoadModel(fdm, "737") == true
+@test JSBSim.LoadIC(fdm, "cruise_init.xml", true) == true
+@test JSBSim.RunIC(fdm) == true
+
+while JSBSim.GetPropertyValue(fdm, "simulation/sim-time-sec") < 5.0
+  JSBSim.Run(fdm)
+end

--- a/julia/test.jl
+++ b/julia/test.jl
@@ -2,7 +2,11 @@ using Test
 
 module JSBSim
   using CxxWrap
-  @wrapmodule(joinpath(pwd(), "libJSBSimJL"))
+  if Sys.islinux()
+    @wrapmodule(joinpath(pwd(), "libJSBSimJL.so"))
+  else
+    @wrapmodule(joinpath(pwd(), "libJSBSimJL"))
+  end
 end
 
 path = JSBSim.SGPath("Hello world!")

--- a/julia/test.jl
+++ b/julia/test.jl
@@ -3,14 +3,21 @@ using Test
 module JSBSim
   using CxxWrap
   @wrapmodule(joinpath(pwd(), "libJSBSimJL"))
+  function convert(::Type{String}, path::SGPath)
+    s = str(path)
+    if Sys.iswindows()
+      replace(s, "/" => "\\")
+    end
+    return s
+  end
   function SetRootDir(fdm::FGFDMExec, path::String)
     _SetRootDir(fdm, SGPath(path))
     SetAircraftPath(fdm, "aircraft")
     SetEnginePath(fdm, "engine")
     SetSystemsPath(fdm, "systems")
   end
-  function GetRootDir(fdm::FGFDMExec)
-    str(_GetRootDir(fdm))
+  function GetRootDir(fdm::FGFDMExec)::String
+    convert(String, _GetRootDir(fdm)[])
   end
   function SetAircraftPath(fdm::FGFDMExec, path::String)
     _SetAircraftPath(fdm, SGPath(path))
@@ -28,7 +35,7 @@ module JSBSim
     _Load(ic, SGPath(path), useStoredPath)
   end
   function LoadIC(fdm::FGFDMExec, path::String, useStoredPath::Bool)
-    ic= GetIC(fdm)
+    ic = GetIC(fdm)
     Load(getindex(ic)[], path, useStoredPath)
   end
 end

--- a/julia/test.jl
+++ b/julia/test.jl
@@ -6,7 +6,7 @@ module JSBSim
   function convert(::Type{String}, path::SGPath)
     s = str(path)
     if Sys.iswindows()
-      replace(s, "/" => "\\")
+      s = replace(s, "/" => "\\")
     end
     return s
   end

--- a/julia/test.jl
+++ b/julia/test.jl
@@ -2,11 +2,7 @@ using Test
 
 module JSBSim
   using CxxWrap
-  if Sys.islinux()
-    @wrapmodule(joinpath(pwd(), "libJSBSimJL.so"))
-  else
-    @wrapmodule(joinpath(pwd(), "libJSBSimJL"))
-  end
+  @wrapmodule(joinpath(pwd(), "libJSBSimJL"))
 end
 
 path = JSBSim.SGPath("Hello world!")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,13 +17,7 @@ if(MINGW)
   add_definitions(-D_WIN32_WINNT=0x600) # Windows Vista/Windows Server 2008
 endif()
 
-if (CMAKE_VERSION VERSION_LESS 3.1)
-  if (NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  endif()
-else()
-  set(CMAKE_CXX_STANDARD 14)
-endif()
+set(CMAKE_CXX_STANDARD 14)
 
 ################################################################################
 # Init the list of libraries that JSBSim links with                            #

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,12 +1,6 @@
 include_directories(${CXXTEST_INCLUDE_DIR})
 
-if (CMAKE_VERSION VERSION_LESS 3.1)
-  if (NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  endif()
-else()
-  set(CMAKE_CXX_STANDARD 14)
-endif()
+set(CMAKE_CXX_STANDARD 14)
 
 set(UNIT_TESTS FGColumnVector3Test
                StringUtilitiesTest

--- a/utils/aeromatic++/CMakeLists.txt
+++ b/utils/aeromatic++/CMakeLists.txt
@@ -1,17 +1,12 @@
-
-ENABLE_LANGUAGE(CXX)
-
-INCLUDE_DIRECTORIES(
-     "${CMAKE_CURRENT_SOURCE_DIR}"
-     "${CMAKE_CURRENT_BINARY_DIR}"
-   )
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+SET(CMAKE_CXX_STANDARD 11)
 
 SET(LIBAEROMATIC3 Aeromatic++)
 
-SET(AEROMATIC_HDRS 
+SET(AEROMATIC_HDRS
      types.h
      Aircraft.h
-	 config.h
+	   config.h
      Systems/Controls.h
      Systems/Propulsion.h
      Systems/Systems.h


### PR DESCRIPTION
As per the discussion #366 and issue #70, this PR adds a basic binding of JSBSim in the [Julia language](https://julialang.org).
Following this PR, it is possible to load a model and run it with Julia
```julia
import JSBSim

fdm = JSBSim.FGFDMExec()
JSBSim.SetRootDir(fdm, ".")

JSBSim.LoadModel(fdm, "737")
JSBSim.LoadIC(fdm, "cruise_init.xml", true)
JSBSim.RunIC(fdm)

while JSBSim.GetPropertyValue(fdm, "simulation/sim-time-sec") < 5.0
  JSBSim.Run(fdm)
end
```
More work to come to make generate proper Julia packages (aka JLL).