### PR TITLE
Remove old unused reset code

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -86,7 +86,6 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   IsChild = false;
   holding = false;
   Terminate = false;
-  ResetMode = 0;
   RandomSeed = 0;
   HoldDown = false;
 
@@ -424,13 +423,6 @@ bool FGFDMExec::Run(void)
   for (unsigned int i = 0; i < Models.size(); i++) {
     LoadInputs(i);
     Models[i]->Run(holding);
-  }
-
-  if (ResetMode) {
-    unsigned int mode = ResetMode;
-
-    ResetMode = 0;
-    ResetToInitialConditions(mode);
   }
 
   if (Terminate) success = false;

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -618,7 +618,6 @@ private:
 
   bool trim_status;
   int ta_mode;
-  unsigned int ResetMode;
   int trim_completed;
 
   std::shared_ptr<FGInitialCondition> IC;


### PR DESCRIPTION
As mentioned by @rjmccabe3701 the `ResetMode` variable and it's references are dead code. Looks like it used to be tied directly to `simulation/reset`.

```c++
instance->Tie("simulation/reset", (int*)&ResetMode);
```