### PR TITLE
Add an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-an-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-an-issue.md
@@ -1,0 +1,38 @@
+---
+name: Report an issue
+about: Report a bug or request a new feature
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Note: for support questions, please use [Discussions](https://github.com/JSBSim-Team/jsbsim/discussions).**
+> **This repository issues are reserved for feature requests and bug reports**. Issues that are neither bug reports or feature requests will be transferred to [Discussions](https://github.com/JSBSim-Team/jsbsim/discussions) by the team **and the issue will be locked and closed.**
+
+***
+
+**I'm submitting a ...**
+  - [ ] bug report
+  - [ ] feature request
+  - [ ] support request => **Please do not submit support request here**, see note at the top of this template.
+
+**Describe the issue**
+A clear and concise description of what the issue is.
+
+**What is the current behavior?**
+Describe the current behavior including steps to reproduce it.
+If applicable, add screenshots to help explain your problem.
+
+**What is the expected behavior?**
+A clear and concise description of what you expected to happen.
+
+**What is the motivation / use case for changing the behavior?**
+
+**Please tell us about your environment:**
+- OS
+- JSBSim version
+- Language if applicable (C++, Python, Julia, ...)
+
+**Other information**
+(e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)

--- a/.github/ISSUE_TEMPLATE/report-an-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-an-issue.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Note: for support questions, please use [Discussions](https://github.com/JSBSim-Team/jsbsim/discussions).
 
-This repository issues are reserved for feature requests and bug reports. Issues that are neither bug reports or feature requests will be transferred to [Discussions](https://github.com/JSBSim-Team/jsbsim/discussions) by the team and the issue will be locked and closed.
+This repository's issues are reserved for feature requests and bug reports. Issues that are neither bug reports or feature requests will be transferred to [Discussions](https://github.com/JSBSim-Team/jsbsim/discussions) by the team and the issue will be locked and closed.
 
 ***
 <!-- please remove the notice above-->

--- a/.github/ISSUE_TEMPLATE/report-an-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-an-issue.md
@@ -7,10 +7,12 @@ assignees: ''
 
 ---
 
-**Note: for support questions, please use [Discussions](https://github.com/JSBSim-Team/jsbsim/discussions).**
-> **This repository issues are reserved for feature requests and bug reports**. Issues that are neither bug reports or feature requests will be transferred to [Discussions](https://github.com/JSBSim-Team/jsbsim/discussions) by the team **and the issue will be locked and closed.**
+Note: for support questions, please use [Discussions](https://github.com/JSBSim-Team/jsbsim/discussions).
+
+This repository issues are reserved for feature requests and bug reports. Issues that are neither bug reports or feature requests will be transferred to [Discussions](https://github.com/JSBSim-Team/jsbsim/discussions) by the team and the issue will be locked and closed.
 
 ***
+<!-- please remove the notice above-->
 
 **I'm submitting a ...**
   - [ ] bug report
@@ -18,21 +20,22 @@ assignees: ''
   - [ ] support request => **Please do not submit support request here**, see note at the top of this template.
 
 **Describe the issue**
-A clear and concise description of what the issue is.
+<!-- A clear and concise description of what the issue is. -->
 
 **What is the current behavior?**
-Describe the current behavior including steps to reproduce it.
-If applicable, add screenshots to help explain your problem.
+<!-- Describe the current behavior including steps to reproduce it.
+If applicable, add screenshots to help explain your problem. -->
 
 **What is the expected behavior?**
-A clear and concise description of what you expected to happen.
+<!--A clear and concise description of what you expected to happen. -->
 
 **What is the motivation / use case for changing the behavior?**
 
 **Please tell us about your environment:**
-- OS
-- JSBSim version
-- Language if applicable (C++, Python, Julia, ...)
+<!--
+ - OS
+ - JSBSim version
+ - Language if applicable (C++, Python, Julia, ...) -->
 
 **Other information**
-(e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)
+<!--(e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)-->


### PR DESCRIPTION
To give a clear notice that support requests should be discussed in Discussions and give guidance to the issuer about the information to supply.