### PR TITLE
Fixed inertia matrix error

### DIFF
--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -117,9 +117,9 @@ static FGMatrix33 ReadInertiaMatrix(Element* document)
 
   // Transform the inertia products from the structural frame to the body frame
   // and create the inertia matrix.
-  return FGMatrix33( bixx, -bixy,  bixz,
-                    -bixy,  biyy, -biyz,
-                     bixz, -biyz,  bizz );
+  return FGMatrix33( bixx,  bixy, -bixz,
+                     bixy,  biyy,  biyz,
+                    -bixz,  biyz,  bizz );
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Under the assumption that in the structural frame the:
 - X-axis is directed afterwards,
 - Y-axis is directed towards the right,
 - Z-axis is directed upwards,
And then a 180 degree rotation is done about the Y axis so that the:
 - X-axis is directed forward,
 - Y-axis is directed towards the right,
 - Z-axis is directed downward.
The original ixx,iyy,izz,ixy,ixz,iyz in structural frame.
So, When transform the inertia products from the structural frame to the body frame, ixy and iyz should be reversed.