### PR TITLE
Allow output precision to be specified for socket output

### DIFF
--- a/src/input_output/FGOutputSocket.cpp
+++ b/src/input_output/FGOutputSocket.cpp
@@ -121,6 +121,12 @@ bool FGOutputSocket::Load(Element* el)
                 el->GetAttributeValue("protocol") + "/" +
                 el->GetAttributeValue("port"));
 
+  // Check if output precision for doubles has been specified, default to 7 if not
+  if(el->HasAttribute("precision"))
+    precision = (int)el->GetAttributeValueAsNumber("precision");
+  else
+    precision = 7;
+
   return true;
 }
 
@@ -130,7 +136,7 @@ bool FGOutputSocket::InitModel(void)
 {
   if (FGOutputType::InitModel()) {
     delete socket;
-    socket = new FGfdmSocket(SockName, SockPort, SockProtocol);
+    socket = new FGfdmSocket(SockName, SockPort, SockProtocol, precision);
 
     if (socket == 0) return false;
     if (!socket->GetConnectStatus()) return false;

--- a/src/input_output/FGOutputSocket.h
+++ b/src/input_output/FGOutputSocket.h
@@ -108,6 +108,7 @@ protected:
   unsigned int SockPort;
   FGfdmSocket::ProtocolType SockProtocol;
   FGfdmSocket* socket;
+  int precision;
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/input_output/FGfdmSocket.cpp
+++ b/src/input_output/FGfdmSocket.cpp
@@ -81,12 +81,13 @@ static bool LoadWinSockDLL(int debug_lvl)
 }
 #endif
 
-FGfdmSocket::FGfdmSocket(const string& address, int port, int protocol)
+FGfdmSocket::FGfdmSocket(const string& address, int port, int protocol, int precision)
 {
   sckt = sckt_in = 0;
   Protocol = (ProtocolType)protocol;
   connected = false;
   struct addrinfo *addr = nullptr;
+  this->precision = precision;
 
   #if defined(_MSC_VER) || defined(__MINGW32__)
   if (!LoadWinSockDLL(debug_lvl)) return;
@@ -150,12 +151,13 @@ FGfdmSocket::FGfdmSocket(const string& address, int port, int protocol)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 // assumes TCP or UDP socket on localhost, for inbound datagrams
-FGfdmSocket::FGfdmSocket(int port, int protocol)
+FGfdmSocket::FGfdmSocket(int port, int protocol, int precision)
 {
   sckt = -1;
   connected = false;
   Protocol = (ProtocolType)protocol;
   string ProtocolName;
+  this->precision = precision;
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
   if (!LoadWinSockDLL(debug_lvl)) return;
@@ -338,7 +340,7 @@ void FGfdmSocket::Append(const char* item)
 void FGfdmSocket::Append(double item)
 {
   if (buffer.tellp() > 0) buffer << ',';
-  buffer << std::setw(12) << std::setprecision(7) << item;
+  buffer << std::setw(12) << std::setprecision(precision) << item;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/input_output/FGfdmSocket.h
+++ b/src/input_output/FGfdmSocket.h
@@ -70,10 +70,8 @@ CLASS DECLARATION
 class FGfdmSocket : public FGJSBBase
 {
 public:
-  FGfdmSocket(const std::string& address, int port)
-    : FGfdmSocket(address, port, ptTCP) {}
-  FGfdmSocket(const std::string&, int, int);
-  FGfdmSocket(int, int);
+  FGfdmSocket(const std::string& address, int port, int protocol, int precision = 7);
+  FGfdmSocket(int port, int protocol, int precision = 7);
   ~FGfdmSocket();
   void Send(void);
   void Send(const char *data, int length);
@@ -104,6 +102,7 @@ private:
   struct sockaddr_in scktName;
   struct hostent *host;
   std::ostringstream buffer;
+  int precision;
   bool connected;
   void Debug(int from);
 };


### PR DESCRIPTION
Allow a user to optionally specify the precision for the output of double properties on an output socket.

```xml
<output name="localhost" type="SOCKET" port="5138" protocol="UDP" rate="10" precision="8">
   
  <property> velocities/vc-kts </property>
  <property> position/h-sl-ft </property>
  <property> attitude/theta-deg </property>

</output>
```