### PR TITLE
Update GeographicLib to version 1.52 to fix issue #475.

### DIFF
--- a/python/fpectl/fpectlmodule.cpp
+++ b/python/fpectl/fpectlmodule.cpp
@@ -141,7 +141,7 @@ static PyObject *turnon_sigfpe(PyObject *self, PyObject *args)
 {
 #ifdef _MSC_VER
   _clearfp();
-  fp_flags = _controlfp(_controlfp(0, 0) & ~(_EM_INVALID | _EM_ZERODIVIDE),
+  fp_flags = _controlfp(_controlfp(0, 0) & ~(_EM_INVALID | _EM_ZERODIVIDE | _EM_OVERFLOW),
                         _MCW_EM);
   handler = PyOS_setsig(SIGFPE, sigfpe_handler);
 #elif defined(__clang__)

--- a/python/fpectl/fpectlmodule.cpp
+++ b/python/fpectl/fpectlmodule.cpp
@@ -141,7 +141,7 @@ static PyObject *turnon_sigfpe(PyObject *self, PyObject *args)
 {
 #ifdef _MSC_VER
   _clearfp();
-  fp_flags = _controlfp(_controlfp(0, 0) & ~(_EM_INVALID | _EM_ZERODIVIDE | _EM_OVERFLOW),
+  fp_flags = _controlfp(_controlfp(0, 0) & ~(_EM_INVALID | _EM_ZERODIVIDE),
                         _MCW_EM);
   handler = PyOS_setsig(SIGFPE, sigfpe_handler);
 #elif defined(__clang__)

--- a/src/GeographicLib/Constants.hpp
+++ b/src/GeographicLib/Constants.hpp
@@ -2,7 +2,7 @@
  * \file Constants.hpp
  * \brief Header for GeographicLib::Constants class
  *
- * Copyright (c) Charles Karney (2008-2019) <charles@karney.com> and licensed
+ * Copyright (c) Charles Karney (2008-2020) <charles@karney.com> and licensed
  * under the MIT/X11 License.  For more information, see
  * https://geographiclib.sourceforge.io/
  **********************************************************************/
@@ -36,14 +36,6 @@
                            GEOGRAPHICLIB_VERSION_MINOR, \
                            GEOGRAPHICLIB_VERSION_PATCH)
 
-/**
- * @relates GeographicLib::Constants
- * Is the C++11 static_assert available?
- **********************************************************************/
-#if !defined(GEOGRAPHICLIB_HAS_STATIC_ASSERT)
-#  if __cplusplus >= 201103 || defined(__GXX_EXPERIMENTAL_CXX0X__)
-#    define GEOGRAPHICLIB_HAS_STATIC_ASSERT 1
-#  elif defined(_MSC_VER) && _MSC_VER >= 1600
 // For reference, here is a table of Visual Studio and _MSC_VER
 // correspondences:
 //
@@ -56,28 +48,10 @@
 //   1500     vc9   (2008)
 //   1600     vc10  (2010)
 //   1700     vc11  (2012)
-//   1800     vc12  (2013) First version of VS to include enough C++11 support
-//   1900     vc14  (2015)
+//   1800     vc12  (2013)
+//   1900     vc14  (2015) First version of VS to include enough C++11 support
 //   191[0-9] vc15  (2017)
 //   192[0-9] vc16  (2019)
-#    define GEOGRAPHICLIB_HAS_STATIC_ASSERT 1
-#  else
-#    define GEOGRAPHICLIB_HAS_STATIC_ASSERT 0
-#  endif
-#endif
-
-/**
- * @relates GeographicLib::Constants
- * A compile-time assert.  Use C++11 static_assert, if available.
- **********************************************************************/
-#if !defined(GEOGRAPHICLIB_STATIC_ASSERT)
-#  if GEOGRAPHICLIB_HAS_STATIC_ASSERT
-#    define GEOGRAPHICLIB_STATIC_ASSERT static_assert
-#  else
-#    define GEOGRAPHICLIB_STATIC_ASSERT(cond,reason) \
-            { enum{ GEOGRAPHICLIB_STATIC_ASSERT_ENUM = 1/int(cond) }; }
-#  endif
-#endif
 
 #if defined(_MSC_VER) && defined(GEOGRAPHICLIB_SHARED_LIB) && \
   GEOGRAPHICLIB_SHARED_LIB
@@ -157,69 +131,45 @@ namespace GeographicLib {
      * @tparam T the type of the returned value.
      * @return the equatorial radius of WGS84 ellipsoid (6378137 m).
      **********************************************************************/
-    template<typename T> static T WGS84_a()
+    template<typename T = real> static T WGS84_a()
     { return 6378137 * meter<T>(); }
-    /**
-     * A synonym for WGS84_a<real>().
-     **********************************************************************/
-    static Math::real WGS84_a() { return WGS84_a<real>(); }
     /**
      * @tparam T the type of the returned value.
      * @return the flattening of WGS84 ellipsoid (1/298.257223563).
      **********************************************************************/
-    template<typename T> static T WGS84_f() {
+    template<typename T = real> static T WGS84_f() {
       // Evaluating this as 1000000000 / T(298257223563LL) reduces the
       // round-off error by about 10%.  However, expressing the flattening as
       // 1/298.257223563 is well ingrained.
       return 1 / ( T(298257223563LL) / 1000000000 );
     }
     /**
-     * A synonym for WGS84_f<real>().
-     **********************************************************************/
-    static Math::real WGS84_f() { return WGS84_f<real>(); }
-    /**
      * @tparam T the type of the returned value.
      * @return the gravitational constant of the WGS84 ellipsoid, \e GM, in
      *   m<sup>3</sup> s<sup>&minus;2</sup>.
      **********************************************************************/
-    template<typename T> static T WGS84_GM()
+    template<typename T = real> static T WGS84_GM()
     { return T(3986004) * 100000000 + 41800000; }
-    /**
-     * A synonym for WGS84_GM<real>().
-     **********************************************************************/
-    static Math::real WGS84_GM() { return WGS84_GM<real>(); }
     /**
      * @tparam T the type of the returned value.
      * @return the angular velocity of the WGS84 ellipsoid, &omega;, in rad
      *   s<sup>&minus;1</sup>.
      **********************************************************************/
-    template<typename T> static T WGS84_omega()
+    template<typename T = real> static T WGS84_omega()
     { return 7292115 / (T(1000000) * 100000); }
-    /**
-     * A synonym for WGS84_omega<real>().
-     **********************************************************************/
-    static Math::real WGS84_omega() { return WGS84_omega<real>(); }
     /**
      * @tparam T the type of the returned value.
      * @return the equatorial radius of GRS80 ellipsoid, \e a, in m.
      **********************************************************************/
-    template<typename T> static T GRS80_a()
+    template<typename T = real> static T GRS80_a()
     { return 6378137 * meter<T>(); }
-    /**
-     * A synonym for GRS80_a<real>().
-     **********************************************************************/
-    static Math::real GRS80_a() { return GRS80_a<real>(); }
     /**
      * @tparam T the type of the returned value.
      * @return the gravitational constant of the GRS80 ellipsoid, \e GM, in
      *   m<sup>3</sup> s<sup>&minus;2</sup>.
      **********************************************************************/
-    template<typename T> static T GRS80_GM()
+    template<typename T = real> static T GRS80_GM()
     { return T(3986005) * 100000000; }
-    /**
-     * A synonym for GRS80_GM<real>().
-     **********************************************************************/
-    static Math::real GRS80_GM() { return GRS80_GM<real>(); }
     /**
      * @tparam T the type of the returned value.
      * @return the angular velocity of the GRS80 ellipsoid, &omega;, in rad
@@ -232,43 +182,27 @@ namespace GeographicLib {
      * approximation (because the Gregorian year includes the precession of the
      * earth's axis).
      **********************************************************************/
-    template<typename T> static T GRS80_omega()
+    template<typename T = real> static T GRS80_omega()
     { return 7292115 / (T(1000000) * 100000); }
-    /**
-     * A synonym for GRS80_omega<real>().
-     **********************************************************************/
-    static Math::real GRS80_omega() { return GRS80_omega<real>(); }
     /**
      * @tparam T the type of the returned value.
      * @return the dynamical form factor of the GRS80 ellipsoid,
      *   <i>J</i><sub>2</sub>.
      **********************************************************************/
-    template<typename T> static T GRS80_J2()
+    template<typename T = real> static T GRS80_J2()
     { return T(108263) / 100000000; }
-    /**
-     * A synonym for GRS80_J2<real>().
-     **********************************************************************/
-    static Math::real GRS80_J2() { return GRS80_J2<real>(); }
     /**
      * @tparam T the type of the returned value.
      * @return the central scale factor for UTM (0.9996).
      **********************************************************************/
-    template<typename T> static T UTM_k0()
+    template<typename T = real> static T UTM_k0()
     {return T(9996) / 10000; }
-    /**
-     * A synonym for UTM_k0<real>().
-     **********************************************************************/
-    static Math::real UTM_k0() { return UTM_k0<real>(); }
     /**
      * @tparam T the type of the returned value.
      * @return the central scale factor for UPS (0.994).
      **********************************************************************/
-    template<typename T> static T UPS_k0()
+    template<typename T = real> static T UPS_k0()
     { return T(994) / 1000; }
-    /**
-     * A synonym for UPS_k0<real>().
-     **********************************************************************/
-    static Math::real UPS_k0() { return UPS_k0<real>(); }
     ///@}
 
     /** \name SI units
@@ -281,11 +215,7 @@ namespace GeographicLib {
      * This is unity, but this lets the internal system of units be changed if
      * necessary.
      **********************************************************************/
-    template<typename T> static T meter() { return T(1); }
-    /**
-     * A synonym for meter<real>().
-     **********************************************************************/
-    static Math::real meter() { return meter<real>(); }
+    template<typename T = real> static T meter() { return T(1); }
     /**
      * @return the number of meters in a kilometer.
      **********************************************************************/
@@ -305,13 +235,8 @@ namespace GeographicLib {
      * This is unity, but this lets the internal system of units be changed if
      * necessary.
      **********************************************************************/
-    template<typename T> static T square_meter()
-    { return meter<real>() * meter<real>(); }
-    /**
-     * A synonym for square_meter<real>().
-     **********************************************************************/
-    static Math::real square_meter()
-    { return square_meter<real>(); }
+    template<typename T = real> static T square_meter()
+    { return meter<T>() * meter<T>(); }
     /**
      * @return the number of square meters in a hectare.
      **********************************************************************/

--- a/src/GeographicLib/Geodesic.cpp
+++ b/src/GeographicLib/Geodesic.cpp
@@ -2,7 +2,7 @@
  * \file Geodesic.cpp
  * \brief Implementation for GeographicLib::Geodesic class
  *
- * Copyright (c) Charles Karney (2009-2019) <charles@karney.com> and licensed
+ * Copyright (c) Charles Karney (2009-2021) <charles@karney.com> and licensed
  * under the MIT/X11 License.  For more information, see
  * https://geographiclib.sourceforge.io/
  *
@@ -77,9 +77,9 @@ namespace GeographicLib {
     , _etol2(real(0.1) * tol2_ /
              sqrt( max(real(0.001), abs(_f)) * min(real(1), 1 - _f/2) / 2 ))
   {
-    if (!(Math::isfinite(_a) && _a > 0))
+    if (!(isfinite(_a) && _a > 0))
       throw GeographicErr("Equatorial radius is not positive");
-    if (!(Math::isfinite(_b) && _b > 0))
+    if (!(isfinite(_b) && _b > 0))
       throw GeographicErr("Polar semi-axis is not positive");
     A3coeff();
     C3coeff();
@@ -272,9 +272,16 @@ namespace GeographicLib {
       //
       // In fact, we will have sig12 > pi/2 for meridional geodesic which is
       // not a shortest path.
+      // TODO: investigate m12 < 0 result for aarch/ppc (with -f -p 20)
+      // 20.001000000000001 0.000000000000000 180.000000000000000
+      // 20.001000000000001 0.000000000000000 180.000000000000000
+      // 0.0000000002 0.000000000000001 -0.0000000001
+      // 0.99999999999999989 0.99999999999999989 0.000
       if (sig12 < 1 || m12x >= 0) {
         // Need at least 2, to handle 90 0 90 180
-        if (sig12 < 3 * tiny_)
+        if (sig12 < 3 * tiny_ ||
+            // Prevent negative s12 or m12 for short lines
+            (sig12 < tol0_ && (s12x < 0 || m12x < 0)))
           sig12 = m12x = s12x = 0;
         m12x *= _b;
         s12x *= _b;
@@ -418,7 +425,7 @@ namespace GeographicLib {
       real
         // From Lambda12: sin(alp1) * cos(bet1) = sin(alp0)
         salp0 = salp1 * cbet1,
-        calp0 = Math::hypot(calp1, salp1 * sbet1); // calp0 > 0
+        calp0 = hypot(calp1, salp1 * sbet1); // calp0 > 0
       real alp12;
       if (calp0 != 0 && salp0 != 0) {
         real
@@ -610,7 +617,7 @@ namespace GeographicLib {
         // of the way the T is used in definition of u.
         T3 += T3 < 0 ? -sqrt(disc) : sqrt(disc); // T3 = (r * t)^3
         // N.B. cbrt always returns the real root.  cbrt(-8) = -2.
-        real T = Math::cbrt(T3); // T = r * t
+        real T = cbrt(T3); // T = r * t
         // T can be zero; but then r2 / T -> 0.
         u += T + (T != 0 ? r2 / T : 0);
       } else {
@@ -676,7 +683,7 @@ namespace GeographicLib {
       sbet12a - cbet2 * sbet1 * Math::sq(somg12) / (1 - comg12);
 
     real
-      ssig12 = Math::hypot(salp1, calp1),
+      ssig12 = hypot(salp1, calp1),
       csig12 = sbet1 * sbet2 + cbet1 * cbet2 * comg12;
 
     if (shortline && ssig12 < _etol2) {
@@ -814,7 +821,7 @@ namespace GeographicLib {
     real
       // sin(alp1) * cos(bet1) = sin(alp0)
       salp0 = salp1 * cbet1,
-      calp0 = Math::hypot(calp1, salp1 * sbet1); // calp0 > 0
+      calp0 = hypot(calp1, salp1 * sbet1); // calp0 > 0
 
     real somg1, comg1, somg2, comg2, somg12, comg12, lam12;
     // tan(bet1) = tan(sig1) * cos(alp1)
@@ -962,8 +969,8 @@ namespace GeographicLib {
 #else
 #error "Bad value for GEOGRAPHICLIB_GEODESIC_ORDER"
 #endif
-    GEOGRAPHICLIB_STATIC_ASSERT(sizeof(coeff) / sizeof(real) == nA1_/2 + 2,
-                                "Coefficient array size mismatch in A1m1f");
+    static_assert(sizeof(coeff) / sizeof(real) == nA1_/2 + 2,
+                  "Coefficient array size mismatch in A1m1f");
     int m = nA1_/2;
     real t = Math::polyval(m, coeff, Math::sq(eps)) / coeff[m + 1];
     return (t + eps) / (1 - eps);
@@ -1059,9 +1066,9 @@ namespace GeographicLib {
 #else
 #error "Bad value for GEOGRAPHICLIB_GEODESIC_ORDER"
 #endif
-    GEOGRAPHICLIB_STATIC_ASSERT(sizeof(coeff) / sizeof(real) ==
-                                (nC1_*nC1_ + 7*nC1_ - 2*(nC1_/2)) / 4,
-                                "Coefficient array size mismatch in C1f");
+    static_assert(sizeof(coeff) / sizeof(real) ==
+                  (nC1_*nC1_ + 7*nC1_ - 2*(nC1_/2)) / 4,
+                  "Coefficient array size mismatch in C1f");
     real
       eps2 = Math::sq(eps),
       d = eps;
@@ -1165,9 +1172,9 @@ namespace GeographicLib {
 #else
 #error "Bad value for GEOGRAPHICLIB_GEODESIC_ORDER"
 #endif
-    GEOGRAPHICLIB_STATIC_ASSERT(sizeof(coeff) / sizeof(real) ==
-                                (nC1p_*nC1p_ + 7*nC1p_ - 2*(nC1p_/2)) / 4,
-                                "Coefficient array size mismatch in C1pf");
+    static_assert(sizeof(coeff) / sizeof(real) ==
+                  (nC1p_*nC1p_ + 7*nC1p_ - 2*(nC1p_/2)) / 4,
+                  "Coefficient array size mismatch in C1pf");
     real
       eps2 = Math::sq(eps),
       d = eps;
@@ -1207,8 +1214,8 @@ namespace GeographicLib {
 #else
 #error "Bad value for GEOGRAPHICLIB_GEODESIC_ORDER"
 #endif
-    GEOGRAPHICLIB_STATIC_ASSERT(sizeof(coeff) / sizeof(real) == nA2_/2 + 2,
-                                "Coefficient array size mismatch in A2m1f");
+    static_assert(sizeof(coeff) / sizeof(real) == nA2_/2 + 2,
+                  "Coefficient array size mismatch in A2m1f");
     int m = nA2_/2;
     real t = Math::polyval(m, coeff, Math::sq(eps)) / coeff[m + 1];
     return (t - eps) / (1 + eps);
@@ -1304,9 +1311,9 @@ namespace GeographicLib {
 #else
 #error "Bad value for GEOGRAPHICLIB_GEODESIC_ORDER"
 #endif
-    GEOGRAPHICLIB_STATIC_ASSERT(sizeof(coeff) / sizeof(real) ==
-                                (nC2_*nC2_ + 7*nC2_ - 2*(nC2_/2)) / 4,
-                                "Coefficient array size mismatch in C2f");
+    static_assert(sizeof(coeff) / sizeof(real) ==
+                  (nC2_*nC2_ + 7*nC2_ - 2*(nC2_/2)) / 4,
+                  "Coefficient array size mismatch in C2f");
     real
       eps2 = Math::sq(eps),
       d = eps;
@@ -1410,9 +1417,9 @@ namespace GeographicLib {
 #else
 #error "Bad value for GEOGRAPHICLIB_GEODESIC_ORDER"
 #endif
-    GEOGRAPHICLIB_STATIC_ASSERT(sizeof(coeff) / sizeof(real) ==
-                                (nA3_*nA3_ + 7*nA3_ - 2*(nA3_/2)) / 4,
-                                "Coefficient array size mismatch in A3f");
+    static_assert(sizeof(coeff) / sizeof(real) ==
+                  (nA3_*nA3_ + 7*nA3_ - 2*(nA3_/2)) / 4,
+                  "Coefficient array size mismatch in A3f");
     int o = 0, k = 0;
     for (int j = nA3_ - 1; j >= 0; --j) { // coeff of eps^j
       int m = min(nA3_ - j - 1, j);       // order of polynomial in n
@@ -1614,9 +1621,9 @@ namespace GeographicLib {
 #else
 #error "Bad value for GEOGRAPHICLIB_GEODESIC_ORDER"
 #endif
-    GEOGRAPHICLIB_STATIC_ASSERT(sizeof(coeff) / sizeof(real) ==
-                                ((nC3_-1)*(nC3_*nC3_ + 7*nC3_ - 2*(nC3_/2)))/8,
-                                "Coefficient array size mismatch in C3coeff");
+    static_assert(sizeof(coeff) / sizeof(real) ==
+                  ((nC3_-1)*(nC3_*nC3_ + 7*nC3_ - 2*(nC3_/2)))/8,
+                  "Coefficient array size mismatch in C3coeff");
     int o = 0, k = 0;
     for (int l = 1; l < nC3_; ++l) {        // l is index of C3[l]
       for (int j = nC3_ - 1; j >= l; --j) { // coeff of eps^j
@@ -1883,9 +1890,9 @@ namespace GeographicLib {
 #else
 #error "Bad value for GEOGRAPHICLIB_GEODESIC_ORDER"
 #endif
-    GEOGRAPHICLIB_STATIC_ASSERT(sizeof(coeff) / sizeof(real) ==
-                                (nC4_ * (nC4_ + 1) * (nC4_ + 5)) / 6,
-                                "Coefficient array size mismatch in C4coeff");
+    static_assert(sizeof(coeff) / sizeof(real) ==
+                  (nC4_ * (nC4_ + 1) * (nC4_ + 5)) / 6,
+                  "Coefficient array size mismatch in C4coeff");
     int o = 0, k = 0;
     for (int l = 0; l < nC4_; ++l) {        // l is index of C4[l]
       for (int j = nC4_ - 1; j >= l; --j) { // coeff of eps^j

--- a/src/GeographicLib/Geodesic.hpp
+++ b/src/GeographicLib/Geodesic.hpp
@@ -2,7 +2,7 @@
  * \file Geodesic.hpp
  * \brief Header for GeographicLib::Geodesic class
  *
- * Copyright (c) Charles Karney (2009-2019) <charles@karney.com> and licensed
+ * Copyright (c) Charles Karney (2009-2020) <charles@karney.com> and licensed
  * under the MIT/X11 License.  For more information, see
  * https://geographiclib.sourceforge.io/
  **********************************************************************/
@@ -958,9 +958,9 @@ namespace GeographicLib {
     { return 4 * Math::pi() * _c2; }
 
     /**
-      * \deprecated An old name for EquatorialRadius().
-      **********************************************************************/
-    // GEOGRAPHICLIB_DEPRECATED("Use EquatorialRadius()")
+     * \deprecated An old name for EquatorialRadius().
+     **********************************************************************/
+    GEOGRAPHICLIB_DEPRECATED("Use EquatorialRadius()")
     Math::real MajorRadius() const { return EquatorialRadius(); }
     ///@}
 

--- a/src/GeographicLib/GeodesicLine.cpp
+++ b/src/GeographicLib/GeodesicLine.cpp
@@ -2,7 +2,7 @@
  * \file GeodesicLine.cpp
  * \brief Implementation for GeographicLib::GeodesicLine class
  *
- * Copyright (c) Charles Karney (2009-2016) <charles@karney.com> and licensed
+ * Copyright (c) Charles Karney (2009-2020) <charles@karney.com> and licensed
  * under the MIT/X11 License.  For more information, see
  * https://geographiclib.sourceforge.io/
  *
@@ -60,7 +60,7 @@ namespace GeographicLib {
     _salp0 = _salp1 * cbet1; // alp0 in [0, pi/2 - |bet1|]
     // Alt: calp0 = hypot(sbet1, calp1 * cbet1).  The following
     // is slightly better (consider the case salp1 = 0).
-    _calp0 = Math::hypot(_calp1, _salp1 * sbet1);
+    _calp0 = hypot(_calp1, _salp1 * sbet1);
     // Evaluate sig with tan(bet1) = tan(sig1) * cos(alp1).
     // sig = 0 is nearest northward crossing of equator.
     // With bet1 = 0, alp1 = pi/2, we have sig1 = 0 (equatorial line).
@@ -210,7 +210,7 @@ namespace GeographicLib {
     // sin(bet2) = cos(alp0) * sin(sig2)
     sbet2 = _calp0 * ssig2;
     // Alt: cbet2 = hypot(csig2, salp0 * ssig2);
-    cbet2 = Math::hypot(_salp0, _calp0 * csig2);
+    cbet2 = hypot(_salp0, _calp0 * csig2);
     if (cbet2 == 0)
       // I.e., salp0 = 0, csig2 = 0.  Break the degeneracy in this case
       cbet2 = csig2 = tiny_;
@@ -223,7 +223,7 @@ namespace GeographicLib {
     if (outmask & LONGITUDE) {
       // tan(omg2) = sin(alp0) * tan(sig2)
       real somg2 = _salp0 * ssig2, comg2 = csig2,  // No need to normalize
-        E = Math::copysign(real(1), _salp0);       // east-going?
+        E = copysign(real(1), _salp0);       // east-going?
       // omg12 = omg2 - omg1
       real omg12 = outmask & LONG_UNROLL
         ? E * (sig12

--- a/src/GeographicLib/GeodesicLine.hpp
+++ b/src/GeographicLib/GeodesicLine.hpp
@@ -2,7 +2,7 @@
  * \file GeodesicLine.hpp
  * \brief Header for GeographicLib::GeodesicLine class
  *
- * Copyright (c) Charles Karney (2009-2019) <charles@karney.com> and licensed
+ * Copyright (c) Charles Karney (2009-2020) <charles@karney.com> and licensed
  * under the MIT/X11 License.  For more information, see
  * https://geographiclib.sourceforge.io/
  **********************************************************************/
@@ -695,9 +695,9 @@ namespace GeographicLib {
     Math::real Arc() const { return GenDistance(true); }
 
     /**
-      * \deprecated An old name for EquatorialRadius().
-      **********************************************************************/
-    // GEOGRAPHICLIB_DEPRECATED("Use EquatorialRadius()")
+     * \deprecated An old name for EquatorialRadius().
+     **********************************************************************/
+    GEOGRAPHICLIB_DEPRECATED("Use EquatorialRadius()")
     Math::real MajorRadius() const { return EquatorialRadius(); }
     ///@}
 

--- a/src/GeographicLib/Math.cpp
+++ b/src/GeographicLib/Math.cpp
@@ -2,7 +2,7 @@
  * \file Math.cpp
  * \brief Implementation for GeographicLib::Math class
  *
- * Copyright (c) Charles Karney (2015-2019) <charles@karney.com> and licensed
+ * Copyright (c) Charles Karney (2015-2021) <charles@karney.com> and licensed
  * under the MIT/X11 License.  For more information, see
  * https://geographiclib.sourceforge.io/
  **********************************************************************/
@@ -19,16 +19,15 @@ namespace GeographicLib {
   using namespace std;
 
   void Math::dummy() {
-    GEOGRAPHICLIB_STATIC_ASSERT(GEOGRAPHICLIB_PRECISION >= 1 &&
-                                GEOGRAPHICLIB_PRECISION <= 5,
-                                "Bad value of precision");
+    static_assert(GEOGRAPHICLIB_PRECISION >= 1 && GEOGRAPHICLIB_PRECISION <= 5,
+                  "Bad value of precision");
   }
 
   int Math::digits() {
 #if GEOGRAPHICLIB_PRECISION != 5
-    return std::numeric_limits<real>::digits;
+    return numeric_limits<real>::digits;
 #else
-    return std::numeric_limits<real>::digits();
+    return numeric_limits<real>::digits();
 #endif
   }
 
@@ -43,187 +42,64 @@ namespace GeographicLib {
 
   int Math::digits10() {
 #if GEOGRAPHICLIB_PRECISION != 5
-    return std::numeric_limits<real>::digits10;
+    return numeric_limits<real>::digits10;
 #else
-    return std::numeric_limits<real>::digits10();
+    return numeric_limits<real>::digits10();
 #endif
   }
 
   int Math::extra_digits() {
     return
-      digits10() > std::numeric_limits<double>::digits10 ?
-      digits10() - std::numeric_limits<double>::digits10 : 0;
+      digits10() > numeric_limits<double>::digits10 ?
+      digits10() - numeric_limits<double>::digits10 : 0;
   }
 
   template<typename T> T Math::hypot(T x, T y) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::hypot; return hypot(x, y);
-#else
-    x = abs(x); y = abs(y);
-    if (x < y) std::swap(x, y); // Now x >= y >= 0
-    y /= (x != 0 ? x : 1);
-    return x * sqrt(1 + y * y);
-    // For an alternative (square-root free) method see
-    // C. Moler and D. Morrision (1983) https://doi.org/10.1147/rd.276.0577
-    // and A. A. Dubrulle (1983) https://doi.org/10.1147/rd.276.0582
-#endif
   }
 
   template<typename T> T Math::expm1(T x) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::expm1; return expm1(x);
-#else
-    GEOGRAPHICLIB_VOLATILE T
-      y = exp(x),
-      z = y - 1;
-    // The reasoning here is similar to that for log1p.  The expression
-    // mathematically reduces to exp(x) - 1, and the factor z/log(y) = (y -
-    // 1)/log(y) is a slowly varying quantity near y = 1 and is accurately
-    // computed.
-    return abs(x) > 1 ? z : (z == 0 ? x : x * z / log(y));
-#endif
   }
 
   template<typename T> T Math::log1p(T x) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::log1p; return log1p(x);
-#else
-    GEOGRAPHICLIB_VOLATILE T
-      y = 1 + x,
-      z = y - 1;
-    // Here's the explanation for this magic: y = 1 + z, exactly, and z
-    // approx x, thus log(y)/z (which is nearly constant near z = 0) returns
-    // a good approximation to the true log(1 + x)/x.  The multiplication x *
-    // (log(y)/z) introduces little additional error.
-    return z == 0 ? x : x * log(y) / z;
-#endif
   }
 
   template<typename T> T Math::asinh(T x) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::asinh; return asinh(x);
-#else
-    T y = abs(x); // Enforce odd parity
-    y = log1p(y * (1 + y/(hypot(T(1), y) + 1)));
-    return x > 0 ? y : (x < 0 ? -y : x); // asinh(-0.0) = -0.0
-#endif
   }
 
   template<typename T> T Math::atanh(T x) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::atanh; return atanh(x);
-#else
-    T y = abs(x); // Enforce odd parity
-    y = log1p(2 * y/(1 - y))/2;
-    return x > 0 ? y : (x < 0 ? -y : x); // atanh(-0.0) = -0.0
-#endif
   }
 
   template<typename T> T Math::copysign(T x, T y) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::copysign; return copysign(x, y);
-#else
-    // NaN counts as positive
-    return abs(x) * (y < 0 || (y == 0 && 1/y < 0) ? -1 : 1);
-#endif
   }
 
   template<typename T> T Math::cbrt(T x) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::cbrt; return cbrt(x);
-#else
-    T y = pow(abs(x), 1/T(3)); // Return the real cube root
-    return x > 0 ? y : (x < 0 ? -y : x); // cbrt(-0.0) = -0.0
-#endif
   }
 
   template<typename T> T Math::remainder(T x, T y) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::remainder; return remainder(x, y);
-#else
-    y = abs(y);               // The result doesn't depend on the sign of y
-    T z = fmod(x, y);
-    if (z == 0)
-      // This shouldn't be necessary.  However, before version 14 (2015),
-      // Visual Studio had problems dealing with -0.0.  Specifically
-      //   VC 10,11,12 and 32-bit compile: fmod(-0.0, 360.0) -> +0.0
-      // python 2.7 on Windows 32-bit machines has the same problem.
-      z = copysign(z, x);
-    else if (2 * abs(z) == y)
-      z -= fmod(x, 2 * y) - z; // Implement ties to even
-    else if (2 * abs(z) > y)
-      z += (z < 0 ? y : -y);  // Fold remaining cases to (-y/2, y/2)
-    return z;
-#endif
   }
 
   template<typename T> T Math::remquo(T x, T y, int* n) {
-    // boost::math::remquo doesn't handle nans correctly
-#if GEOGRAPHICLIB_CXX11_MATH && GEOGRAPHICLIB_PRECISION <= 3
     using std::remquo; return remquo(x, y, n);
-#else
-    T z = remainder(x, y);
-    if (n) {
-      T
-        a = remainder(x, 2 * y),
-        b = remainder(x, 4 * y),
-        c = remainder(x, 8 * y);
-      *n  = (a > z ? 1 : (a < z ? -1 : 0));
-      *n += (b > a ? 2 : (b < a ? -2 : 0));
-      *n += (c > b ? 4 : (c < b ? -4 : 0));
-      if (y < 0) *n *= -1;
-      if (y != 0) {
-        if (x/y > 0 && *n <= 0)
-          *n += 8;
-        else if (x/y < 0 && *n >= 0)
-          *n -= 8;
-      }
-    }
-    return z;
-#endif
   }
 
   template<typename T> T Math::round(T x) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::round; return round(x);
-#else
-    // The handling of corner cases is copied from boost; see
-    //   https://github.com/boostorg/math/pull/8
-    // with improvements to return -0 when appropriate.
-    if      (0 < x && x <  T(0.5))
-      return +T(0);
-    else if (0 > x && x > -T(0.5))
-      return -T(0);
-    else if   (x > 0) {
-      T t = ceil(x);
-      return t - x > T(0.5) ? t - 1 : t;
-    } else if (x < 0) {
-      T t = floor(x);
-      return x - t > T(0.5) ? t + 1 : t;
-    } else                    // +/-0 and NaN
-      return x;               // Retain sign of 0
-#endif
   }
 
   template<typename T> long Math::lround(T x) {
-#if GEOGRAPHICLIB_CXX11_MATH && GEOGRAPHICLIB_PRECISION != 5
     using std::lround; return lround(x);
-#else
-    // Default value for overflow + NaN + (x == LONG_MIN)
-    long r = std::numeric_limits<long>::min();
-    x = round(x);
-    if (abs(x) < -T(r))       // Assume T(LONG_MIN) is exact
-      r = long(x);
-    return r;
-#endif
   }
 
   template<typename T> T Math::fma(T x, T y, T z) {
-#if GEOGRAPHICLIB_CXX11_MATH
     using std::fma; return fma(x, y, z);
-#else
-    return x * y + z;
-#endif
   }
 
   template<typename T> T Math::sum(T u, T v, T& t) {
@@ -250,7 +126,8 @@ namespace GeographicLib {
   template<typename T> void Math::sincosd(T x, T& sinx, T& cosx) {
     // In order to minimize round-off errors, this function exactly reduces
     // the argument to the range [-45, 45] before converting it to radians.
-    T r; int q;
+    using std::remquo;
+    T r; int q = 0;
     // N.B. the implementation of remquo in glibc pre 2.22 were buggy.  See
     // https://sourceware.org/bugzilla/show_bug.cgi?id=17569
     // This was fixed in version 2.22 on 2015-08-05
@@ -258,15 +135,6 @@ namespace GeographicLib {
     r *= degree<T>();
     // g++ -O turns these two function calls into a call to sincos
     T s = sin(r), c = cos(r);
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    // Before version 14 (2015), Visual Studio had problems dealing
-    // with -0.0.  Specifically
-    //   VC 10,11,12 and 32-bit compile: fmod(-0.0, 360.0) -> +0.0
-    //   VC 12       and 64-bit compile:  sin(-0.0)        -> +0.0
-    // AngNormalize has a similar fix.
-    // python 2.7 on Windows 32-bit machines has the same problem.
-    if (x == 0) s = x;
-#endif
     switch (unsigned(q) & 3U) {
     case 0U: sinx =  s; cosx =  c; break;
     case 1U: sinx =  c; cosx = -s; break;
@@ -279,7 +147,8 @@ namespace GeographicLib {
 
   template<typename T> T Math::sind(T x) {
     // See sincosd
-    T r; int q;
+    using std::remquo;
+    T r; int q = 0;
     r = remquo(x, T(90), &q); // now abs(r) <= 45
     r *= degree<T>();
     unsigned p = unsigned(q);
@@ -291,7 +160,8 @@ namespace GeographicLib {
 
   template<typename T> T Math::cosd(T x) {
     // See sincosd
-    T r; int q;
+    using std::remquo;
+    T r; int q = 0;
     r = remquo(x, T(90), &q); // now abs(r) <= 45
     r *= degree<T>();
     unsigned p = unsigned(q + 1);
@@ -301,7 +171,7 @@ namespace GeographicLib {
   }
 
   template<typename T> T Math::tand(T x) {
-    static const T overflow = 1 / sq(std::numeric_limits<T>::epsilon());
+    static const T overflow = 1 / sq(numeric_limits<T>::epsilon());
     T s, c;
     sincosd(x, s, c);
     return c != 0 ? s / c : (s < 0 ? -overflow : overflow);
@@ -313,7 +183,7 @@ namespace GeographicLib {
     // converting it to degrees and mapping the result to the correct
     // quadrant.
     int q = 0;
-    if (abs(y) > abs(x)) { std::swap(x, y); q = 2; }
+    if (abs(y) > abs(x)) { swap(x, y); q = 2; }
     if (x < 0) { x = -x; ++q; }
     // here x >= 0 and x >= abs(y), so angle is in [-pi/4, pi/4]
     T ang = atan2(y, x) / degree<T>();
@@ -327,6 +197,7 @@ namespace GeographicLib {
     case 1: ang = (y >= 0 ? 180 : -180) - ang; break;
     case 2: ang =  90 - ang; break;
     case 3: ang = -90 + ang; break;
+    default: break;
     }
     return ang;
   }
@@ -335,29 +206,42 @@ namespace GeographicLib {
   { return atan2d(x, T(1)); }
 
   template<typename T> T Math::eatanhe(T x, T es)  {
+    using std::atanh;
     return es > T(0) ? es * atanh(es * x) : -es * atan(es * x);
   }
 
   template<typename T> T Math::taupf(T tau, T es) {
-    T tau1 = hypot(T(1), tau),
-      sig = sinh( eatanhe(tau / tau1, es ) );
-    return hypot(T(1), sig) * tau - sig * tau1;
+    // Need this test, otherwise tau = +/-inf gives taup = nan.
+    using std::isfinite; using std::hypot;
+    if (isfinite(tau)) {
+      T tau1 = hypot(T(1), tau),
+        sig = sinh( eatanhe(tau / tau1, es ) );
+      return hypot(T(1), sig) * tau - sig * tau1;
+    } else
+      return tau;
   }
 
   template<typename T> T Math::tauf(T taup, T es) {
-    const int numit = 5;
-    const T tol = sqrt(numeric_limits<T>::epsilon()) / T(10);
+    using std::hypot;
+    static const int numit = 5;
+    // min iterations = 1, max iterations = 2; mean = 1.95
+    static const T tol = sqrt(numeric_limits<T>::epsilon()) / 10;
+    static const T taumax = 2 / sqrt(numeric_limits<T>::epsilon());
     T e2m = T(1) - sq(es),
       // To lowest order in e^2, taup = (1 - e^2) * tau = _e2m * tau; so use
-      // tau = taup/_e2m as a starting guess.  (This starting guess is the
-      // geocentric latitude which, to first order in the flattening, is equal
-      // to the conformal latitude.)  Only 1 iteration is needed for |lat| <
-      // 3.35 deg, otherwise 2 iterations are needed.  If, instead, tau = taup
-      // is used the mean number of iterations increases to 1.99 (2 iterations
-      // are needed except near tau = 0).
-      tau = taup/e2m,
+      // tau = taup/e2m as a starting guess. Only 1 iteration is needed for
+      // |lat| < 3.35 deg, otherwise 2 iterations are needed.  If, instead, tau
+      // = taup is used the mean number of iterations increases to 1.999 (2
+      // iterations are needed except near tau = 0).
+      //
+      // For large tau, taup = exp(-es*atanh(es)) * tau.  Use this as for the
+      // initial guess for |taup| > 70 (approx |phi| > 89deg).  Then for
+      // sufficiently large tau (such that sqrt(1+tau^2) = |tau|), we can exit
+      // with the intial guess and avoid overflow problems.  This also reduces
+      // the mean number of iterations slightly from 1.963 to 1.954.
+      tau = abs(taup) > 70 ? taup * exp(eatanhe(T(1), es)) : taup/e2m,
       stol = tol * max(T(1), abs(taup));
-    // min iterations = 1, max iterations = 2; mean = 1.94
+    if (!(abs(tau) < taumax)) return tau; // handles +/-inf and nan
     for (int i = 0; i < numit || GEOGRAPHICLIB_PANIC; ++i) {
       T taupa = taupf(tau, es),
         dtau = (taup - taupa) * (1 + e2m * sq(tau)) /
@@ -370,51 +254,34 @@ namespace GeographicLib {
   }
 
     template<typename T> bool Math::isfinite(T x) {
-#if GEOGRAPHICLIB_CXX11_MATH
       using std::isfinite; return isfinite(x);
-#else
-#if defined(_MSC_VER)
-      return abs(x) <= (std::numeric_limits<T>::max)();
-#else
-      // There's a problem using MPFR C++ 3.6.3 and g++ -std=c++14 (reported on
-      // 2015-05-04) with the parens around std::numeric_limits<T>::max.  Of
-      // course, these parens are only needed to deal with Windows stupidly
-      // defining max as a macro.  So don't insert the parens on non-Windows
-      // platforms.
-      return abs(x) <= std::numeric_limits<T>::max();
-#endif
-#endif
     }
 
     template<typename T> T Math::NaN() {
 #if defined(_MSC_VER)
-      return std::numeric_limits<T>::has_quiet_NaN ?
-        std::numeric_limits<T>::quiet_NaN() :
-        (std::numeric_limits<T>::max)();
+      return numeric_limits<T>::has_quiet_NaN ?
+        numeric_limits<T>::quiet_NaN() :
+        (numeric_limits<T>::max)();
 #else
-      return std::numeric_limits<T>::has_quiet_NaN ?
-        std::numeric_limits<T>::quiet_NaN() :
-        std::numeric_limits<T>::max();
+      return numeric_limits<T>::has_quiet_NaN ?
+        numeric_limits<T>::quiet_NaN() :
+        numeric_limits<T>::max();
 #endif
     }
 
     template<typename T> bool Math::isnan(T x) {
-#if GEOGRAPHICLIB_CXX11_MATH
       using std::isnan; return isnan(x);
-#else
-      return x != x;
-#endif
     }
 
   template<typename T> T Math::infinity() {
 #if defined(_MSC_VER)
-      return std::numeric_limits<T>::has_infinity ?
-        std::numeric_limits<T>::infinity() :
-        (std::numeric_limits<T>::max)();
+      return numeric_limits<T>::has_infinity ?
+        numeric_limits<T>::infinity() :
+        (numeric_limits<T>::max)();
 #else
-      return std::numeric_limits<T>::has_infinity ?
-        std::numeric_limits<T>::infinity() :
-        std::numeric_limits<T>::max();
+      return numeric_limits<T>::has_infinity ?
+        numeric_limits<T>::infinity() :
+        numeric_limits<T>::max();
 #endif
     }
 

--- a/src/GeographicLib/Math.hpp
+++ b/src/GeographicLib/Math.hpp
@@ -2,7 +2,7 @@
  * \file Math.hpp
  * \brief Header for GeographicLib::Math class
  *
- * Copyright (c) Charles Karney (2008-2019) <charles@karney.com> and licensed
+ * Copyright (c) Charles Karney (2008-2020) <charles@karney.com> and licensed
  * under the MIT/X11 License.  For more information, see
  * https://geographiclib.sourceforge.io/
  **********************************************************************/
@@ -13,28 +13,6 @@
 
 #if !defined(GEOGRAPHICLIB_MATH_HPP)
 #define GEOGRAPHICLIB_MATH_HPP 1
-
-/**
- * Are C++11 math functions available?
- **********************************************************************/
-#if !defined(GEOGRAPHICLIB_CXX11_MATH)
-// Recent versions of g++ -std=c++11 (4.7 and later?) set __cplusplus to 201103
-// and support the new C++11 mathematical functions, std::atanh, etc.  However
-// the Android toolchain, which uses g++ -std=c++11 (4.8 as of 2014-03-11,
-// according to Pullan Lu), does not support std::atanh.  Android toolchains
-// might define __ANDROID__ or ANDROID; so need to check both.  With OSX the
-// version is GNUC version 4.2 and __cplusplus is set to 201103, so remove the
-// version check on GNUC.
-#  if defined(__GNUC__) && __cplusplus >= 201103 && \
-  !(defined(__ANDROID__) || defined(ANDROID) || defined(__CYGWIN__))
-#    define GEOGRAPHICLIB_CXX11_MATH 1
-// Visual C++ 12 supports these functions
-#  elif defined(_MSC_VER) && _MSC_VER >= 1800
-#    define GEOGRAPHICLIB_CXX11_MATH 1
-#  else
-#    define GEOGRAPHICLIB_CXX11_MATH 0
-#  endif
-#endif
 
 #if !defined(GEOGRAPHICLIB_WORDS_BIGENDIAN)
 #  define GEOGRAPHICLIB_WORDS_BIGENDIAN 0
@@ -168,28 +146,20 @@ namespace GeographicLib {
      * @tparam T the type of the returned value.
      * @return &pi;.
      **********************************************************************/
-    template<typename T> static T pi() {
+    template<typename T = real> static T pi() {
       using std::atan2;
       static const T pi = atan2(T(0), T(-1));
       return pi;
     }
-    /**
-     * A synonym for pi<real>().
-     **********************************************************************/
-    static real pi() { return pi<real>(); }
 
     /**
      * @tparam T the type of the returned value.
      * @return the number of radians in a degree.
      **********************************************************************/
-    template<typename T> static T degree() {
+    template<typename T = real> static T degree() {
       static const T degree = pi<T>() / 180;
       return degree;
     }
-    /**
-     * A synonym for degree<real>().
-     **********************************************************************/
-    static real degree() { return degree<real>(); }
 
     /**
      * Square a number.
@@ -208,8 +178,12 @@ namespace GeographicLib {
      * @param[in] x
      * @param[in] y
      * @return sqrt(<i>x</i><sup>2</sup> + <i>y</i><sup>2</sup>).
+     *
+     * \deprecated Use std::hypot(x, y).
      **********************************************************************/
-    template<typename T> static T hypot(T x, T y);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::hypot(x, y)")
+      static T hypot(T x, T y);
 
     /**
      * exp(\e x) &minus; 1 accurate near \e x = 0.
@@ -217,8 +191,12 @@ namespace GeographicLib {
      * @tparam T the type of the argument and the returned value.
      * @param[in] x
      * @return exp(\e x) &minus; 1.
+     *
+     * \deprecated Use std::expm1(x).
      **********************************************************************/
-    template<typename T> static T expm1(T x);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::expm1(x)")
+      static T expm1(T x);
 
     /**
      * log(1 + \e x) accurate near \e x = 0.
@@ -226,8 +204,12 @@ namespace GeographicLib {
      * @tparam T the type of the argument and the returned value.
      * @param[in] x
      * @return log(1 + \e x).
+     *
+     * \deprecated Use std::log1p(x).
      **********************************************************************/
-    template<typename T> static T log1p(T x);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::log1p(x)")
+      static T log1p(T x);
 
     /**
      * The inverse hyperbolic sine function.
@@ -235,8 +217,12 @@ namespace GeographicLib {
      * @tparam T the type of the argument and the returned value.
      * @param[in] x
      * @return asinh(\e x).
+     *
+     * \deprecated Use std::asinh(x).
      **********************************************************************/
-    template<typename T> static T asinh(T x);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::asinh(x)")
+      static T asinh(T x);
 
     /**
      * The inverse hyperbolic tangent function.
@@ -244,8 +230,12 @@ namespace GeographicLib {
      * @tparam T the type of the argument and the returned value.
      * @param[in] x
      * @return atanh(\e x).
+     *
+     * \deprecated Use std::atanh(x).
      **********************************************************************/
-    template<typename T> static T atanh(T x);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::atanh(x)")
+      static T atanh(T x);
 
     /**
      * Copy the sign.
@@ -257,8 +247,12 @@ namespace GeographicLib {
      *
      * This routine correctly handles the case \e y = &minus;0, returning
      * &minus|<i>x</i>|.
+     *
+     * \deprecated Use std::copysign(x, y).
      **********************************************************************/
-    template<typename T> static T copysign(T x, T y);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::copysign(x, y)")
+      static T copysign(T x, T y);
 
     /**
      * The cube root function.
@@ -266,8 +260,12 @@ namespace GeographicLib {
      * @tparam T the type of the argument and the returned value.
      * @param[in] x
      * @return the real cube root of \e x.
+     *
+     * \deprecated Use std::cbrt(x).
      **********************************************************************/
-    template<typename T> static T cbrt(T x);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::cbrt(x)")
+      static T cbrt(T x);
 
     /**
      * The remainder function.
@@ -276,8 +274,12 @@ namespace GeographicLib {
      * @param[in] x
      * @param[in] y
      * @return the remainder of \e x/\e y in the range [&minus;\e y/2, \e y/2].
+     *
+     * \deprecated Use std::remainder(x).
      **********************************************************************/
-    template<typename T> static T remainder(T x, T y);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::remainder(x)")
+      static T remainder(T x, T y);
 
     /**
      * The remquo function.
@@ -287,8 +289,12 @@ namespace GeographicLib {
      * @param[in] y
      * @param[out] n the low 3 bits of the quotient
      * @return the remainder of \e x/\e y in the range [&minus;\e y/2, \e y/2].
+     *
+     * \deprecated Use std::remquo(x, y, n).
      **********************************************************************/
-    template<typename T> static T remquo(T x, T y, int* n);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::remquo(x, y, n)")
+      static T remquo(T x, T y, int* n);
 
     /**
      * The round function.
@@ -296,8 +302,12 @@ namespace GeographicLib {
      * @tparam T the type of the argument and the returned value.
      * @param[in] x
      * @return \e x round to the nearest integer (ties round away from 0).
+     *
+     * \deprecated Use std::round(x).
      **********************************************************************/
-    template<typename T> static T round(T x);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::round(x)")
+      static T round(T x);
 
     /**
      * The lround function.
@@ -308,8 +318,12 @@ namespace GeographicLib {
      *   from 0).
      *
      * If the result does not fit in a long int, the return value is undefined.
+     *
+     * \deprecated Use std::lround(x).
      **********************************************************************/
-    template<typename T> static long lround(T x);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::lround(x)")
+      static long lround(T x);
 
     /**
      * Fused multiply and add.
@@ -324,8 +338,12 @@ namespace GeographicLib {
      * On platforms without the <code>fma</code> instruction, no attempt is
      * made to improve on the result of a rounded multiplication followed by a
      * rounded addition.
+     *
+     * \deprecated Use std::fma(x, y, z).
      **********************************************************************/
-    template<typename T> static T fma(T x, T y, T z);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::fma(x, y, z)")
+      static T fma(T x, T y, T z);
 
     /**
      * Normalize a two-vector.
@@ -334,8 +352,24 @@ namespace GeographicLib {
      * @param[in,out] x on output set to <i>x</i>/hypot(<i>x</i>, <i>y</i>).
      * @param[in,out] y on output set to <i>y</i>/hypot(<i>x</i>, <i>y</i>).
      **********************************************************************/
-    template<typename T> static void norm(T& x, T& y)
-    { T h = hypot(x, y); x /= h; y /= h; }
+    template<typename T> static void norm(T& x, T& y) {
+#if defined(_MSC_VER) && defined(_M_IX86)
+      // hypot for Visual Studio (A=win32) fails monotonicity, e.g., with
+      //   x  = 0.6102683302836215
+      //   y1 = 0.7906090004346522
+      //   y2 = y1 + 1e-16
+      // the test
+      //   hypot(x, y2) >= hypot(x, y1)
+      // fails.  Reported 2021-03-14:
+      //   https://developercommunity.visualstudio.com/t/1369259
+      // See also:
+      //   https://bugs.python.org/issue43088
+      using std::sqrt; T h = sqrt(x * x + y * y);
+#else
+      using std::hypot; T h = hypot(x, y);
+#endif
+      x /= h; y /= h;
+    }
 
     /**
      * The error-free sum of two numbers.
@@ -365,11 +399,14 @@ namespace GeographicLib {
      * Return 0 if \e N &lt; 0.  Return <i>p</i><sub>0</sub>, if \e N = 0 (even
      * if \e x is infinite or a nan).  The evaluation uses Horner's method.
      **********************************************************************/
-    template<typename T> static T polyval(int N, const T p[], T x)
+    template<typename T> static T polyval(int N, const T p[], T x) {
     // This used to employ Math::fma; but that's too slow and it seemed not to
     // improve the accuracy noticeably.  This might change when there's direct
     // hardware support for fma.
-    { T y = N < 0 ? 0 : *p++; while (--N >= 0) y = y * x + *p++; return y; }
+      T y = N < 0 ? 0 : *p++;
+      while (--N >= 0) y = y * x + *p++;
+      return y;
+    }
 
     /**
      * Normalize an angle.
@@ -381,6 +418,7 @@ namespace GeographicLib {
      * The range of \e x is unrestricted.
      **********************************************************************/
     template<typename T> static T AngNormalize(T x) {
+      using std::remainder;
       x = remainder(x, T(360)); return x != -180 ? x : 180;
     }
 
@@ -412,6 +450,7 @@ namespace GeographicLib {
      * &le; 0.
      **********************************************************************/
     template<typename T> static T AngDiff(T x, T y, T& e) {
+      using std::remainder;
       T t, d = AngNormalize(sum(remainder(-x, T(360)),
                                 remainder( y, T(360)), t));
       // Here y - x = d + t (mod 360), exactly, where d is in (-180,180] and
@@ -584,8 +623,12 @@ namespace GeographicLib {
      * @tparam T the type of the argument.
      * @param[in] x
      * @return true if number is finite, false if NaN or infinite.
+     *
+     * \deprecated Use std::isfinite(x).
      **********************************************************************/
-    template<typename T> static bool isfinite(T x);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::isfinite(x)")
+      static bool isfinite(T x);
 
     /**
      * The NaN (not a number)
@@ -593,12 +636,7 @@ namespace GeographicLib {
      * @tparam T the type of the returned value.
      * @return NaN if available, otherwise return the max real of type T.
      **********************************************************************/
-    template<typename T> static T NaN();
-
-    /**
-     * A synonym for NaN<real>().
-     **********************************************************************/
-    static real NaN() { return NaN<real>(); }
+    template<typename T = real> static T NaN();
 
     /**
      * Test for NaN.
@@ -606,8 +644,12 @@ namespace GeographicLib {
      * @tparam T the type of the argument.
      * @param[in] x
      * @return true if argument is a NaN.
+     *
+     * \deprecated Use std::isnan(x).
      **********************************************************************/
-    template<typename T> static bool isnan(T x);
+    template<typename T>
+      GEOGRAPHICLIB_DEPRECATED("Use std::isnan(x)")
+      static bool isnan(T x);
 
     /**
      * Infinity
@@ -615,12 +657,7 @@ namespace GeographicLib {
      * @tparam T the type of the returned value.
      * @return infinity if available, otherwise return the max real.
      **********************************************************************/
-    template<typename T> static T infinity();
-
-    /**
-     * A synonym for infinity<real>().
-     **********************************************************************/
-    static real infinity() { return infinity<real>(); }
+    template<typename T = real> static T infinity();
 
     /**
      * Swap the bytes of a quantity


### PR DESCRIPTION
[GeographicLib v1.52 brought the following update](https://sourceforge.net/p/geographiclib/news/2021/06/geographiclib-152-released-2021-06-22/):
* Geodesic routines: be more aggressive in preventing negative s12 and m12 for short lines (all languages).

This resolves #475.