### PR TITLE
Kinematic element wasn't connected to elevator position

### DIFF
--- a/aircraft/f15/f15.xml
+++ b/aircraft/f15/f15.xml
@@ -305,7 +305,7 @@
             </kinematic>
 
             <aerosurface_scale name="elevator position">
-                <input>fcs/pitch-trim-sum</input>
+                <input>fcs/elevator-pos-norm</input>
                 <gain>0.01745</gain>
                 <domain>
                     <min>-1</min>


### PR DESCRIPTION
While looking into the stable outputs when re-running initial conditions discussion I noticed that the kinematic element wasn't connected to the elevator output position - https://github.com/JSBSim-Team/jsbsim/discussions/455#discussioncomment-949813 Unlike the aileron and rudder cases. 