### PR TITLE
Fixed property "aero/h_b-mac-ft" algorithm error

### DIFF
--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -223,7 +223,7 @@ bool FGAuxiliary::Run(bool Holding)
   hoverbcg = in.DistanceAGL / in.Wingspan;
 
   FGColumnVector3 vMac = in.Tb2l * in.RPBody;
-  hoverbmac = (in.DistanceAGL + vMac(3)) / in.Wingspan;
+  hoverbmac = (in.DistanceAGL - vMac(3)) / in.Wingspan;
 
   return false;
 }


### PR DESCRIPTION
The algorithm of property "aero/h_b-mac-ft" in JSBSim is wrong. This error will lead to an error in the calculation of aircraft ground effect. The code in FGAuxiliary.cpp is：
```
  hoverbcg = in.DistanceAGL / in.Wingspan;

  FGColumnVector3 vMac = in.Tb2l * in.RPBody;
  hoverbmac = (in.DistanceAGL + vMac(3)) / in.Wingspan;
```
In fact, the Z axis of the **body frame** and **NED frame** are downward. Assuming that the aircraft stops on the ground, when MAC is higher than the CG, vMac(3) is negative, resulting in hoverbmac less than hoverbcg. In fact, hoverbmac should be greater than hoverbcg. Therefore, vMac(3) should be inverted，The correct code should be:
```
  hoverbcg = in.DistanceAGL / in.Wingspan;

  FGColumnVector3 vMac = in.Tb2l * in.RPBody;
  hoverbmac = (in.DistanceAGL - vMac(3)) / in.Wingspan;
```
Please confirm and check whether the algorithm is correct.