### PR TITLE
Feature/more granular reset

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -691,7 +691,7 @@ void FGFDMExec::ResetToInitialConditions(int mode)
 {
   if (Constructing) return;
 
-  if (mode == 1) Output->SetStartNewOutput();
+  if (mode&0x1) Output->SetStartNewOutput();
 
   InitializeModels();
 
@@ -700,7 +700,8 @@ void FGFDMExec::ResetToInitialConditions(int mode)
   else
     Setsim_time(0.0);
 
-  RunIC();
+  if(!(mode & 0x2))
+     RunIC();
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -86,7 +86,6 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   IsChild = false;
   holding = false;
   Terminate = false;
-  ResetMode = 0;
   RandomSeed = 0;
   HoldDown = false;
 
@@ -424,13 +423,6 @@ bool FGFDMExec::Run(void)
   for (unsigned int i = 0; i < Models.size(); i++) {
     LoadInputs(i);
     Models[i]->Run(holding);
-  }
-
-  if (ResetMode) {
-    unsigned int mode = ResetMode;
-
-    ResetMode = 0;
-    ResetToInitialConditions(mode);
   }
 
   if (Terminate) success = false;

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -457,7 +457,9 @@ public:
   /** Resets the initial conditions object and prepares the simulation to run
       again. If mode is set to 1 the output instances will take special actions
       such as closing the current output file and open a new one with a
-      different name.
+      different name. If mode & 0x2 is non-zero the method will not perform
+      a RunIC() after reseting (which is useful if you want to manually RunIC()
+      later after reconfiguring other parameters).
       @param mode Sets the reset mode.*/
   void ResetToInitialConditions(int mode);
   /// Sets the debug level.

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -615,7 +615,6 @@ private:
 
   bool trim_status;
   int ta_mode;
-  unsigned int ResetMode;
   int trim_completed;
 
   std::shared_ptr<FGInitialCondition> IC;


### PR DESCRIPTION
Adds the option to ``ResetToInitialConditions`` to not run ``RunIC`` after resettings. This is useful if you want to reconfigure the model with new parameters.

See the discussion:
https://github.com/JSBSim-Team/jsbsim/discussions/455
for more detail.
