### PR TITLE
Remove engine code that reads in position and orientation 

### DIFF
--- a/src/models/propulsion/FGEngine.cpp
+++ b/src/models/propulsion/FGEngine.cpp
@@ -56,8 +56,6 @@ FGEngine::FGEngine(int engine_number, struct Inputs& input)
   : in(input), EngineNumber(engine_number)
 {
   Type = etUnknown;
-  X = Y = Z = 0.0;
-  EnginePitch = EngineYaw = 0.0;
   SLFuelFlowMax = 0.0;
   FuelExpended = 0.0;
   MaxThrottle = 1.0;
@@ -109,18 +107,6 @@ unsigned int FGEngine::GetSourceTank(unsigned int i) const
   } else {
     throw("No such source tank is available for this engine");
   }
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void FGEngine::SetPlacement(const FGColumnVector3& location,
-                            const FGColumnVector3& orientation)
-{
-  X = location(eX);
-  Y = location(eY);
-  Z = location(eZ);
-  EnginePitch = orientation(ePitch);
-  EngineYaw = orientation (eYaw);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -200,19 +186,13 @@ bool FGEngine::Load(FGFDMExec *exec, Element *engine_element)
   // Call ModelFunctions loader
   FGModelFunctions::Load(engine_element, exec, to_string((int)EngineNumber));
 
-// Find and set engine location
+  // If engine location and/or orientation is supplied issue a warning since they
+  // are ignored. What counts is the location and orientation of the thruster.
+  if (parent_element->FindElement("location"))
+    cerr << "Engine location ignored, only thruster location is used." << endl;
 
-  local_element = parent_element->FindElement("location");
-  if (local_element)  location = local_element->FindElementTripletConvertTo("IN");
-//  else      cerr << "No engine location found for this engine." << endl;
-// Jon: The engine location is not important - the nozzle location is.
-
-  local_element = parent_element->FindElement("orient");
-  if (local_element)  orientation = local_element->FindElementTripletConvertTo("RAD");
-//  else          cerr << "No engine orientation found for this engine." << endl;
-// Jon: The engine orientation has a default and is not normally used.
-
-  SetPlacement(location, orientation);
+  if (parent_element->FindElement("orient"))
+    cerr << "Engine orientation ignored, only thruster orientation is used." << endl;
 
   // Load thruster
   local_element = parent_element->FindElement("thruster");

--- a/src/models/propulsion/FGEngine.cpp
+++ b/src/models/propulsion/FGEngine.cpp
@@ -188,11 +188,15 @@ bool FGEngine::Load(FGFDMExec *exec, Element *engine_element)
 
   // If engine location and/or orientation is supplied issue a warning since they
   // are ignored. What counts is the location and orientation of the thruster.
-  if (parent_element->FindElement("location"))
-    cerr << "Engine location ignored, only thruster location is used." << endl;
+  local_element = parent_element->FindElement("location");
+  if (local_element)
+    cerr << local_element->ReadFrom()
+         << "Engine location ignored, only thruster location is used." << endl;
 
-  if (parent_element->FindElement("orient"))
-    cerr << "Engine orientation ignored, only thruster orientation is used." << endl;
+  local_element = parent_element->FindElement("orient");
+  if (local_element)
+    cerr << local_element->ReadFrom()
+         << "Engine orientation ignored, only thruster orientation is used." << endl;
 
   // Load thruster
   local_element = parent_element->FindElement("thruster");

--- a/src/models/propulsion/FGEngine.h
+++ b/src/models/propulsion/FGEngine.h
@@ -71,17 +71,6 @@ CLASS DOCUMENTATION
     <h3>Configuration File Format:</h3>
 @code
         <engine file="{string}">
-            <location unit="{IN | M}">
-                <x> {number} </x>
-                <y> {number} </y>
-                <z> {number} </z>
-            </location>
-            <!-- optional orientation definition -->
-            <orient unit="{RAD | DEG}">
-                <roll>  {number} </roll>
-                <pitch> {number} </pitch>
-                <yaw> {number} </yaw>
-            </orient>
             <feed> {integer} </feed>
             ... optional more feed tank index numbers ... 
             <thruster file="{string}">
@@ -183,9 +172,6 @@ public:
 
   virtual double GetThrust(void) const;
     
-  /// Sets engine placement information
-  virtual void SetPlacement(const FGColumnVector3& location, const FGColumnVector3& orientation);
-
   /** The fuel need is calculated based on power levels and flow rate for that
       power level. It is also turned from a rate into an actual amount (pounds)
       by multiplying it by the delta T and the rate.
@@ -216,9 +202,6 @@ protected:
   std::string Name;
   const int   EngineNumber;
   EngineType Type;
-  double X, Y, Z;
-  double EnginePitch;
-  double EngineYaw;
   double SLFuelFlowMax;
   double MaxThrottle;
   double MinThrottle;


### PR DESCRIPTION
As mentioned in https://github.com/JSBSim-Team/jsbsim/discussions/547#discussioncomment-1863391 the engine position and orientation data is read in but isn't used, it's only the thruster's location and orientation that matter, which causes confusion.