### PR TITLE
Use C++11 standard library to generate random numbers

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -75,7 +75,8 @@ CLASS IMPLEMENTATION
 // Constructor
 
 FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmctr)
-  : RandomSeed(0), RandomEngine(new default_random_engine(RandomSeed)), FDMctr(fdmctr)
+  : RandomSeed(0), RandomEngine(make_shared<RandomNumberGenerator>(RandomSeed)),
+    FDMctr(fdmctr)
 {
   Frame           = 0;
   disperse        = 0;
@@ -1242,9 +1243,8 @@ void FGFDMExec::DoTrim(int mode)
 void FGFDMExec::SRand(int sr)
 {
   RandomSeed = sr;
-  gaussian_random_number_phase = 0;
   RandomEngine->seed(RandomSeed);
-  // srand(RandomSeed);
+  gaussian_random_number_phase = 0;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -155,17 +155,18 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   trim_completed = 0;
 
   Constructing = true;
-  instance->Tie<FGFDMExec, int>("simulation/do_simple_trim", this, nullptr, &FGFDMExec::DoTrim);
-  instance->Tie<FGFDMExec, int>("simulation/reset", this, nullptr, &FGFDMExec::ResetToInitialConditions);
+  typedef int (FGFDMExec::*iPMF)(void) const;
+  instance->Tie("simulation/do_simple_trim", this, (iPMF)0, &FGFDMExec::DoTrim);
+  instance->Tie("simulation/reset", this, (iPMF)0, &FGFDMExec::ResetToInitialConditions);
   instance->Tie("simulation/disperse", this, &FGFDMExec::GetDisperse);
-  instance->Tie("simulation/randomseed", this, &FGFDMExec::SRand, &FGFDMExec::SRand);
+  instance->Tie("simulation/randomseed", this, (iPMF)&FGFDMExec::SRand, &FGFDMExec::SRand);
   instance->Tie("simulation/terminate", (int *)&Terminate);
-  instance->Tie("simulation/pause", &holding);
+  instance->Tie("simulation/pause", (int *)&holding);
   instance->Tie("simulation/sim-time-sec", this, &FGFDMExec::GetSimTime);
   instance->Tie("simulation/dt", this, &FGFDMExec::GetDeltaT);
   instance->Tie("simulation/jsbsim-debug", this, &FGFDMExec::GetDebugLevel, &FGFDMExec::SetDebugLevel);
-  instance->Tie("simulation/frame", (int*)&Frame);
-  instance->Tie("simulation/trim-completed", &trim_completed);
+  instance->Tie("simulation/frame", (int *)&Frame);
+  instance->Tie("simulation/trim-completed", (int *)&trim_completed);
   instance->Tie("forces/hold-down", this, &FGFDMExec::GetHoldDown, &FGFDMExec::SetHoldDown);
 
   Constructing = false;

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -1244,7 +1244,6 @@ void FGFDMExec::SRand(int sr)
 {
   RandomSeed = sr;
   RandomEngine->seed(RandomSeed);
-  gaussian_random_number_phase = 0;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -75,7 +75,7 @@ CLASS IMPLEMENTATION
 // Constructor
 
 FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmctr)
-  : RandomSeed(0), RandomEngine(make_shared<RandomNumberGenerator>(RandomSeed)),
+  : RandomSeed(0), RandomGenerator(make_shared<RandomNumberGenerator>(RandomSeed)),
     FDMctr(fdmctr)
 {
   Frame           = 0;
@@ -1243,7 +1243,7 @@ void FGFDMExec::DoTrim(int mode)
 void FGFDMExec::SRand(int sr)
 {
   RandomSeed = sr;
-  RandomEngine->seed(RandomSeed);
+  RandomGenerator->seed(RandomSeed);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -75,7 +75,7 @@ CLASS IMPLEMENTATION
 // Constructor
 
 FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmctr)
-  : RandomEngine(new default_random_engine), FDMctr(fdmctr)
+  : RandomSeed(0), RandomEngine(new default_random_engine(RandomSeed)), FDMctr(fdmctr)
 {
   Frame           = 0;
   disperse        = 0;
@@ -86,7 +86,6 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   IsChild = false;
   holding = false;
   Terminate = false;
-  RandomSeed = 0;
   HoldDown = false;
 
   IncrementThenHolding = false;  // increment then hold is off by default
@@ -155,18 +154,17 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   trim_completed = 0;
 
   Constructing = true;
-  typedef int (FGFDMExec::*iPMF)(void) const;
-  instance->Tie("simulation/do_simple_trim", this, (iPMF)0, &FGFDMExec::DoTrim);
-  instance->Tie("simulation/reset", this, (iPMF)0, &FGFDMExec::ResetToInitialConditions);
+  instance->Tie<FGFDMExec, int>("simulation/do_simple_trim", this, nullptr, &FGFDMExec::DoTrim);
+  instance->Tie<FGFDMExec, int>("simulation/reset", this, nullptr, &FGFDMExec::ResetToInitialConditions);
   instance->Tie("simulation/disperse", this, &FGFDMExec::GetDisperse);
-  instance->Tie("simulation/randomseed", this, (iPMF)&FGFDMExec::SRand, &FGFDMExec::SRand);
+  instance->Tie("simulation/randomseed", this, &FGFDMExec::SRand, &FGFDMExec::SRand);
   instance->Tie("simulation/terminate", (int *)&Terminate);
-  instance->Tie("simulation/pause", (int *)&holding);
+  instance->Tie("simulation/pause", &holding);
   instance->Tie("simulation/sim-time-sec", this, &FGFDMExec::GetSimTime);
   instance->Tie("simulation/dt", this, &FGFDMExec::GetDeltaT);
   instance->Tie("simulation/jsbsim-debug", this, &FGFDMExec::GetDebugLevel, &FGFDMExec::SetDebugLevel);
-  instance->Tie("simulation/frame", (int *)&Frame);
-  instance->Tie("simulation/trim-completed", (int *)&trim_completed);
+  instance->Tie("simulation/frame", (int*)&Frame);
+  instance->Tie("simulation/trim-completed", &trim_completed);
   instance->Tie("forces/hold-down", this, &FGFDMExec::GetHoldDown, &FGFDMExec::SetHoldDown);
 
   Constructing = false;
@@ -1245,8 +1243,8 @@ void FGFDMExec::SRand(int sr)
 {
   RandomSeed = sr;
   gaussian_random_number_phase = 0;
-  RandomEngine->seed(sr);
-  srand(RandomSeed);
+  RandomEngine->seed(RandomSeed);
+  // srand(RandomSeed);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -482,8 +482,8 @@ public:
   /// Returns true if the simulation is Holding (i.e. simulation time is not moving).
   bool Holding(void) {return holding;}
   /// Mode flags for ResetToInitialConditions
-  enum { START_NEW_OUTPUT    = 1,
-         DONT_EXECUTE_RUN_IC = 2 };
+  static const int START_NEW_OUTPUT    = 0x1;
+  static const int DONT_EXECUTE_RUN_IC = 0x2;
   /** Resets the initial conditions object and prepares the simulation to run
       again. If the mode's first bit is set the output instances will take special actions
       such as closing the current output file and open a new one with a different name.
@@ -616,7 +616,7 @@ private:
   unsigned int Frame;
   unsigned int IdFDM;
   int disperse;
-  unsigned int Terminate;
+  unsigned short Terminate;
   double dT;
   double saved_dT;
   double sim_time;

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -483,8 +483,8 @@ public:
   /// Returns true if the simulation is Holding (i.e. simulation time is not moving).
   bool Holding(void) {return holding;}
   /// Mode flags for ResetToInitialConditions
-  static const int START_NEW_OUTPUT    = 0x1;
-  static const int DONT_EXECUTE_RUN_IC = 0x2;
+  enum { START_NEW_OUTPUT    = 1,
+         DONT_EXECUTE_RUN_IC = 2 };
   /** Resets the initial conditions object and prepares the simulation to run
       again. If the mode's first bit is set the output instances will take special actions
       such as closing the current output file and open a new one with a different name.
@@ -617,7 +617,7 @@ private:
   unsigned int Frame;
   unsigned int IdFDM;
   int disperse;
-  unsigned short Terminate;
+  unsigned int Terminate;
   double dT;
   double saved_dT;
   double sim_time;
@@ -669,7 +669,7 @@ private:
 
   bool HoldDown;
 
-  int RandomSeed;
+  unsigned int RandomSeed;
   std::shared_ptr<std::default_random_engine> RandomEngine;
 
   // The FDM counter is used to give each child FDM an unique ID. The root FDM

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -42,7 +42,6 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <memory>
-#include <random>
 
 #include "models/FGPropagate.h"
 #include "models/FGOutput.h"
@@ -670,7 +669,7 @@ private:
   bool HoldDown;
 
   unsigned int RandomSeed;
-  std::shared_ptr<std::default_random_engine> RandomEngine;
+  std::shared_ptr<RandomNumberGenerator> RandomEngine;
 
   // The FDM counter is used to give each child FDM an unique ID. The root FDM
   // has the ID 0

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -610,7 +610,7 @@ public:
     TemplateFunctions[name] = std::make_shared<FGTemplateFunc>(this, el);
   }
 
-  auto GetRandomEngine(void) const { return RandomEngine; }
+  auto GetRandomGenerator(void) const { return RandomGenerator; }
 
 private:
   unsigned int Frame;
@@ -669,7 +669,7 @@ private:
   bool HoldDown;
 
   unsigned int RandomSeed;
-  std::shared_ptr<RandomNumberGenerator> RandomEngine;
+  std::shared_ptr<RandomNumberGenerator> RandomGenerator;
 
   // The FDM counter is used to give each child FDM an unique ID. The root FDM
   // has the ID 0

--- a/src/FGJSBBase.cpp
+++ b/src/FGJSBBase.cpp
@@ -77,8 +77,6 @@ CLASS IMPLEMENTATION
 const string FGJSBBase::needed_cfg_version = "2.0";
 const string FGJSBBase::JSBSim_version = JSBSIM_VERSION " " __DATE__ " " __TIME__ ;
 
-int FGJSBBase::gaussian_random_number_phase = 0;
-
 short FGJSBBase::debug_lvl  = 1;
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -105,34 +103,6 @@ string FGJSBBase::CreateIndexedPropertyName(const string& Property, int index)
   ostringstream buf;
   buf << Property << '[' << index << ']';
   return buf.str();
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double FGJSBBase::GaussianRandomNumber(void)
-{
-  static double V1, V2, S;
-  double X;
-
-  if (gaussian_random_number_phase == 0) {
-    V1 = V2 = S = X = 0.0;
-
-    do {
-      double U1 = (double)rand() / RAND_MAX;
-      double U2 = (double)rand() / RAND_MAX;
-
-      V1 = 2 * U1 - 1;
-      V2 = 2 * U2 - 1;
-      S = V1 * V1 + V2 * V2;
-    } while(S >= 1 || S == 0);
-
-    X = V1 * sqrt(-2 * log(S) / S);
-  } else
-    X = V2 * sqrt(-2 * log(S) / S);
-
-  gaussian_random_number_phase = 1 - gaussian_random_number_phase;
-
-  return X;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/FGJSBBase.h
+++ b/src/FGJSBBase.h
@@ -43,6 +43,7 @@ INCLUDES
 #include <string>
 #include <cmath>
 #include <stdexcept>
+#include <random>
 
 #include "JSBSim_API.h"
 #include "input_output/string_utilities.h"
@@ -60,6 +61,23 @@ namespace JSBSim {
 class JSBSIM_API BaseException : public std::runtime_error {
   public:
     BaseException(const std::string& msg) : std::runtime_error(msg) {}
+};
+
+class JSBSIM_API RandomNumberGenerator {
+  public:
+    RandomNumberGenerator(unsigned int seed=0)
+      : generator(seed), uniform_random(-1.0, 1.0), normal_random(0.0,1.0) {}
+    void seed(unsigned int value) {
+      generator.seed(value);
+      uniform_random.reset();
+      normal_random.reset();
+    }
+    double GetUniformRandomNumber(void) { return uniform_random(generator); }
+    double GetNormalRandomNumber(void) { return normal_random(generator); }
+  private:
+    std::default_random_engine generator;
+    std::uniform_real_distribution<double> uniform_random;
+    std::normal_distribution<double> normal_random;
 };
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/FGJSBBase.h
+++ b/src/FGJSBBase.h
@@ -44,6 +44,7 @@ INCLUDES
 #include <cmath>
 #include <stdexcept>
 #include <random>
+#include <chrono>
 
 #include "JSBSim_API.h"
 #include "input_output/string_utilities.h"
@@ -65,8 +66,13 @@ class JSBSIM_API BaseException : public std::runtime_error {
 
 class JSBSIM_API RandomNumberGenerator {
   public:
-    RandomNumberGenerator(unsigned int seed=0)
-      : generator(seed), uniform_random(-1.0, 1.0), normal_random(0.0,1.0) {}
+    RandomNumberGenerator(void) : uniform_random(-1.0, 1.0), normal_random(0.0, 1.0)
+    {
+      auto seed_value = std::chrono::system_clock::now().time_since_epoch().count();
+      generator.seed(static_cast<unsigned int>(seed_value));
+    }
+    RandomNumberGenerator(unsigned int seed)
+      : generator(seed), uniform_random(-1.0, 1.0), normal_random(0.0, 1.0) {}
     void seed(unsigned int value) {
       generator.seed(value);
       uniform_random.reset();
@@ -306,8 +312,6 @@ public:
 
   static constexpr double sign(double num) {return num>=0.0?1.0:-1.0;}
 
-  static double GaussianRandomNumber(void);
-
 protected:
   static constexpr double radtodeg = 180. / M_PI;
   static constexpr double degtorad = M_PI / 180.;
@@ -335,8 +339,6 @@ protected:
   static const std::string JSBSim_version;
 
   static std::string CreateIndexedPropertyName(const std::string& Property, int index);
-
-  static int gaussian_random_number_phase;
 
 public:
 /// Moments L, M, N

--- a/src/FGJSBBase.h
+++ b/src/FGJSBBase.h
@@ -64,21 +64,36 @@ class JSBSIM_API BaseException : public std::runtime_error {
     BaseException(const std::string& msg) : std::runtime_error(msg) {}
 };
 
+/**
+ * @brief Random number generator.
+ * This class encapsulates the C++11 random number generation classes for
+ * uniform and gaussian (aka normal) distributions as well as their seed.
+ * This class guarantees that whenever its seed is reset so are its uniform
+ * and normal random number generators.
+ */
+
 class JSBSIM_API RandomNumberGenerator {
   public:
+    /// Default constructor using a seed based on the system clock.
     RandomNumberGenerator(void) : uniform_random(-1.0, 1.0), normal_random(0.0, 1.0)
     {
       auto seed_value = std::chrono::system_clock::now().time_since_epoch().count();
       generator.seed(static_cast<unsigned int>(seed_value));
     }
+    /// Constructor allowing to specify a seed.
     RandomNumberGenerator(unsigned int seed)
       : generator(seed), uniform_random(-1.0, 1.0), normal_random(0.0, 1.0) {}
+    /// Specify a new seed and reinitialize the random generation process.
     void seed(unsigned int value) {
       generator.seed(value);
       uniform_random.reset();
       normal_random.reset();
     }
+    /** Get a random number which probability of occurrence is uniformly
+     * distributed over the segment [-1;1( */
     double GetUniformRandomNumber(void) { return uniform_random(generator); }
+    /** Get a random number which probability of occurrence is following Gauss
+     * normal distribution with a mean of 0.0 and a standard deviation of 1.0 */
     double GetNormalRandomNumber(void) { return normal_random(generator); }
   private:
     std::default_random_engine generator;

--- a/src/input_output/FGXMLElement.cpp
+++ b/src/input_output/FGXMLElement.cpp
@@ -30,6 +30,7 @@ INCLUDES
 
 #include <sstream>  // for assembling the error messages / what of exceptions.
 #include <stdexcept>  // using domain_error, invalid_argument, and length_error.
+
 #include "FGXMLElement.h"
 #include "FGJSBBase.h"
 
@@ -670,20 +671,20 @@ double Element::DisperseValue(Element *e, double val, const std::string& supplie
     double disp = e->GetAttributeValueAsNumber("dispersion");
     if (!supplied_units.empty()) disp *= convert[supplied_units][target_units];
     string attType = e->GetAttributeValue("type");
+    RandomNumberGenerator generator;
+
     if (attType == "gaussian" || attType == "gaussiansigned") {
-      double grn = FGJSBBase::GaussianRandomNumber();
-    if (attType == "gaussian") {
-      value = val + disp*grn;
-      } else { // Assume gaussiansigned
-        value = (val + disp*grn)*(fabs(grn)/grn);
-      }
+      double grn = generator.GetNormalRandomNumber();
+      if (attType == "gaussian")
+        value = val + disp*grn;
+      else // Assume gaussiansigned
+        value = (val + disp*grn)*FGJSBBase::sign(grn);
     } else if (attType == "uniform" || attType == "uniformsigned") {
-      double urn = ((((double)rand()/RAND_MAX)-0.5)*2.0);
-      if (attType == "uniform") {
-      value = val + disp * urn;
-      } else { // Assume uniformsigned
-        value = (val + disp * urn)*(fabs(urn)/urn);
-      }
+      double urn = generator.GetUniformRandomNumber();
+      if (attType == "uniform")
+        value = val + disp * urn;
+      else // Assume uniformsigned
+        value = (val + disp * urn)*FGJSBBase::sign(urn);
     } else {
       std::stringstream s;
       s << ReadFrom() << "Unknown dispersion type" << attType;

--- a/src/input_output/FGXMLElement.cpp
+++ b/src/input_output/FGXMLElement.cpp
@@ -30,7 +30,6 @@ INCLUDES
 
 #include <sstream>  // for assembling the error messages / what of exceptions.
 #include <stdexcept>  // using domain_error, invalid_argument, and length_error.
-
 #include "FGXMLElement.h"
 #include "FGJSBBase.h"
 

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -290,11 +290,11 @@ void FGFunction::CheckOddOrEvenArguments(Element* el, OddEven odd_even)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-shared_ptr<RandomNumberGenerator> makeRandomEngine(Element *el, FGFDMExec* fdmex)
+shared_ptr<RandomNumberGenerator> makeRandomGenerator(Element *el, FGFDMExec* fdmex)
 {
   string seed_attr = el->GetAttributeValue("seed");
   if (seed_attr.empty())
-    return fdmex->GetRandomEngine();
+    return fdmex->GetRandomGenerator();
   else if (seed_attr == "time_now")
     return make_shared<RandomNumberGenerator>();
   else {
@@ -604,7 +604,7 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
         mean = atof(mean_attr.c_str());
       if (!stddev_attr.empty())
         stddev = atof(stddev_attr.c_str());
-      auto generator(makeRandomEngine(element, fdmex));
+      auto generator(makeRandomGenerator(element, fdmex));
       auto f = [generator, mean, stddev]()->double {
                  double value = generator->GetNormalRandomNumber();
                  return value*stddev + mean;
@@ -620,7 +620,7 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
         lower = atof(lower_attr.c_str());
       if (!upper_attr.empty())
         upper = atof(upper_attr.c_str());
-      auto generator(makeRandomEngine(element, fdmex));
+      auto generator(makeRandomGenerator(element, fdmex));
       double a = 0.5*(upper-lower);
       double b = 0.5*(upper+lower);
       auto f = [generator, a, b]()->double {

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -29,7 +29,6 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <iomanip>
-#include <chrono>
 #include <memory>
 
 #include "simgear/misc/strutils.hxx"
@@ -294,14 +293,14 @@ void FGFunction::CheckOddOrEvenArguments(Element* el, OddEven odd_even)
 shared_ptr<RandomNumberGenerator> makeRandomEngine(Element *el, FGFDMExec* fdmex)
 {
   string seed_attr = el->GetAttributeValue("seed");
-  unsigned int seed;
   if (seed_attr.empty())
     return fdmex->GetRandomEngine();
   else if (seed_attr == "time_now")
-    seed = chrono::system_clock::now().time_since_epoch().count();
-  else
-    seed = atoi(seed_attr.c_str());
-  return make_shared<RandomNumberGenerator>(seed);
+    return make_shared<RandomNumberGenerator>();
+  else {
+    unsigned int seed = atoi(seed_attr.c_str());
+    return make_shared<RandomNumberGenerator>(seed);
+  }
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -72,7 +72,7 @@ static inline double square_signed (double value)
 constexpr double sqr(double x) { return x*x; }
 
 FGWinds::FGWinds(FGFDMExec* fdmex)
-  : FGModel(fdmex), generator(fdmex->GetRandomEngine())
+  : FGModel(fdmex), generator(fdmex->GetRandomGenerator())
 {
   Name = "FGWinds";
 

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -72,8 +72,7 @@ static inline double square_signed (double value)
 constexpr double sqr(double x) { return x*x; }
 
 FGWinds::FGWinds(FGFDMExec* fdmex)
-  : FGModel(fdmex), generator(fdmex->GetRandomEngine()),
-    uniform_random(-1.0, 1.0), normal_random(0.0, 1.0)
+  : FGModel(fdmex), generator(fdmex->GetRandomEngine())
 {
   Name = "FGWinds";
 
@@ -215,7 +214,7 @@ void FGWinds::Turbulence(double h)
 
     double random = 0.0;
     if (target_time == 0.0) {
-      strength = random = uniform_random(*generator.get());
+      strength = random = generator->GetUniformRandomNumber();
       target_time = time + 0.71 + (random * 0.5);
     }
     if (time > target_time) {
@@ -301,10 +300,10 @@ void FGWinds::Turbulence(double h)
       tau_p = L_p/in.V, // eq. (9)
       tau_q = 4*b_w/M_PI/in.V, // eq. (13)
       tau_r =3*b_w/M_PI/in.V, // eq. (17)
-      nu_u = normal_random(*generator.get()),
-      nu_v = normal_random(*generator.get()),
-      nu_w = normal_random(*generator.get()),
-      nu_p = normal_random(*generator.get()),
+      nu_u = generator->GetNormalRandomNumber(),
+      nu_v = generator->GetNormalRandomNumber(),
+      nu_w = generator->GetNormalRandomNumber(),
+      nu_p = generator->GetNormalRandomNumber(),
       xi_u=0, xi_v=0, xi_w=0, xi_p=0, xi_q=0, xi_r=0;
 
     // values of turbulence NED velocities

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -71,7 +71,9 @@ static inline double square_signed (double value)
 /// simply square a value
 constexpr double sqr(double x) { return x*x; }
 
-FGWinds::FGWinds(FGFDMExec* fdmex) : FGModel(fdmex)
+FGWinds::FGWinds(FGFDMExec* fdmex)
+  : FGModel(fdmex), generator(fdmex->GetRandomEngine()),
+    uniform_random(-1.0, 1.0), normal_random(0.0, 1.0)
 {
   Name = "FGWinds";
 
@@ -213,7 +215,7 @@ void FGWinds::Turbulence(double h)
 
     double random = 0.0;
     if (target_time == 0.0) {
-      strength = random = 1 - 2.0*(double(rand())/double(RAND_MAX));
+      strength = random = uniform_random(*generator.get());
       target_time = time + 0.71 + (random * 0.5);
     }
     if (time > target_time) {
@@ -299,10 +301,10 @@ void FGWinds::Turbulence(double h)
       tau_p = L_p/in.V, // eq. (9)
       tau_q = 4*b_w/M_PI/in.V, // eq. (13)
       tau_r =3*b_w/M_PI/in.V, // eq. (17)
-      nu_u = GaussianRandomNumber(),
-      nu_v = GaussianRandomNumber(),
-      nu_w = GaussianRandomNumber(),
-      nu_p = GaussianRandomNumber(),
+      nu_u = normal_random(*generator.get()),
+      nu_v = normal_random(*generator.get()),
+      nu_w = normal_random(*generator.get()),
+      nu_p = normal_random(*generator.get()),
       xi_u=0, xi_v=0, xi_w=0, xi_p=0, xi_q=0, xi_r=0;
 
     // values of turbulence NED velocities

--- a/src/models/atmosphere/FGWinds.h
+++ b/src/models/atmosphere/FGWinds.h
@@ -38,8 +38,6 @@ SENTRY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <random>
-
 #include "models/FGModel.h"
 #include "math/FGMatrix33.h"
 
@@ -396,9 +394,7 @@ private:
   FGColumnVector3 vBurstGust;
   FGColumnVector3 vTurbulenceNED;
 
-  std::shared_ptr<std::default_random_engine> generator;
-  std::uniform_real_distribution<double> uniform_random;
-  std::normal_distribution<double> normal_random;
+  std::shared_ptr<RandomNumberGenerator> generator;
 
   void Turbulence(double h);
   void UpDownBurst();

--- a/src/models/atmosphere/FGWinds.h
+++ b/src/models/atmosphere/FGWinds.h
@@ -38,6 +38,8 @@ SENTRY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+#include <random>
+
 #include "models/FGModel.h"
 #include "math/FGMatrix33.h"
 
@@ -393,6 +395,10 @@ private:
   FGColumnVector3 vCosineGust;
   FGColumnVector3 vBurstGust;
   FGColumnVector3 vTurbulenceNED;
+
+  std::shared_ptr<std::default_random_engine> generator;
+  std::uniform_real_distribution<double> uniform_random;
+  std::normal_distribution<double> normal_random;
 
   void Turbulence(double h);
   void UpDownBurst();

--- a/src/models/flight_control/FGSensor.cpp
+++ b/src/models/flight_control/FGSensor.cpp
@@ -51,7 +51,7 @@ CLASS IMPLEMENTATION
 
 
 FGSensor::FGSensor(FGFCS* fcs, Element* element)
-  : FGFCSComponent(fcs, element), generator(fcs->GetExec()->GetRandomEngine())
+  : FGFCSComponent(fcs, element), generator(fcs->GetExec()->GetRandomGenerator())
 {
   // inputs are read from the base class constructor
 

--- a/src/models/flight_control/FGSensor.cpp
+++ b/src/models/flight_control/FGSensor.cpp
@@ -51,8 +51,7 @@ CLASS IMPLEMENTATION
 
 
 FGSensor::FGSensor(FGFCS* fcs, Element* element)
-  : FGFCSComponent(fcs, element), generator(fcs->GetExec()->GetRandomEngine()),
-    uniform_random(-1.0, 1.0), normal_random(0.0, 1.0)
+  : FGFCSComponent(fcs, element), generator(fcs->GetExec()->GetRandomEngine())
 {
   // inputs are read from the base class constructor
 
@@ -184,11 +183,10 @@ void FGSensor::Noise(void)
 {
   double random_value=0.0;
 
-  if (DistributionType == eUniform) {
-    random_value = uniform_random(*generator.get());
-  } else {
-    random_value = normal_random(*generator.get());
-  }
+  if (DistributionType == eUniform)
+    random_value = generator->GetUniformRandomNumber();
+  else
+    random_value = generator->GetNormalRandomNumber();
 
   switch( NoiseType ) {
   case ePercent:

--- a/src/models/flight_control/FGSensor.cpp
+++ b/src/models/flight_control/FGSensor.cpp
@@ -50,7 +50,9 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 
-FGSensor::FGSensor(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
+FGSensor::FGSensor(FGFCS* fcs, Element* element)
+  : FGFCSComponent(fcs, element), generator(fcs->GetExec()->GetRandomEngine()),
+    uniform_random(-1.0, 1.0), normal_random(0.0, 1.0)
 {
   // inputs are read from the base class constructor
 
@@ -183,9 +185,9 @@ void FGSensor::Noise(void)
   double random_value=0.0;
 
   if (DistributionType == eUniform) {
-    random_value = 2.0*(((double)rand()/(double)RAND_MAX) - 0.5);
+    random_value = uniform_random(*generator.get());
   } else {
-    random_value = GaussianRandomNumber();
+    random_value = normal_random(*generator.get());
   }
 
   switch( NoiseType ) {

--- a/src/models/flight_control/FGSensor.h
+++ b/src/models/flight_control/FGSensor.h
@@ -37,8 +37,6 @@ SENTRY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <random>
-
 #include "FGFCSComponent.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -180,9 +178,7 @@ protected:
   void bind(Element* el, FGPropertyManager* pm) override;
 
 private:
-  std::shared_ptr<std::default_random_engine> generator;
-  std::uniform_real_distribution<double> uniform_random;
-  std::normal_distribution<double> normal_random;
+  std::shared_ptr<RandomNumberGenerator> generator;
   void Debug(int from) override;
 };
 }

--- a/src/models/flight_control/FGSensor.h
+++ b/src/models/flight_control/FGSensor.h
@@ -37,6 +37,8 @@ SENTRY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+#include <random>
+
 #include "FGFCSComponent.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -178,6 +180,9 @@ protected:
   void bind(Element* el, FGPropertyManager* pm) override;
 
 private:
+  std::shared_ptr<std::default_random_engine> generator;
+  std::uniform_real_distribution<double> uniform_random;
+  std::normal_distribution<double> normal_random;
   void Debug(int from) override;
 };
 }

--- a/tests/unit_tests/FGJSBBaseTest.h
+++ b/tests/unit_tests/FGJSBBaseTest.h
@@ -37,10 +37,6 @@ public:
     Filter f0;
     Filter f(1.0, 1E-5);
     double x = f.execute(3.0);
-    // Called twice for 100% coverage
-    // Need to test that the numbers follow a Gaussian law ?
-    double ran0 = GaussianRandomNumber();
-    double ran1 = GaussianRandomNumber();
   }
 
   void testTemperatureConversion() {
@@ -67,5 +63,35 @@ public:
   void testMisc() {
     std::string version = GetVersion();
     disableHighLighting();
+  }
+
+  void testRandomNumberGenerator() {
+    JSBSim::RandomNumberGenerator generator(17);
+
+    double u0 = generator.GetUniformRandomNumber();
+    double u1 = generator.GetUniformRandomNumber();
+    double u2 = generator.GetUniformRandomNumber();
+
+    double x0 = generator.GetNormalRandomNumber();
+    double x1 = generator.GetNormalRandomNumber();
+    double x2 = generator.GetNormalRandomNumber();
+
+    // Check that the seed() method correctly resets the random number generator
+    generator.seed(17);
+    double v0 = generator.GetUniformRandomNumber();
+    double v1 = generator.GetUniformRandomNumber();
+    double v2 = generator.GetUniformRandomNumber();
+
+    double y0 = generator.GetNormalRandomNumber();
+    double y1 = generator.GetNormalRandomNumber();
+    double y2 = generator.GetNormalRandomNumber();
+
+    TS_ASSERT_EQUALS(u0, v0);
+    TS_ASSERT_EQUALS(u1, v1);
+    TS_ASSERT_EQUALS(u2, v2);
+
+    TS_ASSERT_EQUALS(x0, y0);
+    TS_ASSERT_EQUALS(x1, y1);
+    TS_ASSERT_EQUALS(x2, y2);
   }
 };


### PR DESCRIPTION
This PR addresses issue #666 and allows removing the static method `FGJSBBase::GaussianRandomNumber` and its static member `gaussian_random_number_phase`.

The method `FGJSBBase::GaussianRandomNumber` is replaced by the C++ standard library class `std::normal_distribution` and all the other calls to the system function `rand()` have been replaced by the C++ standard library class `std::uniform_real_distribution`. The purpose of that is to use the same random number generator for both the gaussian and uniform distributions.

A new class `JSBSim::RandomNumberGenerator` has been created to centralize the random seed value and make sure all the random generators in JSBSim are referring to the same instance of `RandomNumberGenerator` so that calling `FGFDMExec::Srand()` (or setting the property `simulation/randomseed`) has a global effect over JSBSim random number generation.

There are 2 exceptions to this behavior:
1. The method `FGFunction::makeRandomEngine` which allows using specific instances of `JSBSim::RandomNumberGenerator` at the explicit request of the user (i.e. when specifying either `time_now` or a value to the XML attribute `seed`).
2. The dispersion feature of `FGXMLElement` which is now using a local instance of `JSBSim::RandomNumberGenerator` which seed is based on the system clock. The purpose of the code is that the dispersion will change at each execution of a script (currently the dispersion is identical at each execution which kind of defeats the purpose of testing how some parameters dispersion influences the script results).