### PR TITLE
Add propulsion/fuel_freeze property

### DIFF
--- a/src/models/FGPropulsion.cpp
+++ b/src/models/FGPropulsion.cpp
@@ -774,6 +774,7 @@ void FGPropulsion::SetFuelFreeze(bool f)
 void FGPropulsion::bind(void)
 {
   typedef int (FGPropulsion::*iPMF)(void) const;
+  typedef bool (FGPropulsion::*bPMF)(void) const;
   bool HavePistonEngine = false;
   bool HaveTurboEngine = false;
 
@@ -806,6 +807,7 @@ void FGPropulsion::bind(void)
   PropertyManager->Tie("propulsion/total-oxidizer-lbs", &TotalOxidizerQuantity);
   PropertyManager->Tie("propulsion/refuel", &refuel);
   PropertyManager->Tie("propulsion/fuel_dump", &dump);
+  PropertyManager->Tie("propulsion/fuel_freeze", this, (bPMF)nullptr, &FGPropulsion::SetFuelFreeze);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Add a binding for property `prpulsion/fuel_freeze` to bind to the existing `FGPropulsion::SetFuelFreeze(bool f)` method. This allows python clients and JSBSim scripts to set the state of `fuel freeze`.