### PR TITLE
Add .editorconfig file to set coding conventions for editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{h,hpp,cpp}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
While setting up a new laptop with a new install of Visual Studio 2022 I decided to look into the options for setting the coding conventions in terms of tabs vs spaces and the indent size on a per project basis as opposed to setting them globally in Visual Studio.

I came across .editorconfig which is supported by a number of editors/IDEs. So hopefully in virtually all cases when a new JSBSim developer clones the repo and submits a pull request their IDE of choice will make use of the settings in .editorconfig.

https://editorconfig.org/