### PR TITLE
Add a compilation check for Apple M1 chips

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -527,7 +527,7 @@ jobs:
         working-directory: build
         run: make -j3
       - name: Test JSBSim
-        #if: matrix.arch == 'x86_64'
+        if: matrix.arch == 'x86_64'
         working-directory: build
         run: ctest -j3 -E TestInputSocket --output-on-failure
       - name: Build source package for Python

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -522,7 +522,7 @@ jobs:
         if: matrix.arch == 'arm64'
         run: |
           mkdir -p build && cd build
-          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DCMAKE_OSX_ARCHITECTURE=${{matrix.arch}} -DBUILD_PYTHON_MODULE=OFF -DBUILD_DOCS=OFF ..
+          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DCMAKE_OSX_ARCHITECTURES=${{matrix.arch}} -DBUILD_PYTHON_MODULE=OFF -DBUILD_DOCS=OFF ..
       - name: Build JSBSim
         working-directory: build
         run: make -j3

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -473,12 +473,16 @@ jobs:
     name: C/C++ build (MacOSX)
     needs: XML-validation
     runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
     steps:
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
           python-version: '3.7'
       - name: Install Python packages
+        if: matrix.arch == 'x86_64'
         run: pip install -U cython numpy pandas scipy build 'setuptools>=60.0.0'
       - name: Checkout JSBSim
         uses: actions/checkout@v2
@@ -486,11 +490,12 @@ jobs:
         # This file is used by CTest to optimize the distribution of the tests
         # between the cores and reduce execution time.
         uses: actions/cache@v2
+        if: matrix.arch == 'x86_64'
         with:
           path: build/Testing/Temporary/CTestCostData.txt
           key: ${{ runner.os }}-${{ hashFiles('tests/CMakeLists.txt') }}
       - name: Install & Configure Doxygen
-        if: env.release == 'true'
+        if: env.release == 'true' && matrix.arch == 'x86_64'
         run: |
           brew install doxygen
           # We don't want Doxygen to generate the HTML docs in this job (saves time)
@@ -506,20 +511,25 @@ jobs:
       - name: Configure CxxTest
         working-directory: cxxtest/python
         run: python setup.py install
-      - name: Configure JSBSim
+      - name: Configure JSBSim (x86_64)
         run: |
           mkdir -p build && cd build
           julia -e "import Pkg;Pkg.add(\"CxxWrap\")"
           export CXXWRAP_PREFIX_PATH=`julia -e "using CxxWrap;print(CxxWrap.prefix_path())"`
           cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DBUILD_JULIA_PACKAGE=ON -DCMAKE_PREFIX_PATH=$CXXWRAP_PREFIX_PATH ..
+      - name: Configure JSBSim (arm64)
+        run: |
+          mkdir -p build && cd build
+          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DCMAKE_OSX_ARCHITECTURE=${{matrix.arch}} -DBUILD_PYTHON_MODULE=OFF -DBUILD_DOCS=OFF ..
       - name: Build JSBSim
         working-directory: build
         run: make -j3
       - name: Test JSBSim
+        if: matrix.arch == 'x86_64'
         working-directory: build
         run: ctest -j3 -E TestInputSocket --output-on-failure
       - name: Build source package for Python
-        if: env.release == 'true'
+        if: env.release == 'true' && matrix.arch == 'x86_64'
         working-directory: build/python
         run: |
           rm -f jsbsim.cxx  # Make sure that jsbsim.cxx is not stored in the source distribution
@@ -537,7 +547,7 @@ jobs:
 
       - name: Upload Files for Release
         uses: actions/upload-artifact@v2
-        if: env.release == 'true'
+        if: env.release == 'true' && matrix.arch == 'x86_64'
         with:
           name: ${{ runner.os }}.binaries
           path: |

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -512,12 +512,14 @@ jobs:
         working-directory: cxxtest/python
         run: python setup.py install
       - name: Configure JSBSim (x86_64)
+        if: matrix.arch == 'x86_64'
         run: |
           mkdir -p build && cd build
           julia -e "import Pkg;Pkg.add(\"CxxWrap\")"
           export CXXWRAP_PREFIX_PATH=`julia -e "using CxxWrap;print(CxxWrap.prefix_path())"`
           cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DBUILD_JULIA_PACKAGE=ON -DCMAKE_PREFIX_PATH=$CXXWRAP_PREFIX_PATH ..
       - name: Configure JSBSim (arm64)
+        if: matrix.arch == 'arm64'
         run: |
           mkdir -p build && cd build
           cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DCMAKE_OSX_ARCHITECTURE=${{matrix.arch}} -DBUILD_PYTHON_MODULE=OFF -DBUILD_DOCS=OFF ..
@@ -525,7 +527,7 @@ jobs:
         working-directory: build
         run: make -j3
       - name: Test JSBSim
-        if: matrix.arch == 'x86_64'
+        #if: matrix.arch == 'x86_64'
         working-directory: build
         run: ctest -j3 -E TestInputSocket --output-on-failure
       - name: Build source package for Python


### PR DESCRIPTION
Following the discussion in issue #688, it appeared that JSBSim does not provide Python wheels for Apple M1 chips. This PR adds a job to our CI workflow to check that the compilation of C++ code succeeds for M1 chips.

At the moment, GitHub Actions does not provide MacOSX runners for M1 chips, so it is only the cross compilation that is checked, tests are not executed. 