### PR TITLE
adding scripts for engineering

### DIFF
--- a/aircraft/global5000/airborne.xml
+++ b/aircraft/global5000/airborne.xml
@@ -9,6 +9,7 @@
   -->
   <running>                -1   </running>
   <altitude unit="FT">  30000.0  </altitude>
-  <vc unit="KTS">        200.0  </vc>
+  <!-- <vc unit="KTS">        200.0  </vc> -->
+  <mach>        0.43  </mach>
 
 </initialize>

--- a/aircraft/global5000/global5000ap.xml
+++ b/aircraft/global5000/global5000ap.xml
@@ -43,6 +43,8 @@
   <property> ap/throttle-cmd-norm </property>
   <property> ap/alpha_setpoint </property>
   <property> ap/alpha_hold     </property>
+  <property> ap/mach_setpoint </property>
+  <property> ap/mach_hold     </property>
 
 <!-- INITIAL GAIN VALUES -->
   
@@ -336,16 +338,9 @@ PITCH CHANNEL
       <max> 5</max>
     </clipto>
   </summer>
-  
-  <switch name="aero/ap-alpha-hold-switch">
-    <default value="0.0"/>
-    <test value="aero/alpha-error">
-      ap/alpha_hold == 1
-    </test>
-  </switch>
 
   <pid name="aero/alpha-hold-pid">
-    <input> aero/ap-alpha-hold-switch </input>
+    <input> aero/alpha-error </input>
     <kp> 100 </kp>
     <ki> 0 </ki>
     <kd> 320 </kd>
@@ -379,6 +374,68 @@ PITCH CHANNEL
     <input> -ap/throttle-cmd </input>
     <clipto>
       <min> 0 </min>
+      <max> 1.0 </max>
+    </clipto>
+  </summer>
+  
+</channel>
+
+<channel name="Mach hold">
+  <!-- Compute the error between the target mach and the actual value -->
+  <summer name="aero/mach-error">
+    <input> ap/mach_setpoint </input>
+    <input> -velocities/mach</input>
+    <clipto>
+      <min> -.25 </min>
+      <max> .25 </max>
+    </clipto>
+  </summer>
+
+  <pid name="aero/mach-hold-pid">
+    <input> aero/mach-error </input>
+    <kp> 3500 </kp>
+    <ki> .25 </ki>
+    <kd> 800000 </kd>
+    <clipto>
+      <min> -1 </min>
+      <max> 1 </max> 
+    </clipto>
+  </pid>
+
+  <!-- Forces the auto throttle value to 0 when ap/alpha_hold is different than 1.0
+        This allows to disable the autothrottle. -->
+  <switch name="ap/throttle-cmd">
+    <default value="0.0"/>
+    <test value="aero/mach-hold-pid">
+      ap/mach_hold == 1
+    </test>
+  </switch>
+
+  <lag_filter name="ap/throttle-cmd-filter">
+    <input> ap/throttle-cmd </input>
+    <c1> 0.7 </c1>
+    <clipto>
+      <min> -1 </min>
+      <max> 1 </max>
+    </clipto>
+  </lag_filter>
+
+  <!-- Drives engine #0 throttle position -->
+  <summer name="fcs/throttle-pos-norm[0]">
+    <input> fcs/throttle-cmd-norm[0] </input>
+    <input> ap/throttle-cmd-filter </input>
+    <clipto>
+      <min> 0.0 </min>
+      <max> 1.0 </max>
+    </clipto>
+  </summer>
+
+  <!-- Drives engine #1 throttle position -->
+  <summer name="fcs/throttle-pos-norm[1]">
+    <input> fcs/throttle-cmd-norm[1] </input>
+    <input> ap/throttle-cmd-filter </input>
+    <clipto>
+      <min> 0.0 </min>
       <max> 1.0 </max>
     </clipto>
   </summer>

--- a/aircraft/global5000/scripts/trim-cruise_ap.xml
+++ b/aircraft/global5000/scripts/trim-cruise_ap.xml
@@ -35,8 +35,9 @@
 	-->
     <event name="Trim">
       <condition> simulation/sim-time-sec ge 0.0 </condition>
-	  <set name="ic/vc-kts"  value="161.25"/>
-	  <set name="ic/h-sl-ft" value="30000.0"/>
+      <set name="ic/h-sl-ft" value="30000.0"/>
+      <set name="ap/mach_setpoint" value="0.43"/>
+      <set name="ap/mach_hold" value="1"/>
       <set name="simulation/do_simple_trim" value="1"/>
     </event>
     
@@ -44,9 +45,9 @@
         <condition> velocities/vc-kts >= 51 </condition>
         <delay>10.0</delay>
         <set name="ap/altitude_setpoint" value="30000.0"/>
-        <set name="ap/altitude_hold" value="1"/>
+        <set name="ap/altitude_hold" value="0"/>
         <set name="ap/alpha_setpoint" value="6.08"/>
-        <set name="ap/alpha_hold" value="1"/>
+        <set name="ap/alpha_hold" value="0"/>
       <set name="simulation/output/log_rate_hz" value="10"/>
       <notify>
         <property caption="Cal. airspeed (kts):  "> velocities/vc-kts</property>
@@ -62,6 +63,10 @@
       </description>
       <notify>
         <property>position/h-agl-ft</property>
+        <property>ap/mach_setpoint</property> 
+        <property>fcs/throttle-pos-norm[1]</property>
+        <property>fcs/throttle-cmd-norm[1]</property>
+        <property>ap/throttle-cmd</property>
         <property>velocities/mach</property>  
         <property>propulsion/engine[0]/n1</property>
         <property>propulsion/engine[1]/n1</property>

--- a/examples/python/catalog.py
+++ b/examples/python/catalog.py
@@ -1,0 +1,33 @@
+# Originally developed by JSBSim Team
+# Modified by Guilherme A. L. da Silva - aerothermalsolutions.co
+
+# List properties of a script
+# This is good to know which variable to read and write
+
+# Instructions
+# Select a string to search
+# See the list of properties containing that string
+# And its status
+# R - Read
+# W - Write
+
+# GNU Lesser General Public License v2.1
+
+# To install jsbsim module in Python
+# pip install jsbsim
+# Or conda install jsbsim (if you have anaconda, this is the best way)
+
+import jsbsim
+import os
+
+# Put your path here
+PATH_TO_JSBSIM_FILES="/Users/gasilva/Documents/GitHub/jsbsim" #my is a macbook
+# Object with JSB executable
+fdm = jsbsim.FGFDMExec(PATH_TO_JSBSIM_FILES)
+# Load script
+fdm.load_script(os.path.join(fdm.get_root_dir(), 'aircraft/global5000/scripts/trim-cruise_ap.xml')) 
+
+# Provide an empty string to get the complete list of properties.
+# Provide a string to seach properites that contains the string
+string4Search="throttle"
+print(fdm.query_property_catalog(string4Search))  

--- a/examples/python/runJSBSimFuelMach.py
+++ b/examples/python/runJSBSimFuelMach.py
@@ -1,0 +1,149 @@
+# Developed Guilherme A. L. da Silva - aerothermalsolutions.co
+
+# Calculation required by aircraft icing enginering
+# Find the optimum value for fuel consumption 
+# For greatest distance - low AoA and high speed (Carson cruise)
+# For greatest time - high AoA and low speed (miminum power required)
+
+# GNU Lesser General Public License v2.1
+
+# To install jsbsim module in Python
+# pip install jsbsim
+# Or conda install jsbsim (if you have anaconda, this is the best way)
+
+# To install matplotlib module in Python
+# pip install matplotlib
+# Or conda install matplotlib (if you have anaconda, this is the best way)
+
+import jsbsim
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Alternate visualization just uncomment
+# import matplotlib.style as style
+# style.use('fivethirtyeight')
+
+# Prepare subplots to overlay plots
+fig, ((ax,ax1),(ax2,ax3)) = plt.subplots(2,2,figsize=(12,8),sharex=True)
+
+# Fuel Max for Global5000
+fuelmax=8097.63
+# Define here the payloads to be studied
+payload=[1500,15172]
+# Define here the mass of fuel
+fuel=[500,fuelmax]
+# Two cases for weight
+weight=["light","heavy"]
+# Consumption Option
+# 0 - lb/nm - find point near Carson Cruise
+# 1 - lb - find point near Minimum Power Required
+consOpt=0
+
+# Format lines in plot
+strDash=["-","-o"]
+
+# Put your path here
+PATH_TO_JSBSIM_FILES="/Users/gasilva/Documents/GitHub/jsbsim" #my is a macbook
+
+# Variation of weight
+for i in range(2):
+    machMin=[]
+    deltaMin=[]
+    # Variation of altitude
+    for k in range(5):
+        results=[]
+        tank=[]
+        # Variation of speed
+        for j in range(45):
+            fdm = jsbsim.FGFDMExec(PATH_TO_JSBSIM_FILES) 
+            fdm.load_model('global5000')
+            fdm.reset_to_initial_conditions(1)
+            fdm['propulsion/tank[0]/contents-lbs'] = fuel[i]
+            fdm['propulsion/tank[1]/contents-lbs'] = fuel[i]
+            fdm['propulsion/tank[2]/contents-lbs'] = fuel[i]
+            fdm['inertia/pointmass-weight-lbs[0]'] = payload[i]
+            # Set engines running
+            fdm['propulsion/engine[0]/set-running'] = 1
+            fdm['propulsion/engine[1]/set-running'] = 1
+            fdm['ic/h-sl-ft'] = 10000+k*10000
+            fdm['ic/gamma-deg'] = 0
+            fdm['ap/alpha_hold']= 0
+            fdm['ap/altitude_hold']= 0
+            fdm['ic/vc-kts']=110+5*float(j)
+
+            # Initial tank contents
+            tank0i=fdm["propulsion/tank[0]/contents-lbs"]
+            tank1i=fdm["propulsion/tank[1]/contents-lbs"]
+            tank2i=fdm["propulsion/tank[2]/contents-lbs"]
+
+            # Run JSBSim
+            fdm.run_ic()
+            fdm.run()
+
+            # Trim
+            try:
+                fdm['simulation/do_simple_trim'] = 1
+
+                while fdm.run() and fdm.get_sim_time() <= 10:
+                    if fdm.get_sim_time()<1:
+                        fdm['ap/altitude_hold']= 1
+                    fdm.run()
+
+                results.append((fdm['simulation/sim-time-sec'],fdm['velocities/vc-kts'], fdm['aero/alpha-deg'],fdm["propulsion/tank[0]/contents-lbs"],fdm["propulsion/tank[1]/contents-lbs"],fdm["propulsion/tank[2]/contents-lbs"]))
+
+                tank0f=fdm["propulsion/tank[0]/contents-lbs"]
+                tank1f=fdm["propulsion/tank[1]/contents-lbs"]
+                tank2f=fdm["propulsion/tank[2]/contents-lbs"]
+
+                # Calculate Fuel Used in each Tank
+                deltaTank0=tank0i-tank0f
+                deltaTank1=tank1i-tank1f
+                deltaTank2=tank2i-tank2f
+                deltaTotal=deltaTank0+deltaTank2+deltaTank1
+
+                print("--------------------------------------")
+                print("Fuel Consumed = {}".format(deltaTotal))
+                print("Average Rate Fuel Consumed per hour = {}".format(deltaTotal/(1600/3600)))
+                print("--------------------------------------")
+
+                if consOpt==0:
+                    distance=fdm["position/distance-from-start-mag-mt"]/1852
+                else:
+                    distance=1
+                tank.append((fdm['velocities/mach'],fdm['aero/alpha-deg'],fdm['ic/h-sl-ft'],deltaTotal/distance,fdm["fcs/throttle-cmd-norm"]))
+
+            except RuntimeError as e:
+                if e.args[0] != 'Trim Failed':
+                    raise
+
+        if  len(results)>0 and len(tank)>0:
+            time, speed, alpha, tank0, tank1, tank2 = zip(*results)
+            machPlot,alpha,altitude,deltaPlot,TLA = zip(*tank)
+
+            # Plot results
+            size=len(machPlot)
+            ax.plot(machPlot, deltaPlot[:size],strDash[i],label="{0:.0f} kft {1}".format(altitude[1]/1000,weight[i]))
+            ax1.plot(machPlot, alpha[:size],strDash[i])
+            ax2.plot(machPlot, altitude[:size],strDash[i])
+            ax3.plot(machPlot, TLA[:size],strDash[i])
+            ind=np.argmin(deltaPlot)
+            machMin.append(machPlot[ind])
+            deltaMin.append(deltaPlot[ind])
+
+    # Plot line of optimum locals
+    ax.plot(machMin,deltaMin,'--',linewidth=2.0,color="black")
+
+# Finalize Plots
+ax.legend(frameon=False,loc='lower left', ncol=2,fontsize=10)
+ax2.set_xlabel('Mach')
+ax3.set_xlabel('Mach')
+if consOpt==0:
+    ax.set_ylabel('Delta Fuel [lb/nm]')
+else:
+    ax.set_ylabel('Delta Fuel [lb]')
+ax1.set_ylabel('Alpha [degrees]')
+ax2.set_ylabel('Altitude [ft]')
+ax3.set_ylabel('Throttle')
+fig.suptitle('Fuel Consumption and Alpha per Mach')
+plt.tight_layout()
+plt.show()

--- a/examples/python/runScriptLongFlight.py
+++ b/examples/python/runScriptLongFlight.py
@@ -1,0 +1,143 @@
+# Originally developed by JSBSim Team
+# Modified by Guilherme A. L. da Silva - aerothermalsolutions.co
+# Calculation required by aircraft icing enginering
+# Information required to calculate fuel consuption in leveled flight
+# with no slats or flaps in order to provide data for mission profile analysis
+
+# GNU Lesser General Public License v2.1
+
+# To install jsbsim module in Python
+# pip install jsbsim
+# Or conda install jsbsim (if you have anaconda, this is the best way)
+
+# To install matplotlib module in Python
+# pip install matplotlib
+# Or conda install matplotlib (if you have anaconda, this is the best way)
+
+# You should change aircraft XML global5000.xml to use
+# autopilot global5000apMach.xml to hold Mach number
+
+import jsbsim
+import matplotlib.pyplot as plt
+
+# Alternate visualization just uncomment
+# import matplotlib.style as style
+# style.use('fivethirtyeight')
+
+# Prepare subplots to overlay plots
+fig, ax = plt.subplots(figsize=(9,7))
+
+# Initial results variable
+results=[]
+
+# Put your path here
+PATH_TO_JSBSIM_FILES="/Users/gasilva/Documents/GitHub/jsbsim" #my is a macbook
+# Executable of jsbsim
+fdm = jsbsim.FGFDMExec(root_dir=PATH_TO_JSBSIM_FILES)
+
+# Load script for cruise flight
+fdm.load_script('aircraft/global5000/scripts/trim-cruise_ap.xml') 
+
+# Initial conditions
+fdm.reset_to_initial_conditions(1)
+fdm['ic/mach']=0.43
+fdm.run_ic()
+
+# Mark first iteration
+i=0
+# optM True mach is kept
+# optM False mach varies
+optM=True
+# Data for mach variation
+machFinal=0.52
+machInit=0.49
+
+# Run each time step as defined in the script
+while fdm.run():
+
+    if optM:
+        # Keep Mach along flight with a step
+        if fdm['simulation/sim-time-sec']>2500:
+            fdm['ap/mach_setpoint']=0.5
+        else:
+            fdm['ap/mach_setpoint']=0.43
+    else:
+        # Varying Mach
+        fdm['ap/mach_setpoint']=machInit+(machFinal-machInit)*fdm['simulation/sim-time-sec']/18000       
+
+    # Save results for plotting
+    results.append((fdm['simulation/sim-time-sec'],fdm['velocities/mach'], 
+        fdm['aero/alpha-deg'],fdm["propulsion/tank[0]/contents-lbs"],
+        fdm["propulsion/tank[1]/contents-lbs"],fdm["propulsion/tank[2]/contents-lbs"],
+        fdm["propulsion/engine/fuel-used-lbs"]))
+    if i==0:
+        # Inital tank contents
+        tank0i=fdm["propulsion/tank[0]/contents-lbs"]
+        tank1i=fdm["propulsion/tank[1]/contents-lbs"]
+        tank2i=fdm["propulsion/tank[2]/contents-lbs"]
+    i+=1
+    # Final tank contents
+    tank0f=fdm["propulsion/tank[0]/contents-lbs"]
+    tank1f=fdm["propulsion/tank[1]/contents-lbs"]
+    tank2f=fdm["propulsion/tank[2]/contents-lbs"]
+    pass
+
+# Delta Consumption for Tanks 0,1 and 2
+deltaTank0=tank0i-tank0f
+deltaTank1=tank1i-tank1f
+deltaTank2=tank2i-tank2f
+deltaTotal=deltaTank0+deltaTank2+deltaTank1
+initialTanks=tank0i+tank1i+tank2i
+print("--------------------------------------")
+print("Fuel Consumed = {:.0f}".format(deltaTotal))
+print("Average Rate Fuel Consumed per hour = {:.0f}".format(deltaTotal/5))
+print("--------------------------------------")
+
+# Variables for plotting
+time, speed, alpha, tank0, tank1, tank2, allFuel = zip(*results)
+
+# Subtract used fuel from inital fuel contents
+allFuel= [initialTanks-2*x for x in allFuel]
+
+# Plot results in time
+ax.plot(time, tank0,'-',label="Tank 0")
+ax.plot(time, tank1,'--',label="Tank 1")
+ax.plot(time, tank2,'-',label="Tank 2")
+ax.plot(time, allFuel,'-',label="All Tanks")
+
+# Plot show final results
+ax.legend(frameon=False)
+ax.set_xlabel('Time [s]')
+ax.set_ylabel('Fuel [lb]')
+ax.set_title('Fuel Consumption')
+ax.text(0.4, .7, "Fuel Consumed = {:.0f}".format(deltaTotal), fontsize=12,
+    transform=ax.transAxes)
+hours=time[-1]/3600
+ax.text(0.4, .65, "Average Rate Fuel Consumed per hour = {:.0f}".format(deltaTotal/hours), 
+    fontsize=12,transform=ax.transAxes)
+plt.tight_layout()
+plt.show()
+
+# Prepare subplots to overlay plots
+fig, ax = plt.subplots(figsize=(9,7))
+ax.set_xlabel('Time [s]')
+ax.set_ylabel('Mach')
+ax.set_title('Mach Hold During Flight')
+ax.plot(time, speed,'-',label="mach")
+ax.ticklabel_format(useOffset=False)
+ax.set_ylim([0,0.6])
+plt.tight_layout()
+plt.show()
+
+# Prepare subplots to overlay plots
+fig, ax = plt.subplots(figsize=(9,7))
+ax.set_xlabel('Time [s]')
+ax.set_ylabel('Mach')
+ax.set_title('Zoom - Mach Hold During Flight')
+ax.plot(time, speed,'-',label="mach")
+ax.ticklabel_format(useOffset=False)
+ax.set_ylim([.4,0.55])
+ax.set_xlim([0,18000])
+plt.tight_layout()
+plt.show()
+


### PR DESCRIPTION
To implement three python scripts to give an example of powerful integration between jsbsim and python. For engineering purposes may be the most recommended tool.

All have graphics outputs but they can be changed to a table format.
The plot are more useful basically.

- catalog.py:
List properties of a script
This is good to know which variable to read and write

- runScriptLongFlight.py
Calculation required by aircraft icing enginering
Information required to calculate fuel consuption in leveled flight with no slats or flaps in order to provide data for mission profile analysis

it requires change in autopilot, trim-cruise script with autopilot and airborne.xml

- runJSBSimFuelMach.py
Calculation required by aircraft icing enginering
Find the optimum value for fuel consumption
For greatest distance - low AoA and high speed (Carson cruise)
For greatest time - high AoA and low speed (miminum power required)

The aoa.py appeared in the commit without adding it.
It appears to be the last version the in the github. I checkout the file before PR.