### PR TITLE
Allow alternative spellings for `Systems` and `Engines` sub-directories.

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -222,10 +222,11 @@ for d in os.scandir('data/aircraft'):
         data_files.append(('share/${PROJECT_NAME}/'+dir_name,
                             list(XML_files(dir_name))))
 
-        # Some aircraft folders include a `Systems` and/or an `Engines`
-        # sub-directory so make sure it is copied in the wheel archive
-        # (see GH issue #687)
-        for sub_dir in ('Systems', 'Engines'):
+        # Some aircraft folders include a "Systems" and/or an "Engines"
+        # sub-directory (with several alternative spelling) so make sure they
+        # are copied in the wheel archive (see GH issue #687)
+        for sub_dir in ('Systems', 'systems', 'Engines', 'engines', 'Engine',
+                        'engine'):
             sub_dir_name = dir_name + '/' + sub_dir
             subdir_dir_fullname = os.path.join('data', sub_dir_name)
             if os.path.exists(subdir_dir_fullname) and os.path.isdir(subdir_dir_fullname):

--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -38,6 +38,7 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <iomanip>
+#include <array>
 
 #include "FGFCS.h"
 #include "input_output/FGModelLoader.h"
@@ -613,8 +614,17 @@ SGPath FGFCS::FindFullPathName(const SGPath& path) const
   SGPath name = FGModel::FindFullPathName(path);
   if (systype != stSystem || !name.isNull()) return name;
 
-  name = CheckPathName(FDMExec->GetFullAircraftPath()/string("Systems"), path);
-  if (!name.isNull()) return name;
+#ifdef _WIN32
+  const array<string, 1> dir_names = {"Systems"};
+#else
+  // Check alternative capitalization for case sensitive OSes.
+  const array<string, 2> dir_names = {"Systems", "systems"};
+#endif
+
+  for(const string& dir_name: dir_names) {
+    name = CheckPathName(FDMExec->GetFullAircraftPath()/dir_name, path);
+    if (!name.isNull()) return name;
+  }
 
   return CheckPathName(FDMExec->GetSystemsPath(), path);
 }

--- a/src/models/FGPropulsion.cpp
+++ b/src/models/FGPropulsion.cpp
@@ -45,6 +45,7 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <iomanip>
+#include <array>
 
 #include "FGFDMExec.h"
 #include "FGPropulsion.h"
@@ -438,11 +439,23 @@ bool FGPropulsion::Load(Element* el)
 
 SGPath FGPropulsion::FindFullPathName(const SGPath& path) const
 {
-  if (!ReadingEngine) return FGModel::FindFullPathName(path);
+  SGPath name = FGModel::FindFullPathName(path);
+  if (!ReadingEngine && !name.isNull()) return name;
 
-  SGPath name = CheckPathName(FDMExec->GetFullAircraftPath()/string("Engines"),
-                              path);
-  if (!name.isNull()) return name;
+#ifdef _WIN32
+  // Singular and plural are allowed for the folder names for consistency with
+  // the default engine folder name "engine" and for backward compatibility
+  // regarding the folder name "Engines".
+  const array<string, 2> dir_names = {"Engines", "engine"};
+#else
+  // Allow alternative capitalization for case sensitive OSes.
+  const array<string, 4> dir_names = {"Engines", "engines", "Engine", "engine"};
+#endif
+
+  for(const string& dir_name: dir_names) {
+    name = CheckPathName(FDMExec->GetFullAircraftPath()/dir_name, path);
+    if (!name.isNull()) return name;
+  }
 
   return CheckPathName(FDMExec->GetEnginePath(), path);
 }


### PR DESCRIPTION
As per the discussion in issue #687 and especially @seanmcleod's https://github.com/JSBSim-Team/jsbsim/issues/687#issuecomment-1196520499, the default folder name for engines is `engine` but JSBSim requests using the spelling `Engines` for the engine sub-directory under the aircraft folder. 
Note that :
1. The capitalization is different between the 2 spellings.
2. One is using the singular form while the other one is using the plural form.

This behavior is not consistent and users might struggle finding the correct spelling (especially on case sensitive OSes) depending on where they intend to locate their engine definition files.

There is a similar issue for systems folders which use a different capitalization for the default folder (`systems`) and for a sub-directory located under the aircraft folder (`Systems`). Unlike the engine folder name, both systems folder names are using the plural form however.

This pull request allows using alternative spelling for the engine folder: `engine`, `engines` `Engine`, `Engines` and for the systems folder: `systems` and `Systems`. The change is backward compatible.