### PR TITLE
New unit tests

### DIFF
--- a/src/input_output/string_utilities.h
+++ b/src/input_output/string_utilities.h
@@ -44,9 +44,13 @@ INCLUDES
 #include <vector>
 #include <stdio.h>
 
+#include "JSBSim_API.h"
+
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+JSBSIM_API bool is_number(const std::string& str);
 
 #if !defined(BASE)
   extern std::string& trim_left(std::string& str);
@@ -55,7 +59,6 @@ CLASS DECLARATION
   extern std::string& trim_all_space(std::string& str);
   extern std::string& to_upper(std::string& str);
   extern std::string& to_lower(std::string& str);
-  extern bool is_number(const std::string& str);
   std::vector <std::string> split(std::string str, char d);
 
   extern std::string replace(std::string str, const std::string& old, const std::string& newstr);

--- a/src/math/FGCondition.h
+++ b/src/math/FGCondition.h
@@ -63,7 +63,7 @@ CLASS DOCUMENTATION
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class FGCondition : public FGJSBBase
+class JSBSIM_API FGCondition : public FGJSBBase
 {
 public:
   FGCondition(Element* element, std::shared_ptr<FGPropertyManager> PropertyManager);

--- a/src/math/FGParameterValue.h
+++ b/src/math/FGParameterValue.h
@@ -73,7 +73,7 @@ public:
            << "The element <" << el->GetName()
            << "> must either contain a value number or a property name."
            << endl;
-      throw invalid_argument("FGParameterValue: Illegal argument defining: " + el->GetName());
+      throw BaseException("FGParameterValue: Illegal argument defining: " + el->GetName());
     }
   }
 
@@ -95,7 +95,7 @@ public:
     if (v)
       return v->GetNameWithSign();
     else
-      return to_string(param->GetValue());
+      return param->GetName();
   }
 
   bool IsLateBound(void) const {

--- a/src/math/FGParameterValue.h
+++ b/src/math/FGParameterValue.h
@@ -60,7 +60,7 @@ class FGPropertyManager;
   DECLARATION: FGParameterValue
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class FGParameterValue : public FGParameter
+class JSBSIM_API FGParameterValue : public FGParameter
 {
 public:
   FGParameterValue(Element* el, std::shared_ptr<FGPropertyManager> pm)

--- a/src/math/FGPropertyValue.cpp
+++ b/src/math/FGPropertyValue.cpp
@@ -62,11 +62,11 @@ FGPropertyNode* FGPropertyValue::GetNode(void) const
   // Manage late binding.
   PropertyNode = PropertyManager->GetNode(PropertyName);
   if (!PropertyNode) {
-    if (!XML_def)
-      cerr << XML_def->ReadFrom() 
+    if (XML_def)
+      cerr << XML_def->ReadFrom()
            << "Property " << PropertyName << " does not exist" << endl;
-    throw(std::string("FGPropertyValue::GetValue() The property " +
-                      PropertyName + " does not exist."));
+    throw BaseException("FGPropertyValue::GetValue() The property " +
+                        PropertyName + " does not exist.");
   }
 
   XML_def = nullptr; // Now that the property is bound, we no longer need that.

--- a/src/math/FGRealValue.h
+++ b/src/math/FGRealValue.h
@@ -54,7 +54,7 @@ CLASS DOCUMENTATION
 DECLARATION: FGRealValue
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class FGRealValue : public FGParameter
+class JSBSIM_API FGRealValue : public FGParameter
 {
 public:
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -12,7 +12,10 @@ set(UNIT_TESTS FGColumnVector3Test
                FGInitialConditionTest
                FGInertialTest
                FGPropertyValueTest
-               FGTableTest)
+               FGTableTest
+               FGRealValueTest
+               FGParameterTest
+               FGParameterValueTest)
 
 foreach(test ${UNIT_TESTS})
   cxxtest_add_test(${test}1 ${test}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${test}.h)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -15,7 +15,8 @@ set(UNIT_TESTS FGColumnVector3Test
                FGTableTest
                FGRealValueTest
                FGParameterTest
-               FGParameterValueTest)
+               FGParameterValueTest
+               FGConditionTest)
 
 foreach(test ${UNIT_TESTS})
   cxxtest_add_test(${test}1 ${test}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${test}.h)

--- a/tests/unit_tests/FGConditionTest.h
+++ b/tests/unit_tests/FGConditionTest.h
@@ -1,0 +1,459 @@
+#include <array>
+
+#include <cxxtest/TestSuite.h>
+#include <math/FGCondition.h>
+#include "TestUtilities.h"
+
+using namespace JSBSim;
+
+
+class FGConditionTest : public CxxTest::TestSuite
+{
+public:
+  void testEqualConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> XML{"<dummy> x == 1.0 </dummy>",
+                                "<dummy> x EQ 1.0 </dummy>",
+                                "<dummy> x eq 1.0 </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testNotEqualConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> XML{"<dummy> x != 1.0 </dummy>",
+                                "<dummy> x NE 1.0 </dummy>",
+                                "<dummy> x ne 1.0 </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testGreaterThanConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> XML{"<dummy> x &gt; 1.0 </dummy>",
+                                "<dummy> x GT 1.0 </dummy>",
+                                "<dummy> x gt 1.0 </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testGreaterOrEqualConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> XML{"<dummy> x &gt;= 1.0 </dummy>",
+                                "<dummy> x GE 1.0 </dummy>",
+                                "<dummy> x ge 1.0 </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testLowerThanConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> XML{"<dummy> x &lt; 1.0 </dummy>",
+                                "<dummy> x LT 1.0 </dummy>",
+                                "<dummy> x lt 1.0 </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testLowerOrEqualConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> XML{"<dummy> x &lt;= 1.0 </dummy>",
+                                "<dummy> x LE 1.0 </dummy>",
+                                "<dummy> x le 1.0 </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testEqualProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> XML{"<dummy> x == y </dummy>",
+                                "<dummy> x EQ y </dummy>",
+                                "<dummy> x eq y </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testNotEqualProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> XML{"<dummy> x != y </dummy>",
+                                "<dummy> x NE y </dummy>",
+                                "<dummy> x ne y </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testGreaterThanProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> XML{"<dummy> x &gt; y </dummy>",
+                                "<dummy> x GT y </dummy>",
+                                "<dummy> x gt y </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(-1.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testGreaterOrEqualProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> XML{"<dummy> x &gt;= y </dummy>",
+                                "<dummy> x GE y </dummy>",
+                                "<dummy> x ge y </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(-1.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testLowerThanProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> XML{"<dummy> x &lt; y </dummy>",
+                                "<dummy> x LT y </dummy>",
+                                "<dummy> x lt y </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(-1.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testLowerOrEqualProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> XML{"<dummy> x &lt;= y </dummy>",
+                                "<dummy> x LE y </dummy>",
+                                "<dummy> x le y </dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      x->setDoubleValue(-1.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testAND() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto onoff = pm->GetNode("on-off", true);
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 2> XML{"<dummy> on-off == 1\nx GE y</dummy>",
+                                "<dummy logic=\"AND\"> on-off == 1\nx GE y</dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      onoff->setDoubleValue(0.0);
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      onoff->setDoubleValue(1.0);
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+
+      y->setDoubleValue(3.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testANDLateBound() {
+    auto pm = make_shared<FGPropertyManager>();
+    const array<string, 2> XML{"<dummy> on-off == 1\nx GE y</dummy>",
+                                "<dummy logic=\"AND\"> on-off == 1\nx GE y</dummy>"};
+    for(const string& line: XML) {
+      Element_ptr elm = readFromXML(line);
+      FGCondition cond(elm, pm);
+
+      auto onoff = pm->GetNode("on-off", true);
+      auto x = pm->GetNode("x", true);
+      auto y = pm->GetNode("y", true);
+
+      onoff->setDoubleValue(0.0);
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      onoff->setDoubleValue(1.0);
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+
+      y->setDoubleValue(3.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testOR() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto onoff = pm->GetNode("on-off", true);
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    Element_ptr elm = readFromXML("<dummy logic=\"OR\">"
+                                  "on-off == 1\n"
+                                  "x GE y"
+                                  "</dummy>");
+    FGCondition cond(elm, pm);
+
+    onoff->setDoubleValue(0.0);
+    x->setDoubleValue(0.0);
+    y->setDoubleValue(1.0);
+    TS_ASSERT(!cond.Evaluate());
+
+    x->setDoubleValue(2.0);
+    TS_ASSERT(cond.Evaluate());
+
+    y->setDoubleValue(3.0);
+    TS_ASSERT(!cond.Evaluate());
+
+    onoff->setDoubleValue(1.0);
+    x->setDoubleValue(4.0);
+    TS_ASSERT(cond.Evaluate());
+
+    x->setDoubleValue(2.0);
+    TS_ASSERT(cond.Evaluate());
+  }
+
+  void testNested() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto onoff = pm->GetNode("on-off", true);
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  on-off == 1"
+                                  "  <dummy logic=\"AND\">"
+                                  "    x GE y\n"
+                                  "    x LT 2.0"
+                                  "  </dummy>"
+                                  "</dummy>");
+    FGCondition cond(elm, pm);
+
+    onoff->setDoubleValue(0.0);
+    x->setDoubleValue(0.0);
+    y->setDoubleValue(1.0);
+    TS_ASSERT(!cond.Evaluate());
+
+    x->setDoubleValue(1.5);
+    TS_ASSERT(!cond.Evaluate());
+
+    x->setDoubleValue(3.0);
+    TS_ASSERT(!cond.Evaluate());
+
+    onoff->setDoubleValue(1.0);
+    x->setDoubleValue(0.0);
+    TS_ASSERT(!cond.Evaluate());
+
+    y->setDoubleValue(-1.0);
+    TS_ASSERT(cond.Evaluate());
+
+    x->setDoubleValue(3.0);
+    TS_ASSERT(!cond.Evaluate());
+  }
+
+  void testIllegalLOGIC() {
+    auto pm = make_shared<FGPropertyManager>();
+    Element_ptr elm = readFromXML("<dummy logic=\"XOR\">"
+                                  "  on-off == 1\n"
+                                  "  x GE y"
+                                  "</dummy>");
+    TS_ASSERT_THROWS(FGCondition cond(elm, pm), BaseException&);
+  }
+
+  void testWrongNumberOfElements() {
+    auto pm = make_shared<FGPropertyManager>();
+    Element_ptr elm = readFromXML("<dummy> on-off == </dummy>");
+    TS_ASSERT_THROWS(FGCondition cond(elm, pm), BaseException&);
+
+    elm = readFromXML("<dummy> on-off </dummy>");
+    TS_ASSERT_THROWS(FGCondition cond(elm, pm), BaseException&);
+
+    elm = readFromXML("<dummy/>");
+    TS_ASSERT_THROWS(FGCondition cond(elm, pm), BaseException&);
+
+    elm = readFromXML("<dummy> 0.0 LE on-off GE 1.0 </dummy>");
+    TS_ASSERT_THROWS(FGCondition cond(elm, pm), BaseException&);
+  }
+
+  void testIllegalNested() {
+    auto pm = make_shared<FGPropertyManager>();
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  on-off == 1"
+                                  "  <crash logic=\"AND\">"
+                                  "    x GE y\n"
+                                  "    x LT 2.0"
+                                  "  </crash>"
+                                  "</dummy>");
+    TS_ASSERT_THROWS(FGCondition cond(elm, pm), BaseException&);
+  }
+
+  void testIllegalOperation() {
+    auto pm = make_shared<FGPropertyManager>();
+    Element_ptr elm = readFromXML("<dummy> on-off # 0.0 </dummy>");
+    TS_ASSERT_THROWS(FGCondition cond(elm, pm), BaseException&);
+  }
+};

--- a/tests/unit_tests/FGParameterTest.h
+++ b/tests/unit_tests/FGParameterTest.h
@@ -1,0 +1,52 @@
+#include <cxxtest/TestSuite.h>
+#include <math/FGParameter.h>
+
+using namespace JSBSim;
+
+
+// Dummy class that inherits the abstract class `FGParameter`.
+class FGDummy : public FGParameter
+{
+public:
+  FGDummy(void) : count(0) {}
+  double GetValue(void) const { return count++; }
+  std::string GetName(void) const { return "Counting..."; }
+private:
+  mutable unsigned int count;
+};
+
+class FGParameterTest : public CxxTest::TestSuite
+{
+public:
+  void testConstructor() {
+    FGDummy x;
+
+    TS_ASSERT(!x.IsConstant());
+    TS_ASSERT_EQUALS(x.GetValue(), 0.0);
+    TS_ASSERT_EQUALS(x.getDoubleValue(), 1.0);
+    TS_ASSERT_EQUALS(x.GetName(), "Counting...");
+  }
+
+  void testCopyConstructor() {
+    FGDummy x;
+    TS_ASSERT_EQUALS(x.GetValue(), 0.0);
+
+    FGDummy y(x);
+    TS_ASSERT_EQUALS(x.GetValue(), 1.0);
+    TS_ASSERT_EQUALS(x.getDoubleValue(), 2.0);
+    TS_ASSERT(!x.IsConstant());
+
+    TS_ASSERT(!y.IsConstant());
+    TS_ASSERT_EQUALS(y.GetValue(), 1.0);
+    TS_ASSERT_EQUALS(y.GetName(), "Counting...");
+    TS_ASSERT_EQUALS(x.GetValue(), 3.0);
+  }
+
+  void testOperators() {
+    SGSharedPtr<FGDummy> px(new FGDummy);
+
+    TS_ASSERT_EQUALS(px*2.0, 0.0);
+    TS_ASSERT_EQUALS(-3.0*px, -3.0);
+    TS_ASSERT_EQUALS(px*2.0, 4.0);
+  }
+};

--- a/tests/unit_tests/FGParameterValueTest.h
+++ b/tests/unit_tests/FGParameterValueTest.h
@@ -1,0 +1,128 @@
+#include <cxxtest/TestSuite.h>
+#include <math/FGParameterValue.h>
+#include "TestUtilities.h"
+
+using namespace JSBSim;
+
+
+class FGParameterValueTest : public CxxTest::TestSuite
+{
+public:
+  void testRealConstructor() {
+    auto pm = make_shared<FGPropertyManager>();
+    FGParameterValue x("1.2", pm, nullptr);
+
+    TS_ASSERT(x.IsConstant());
+    TS_ASSERT(!x.IsLateBound());
+    TS_ASSERT_EQUALS(x.GetValue(), 1.2);
+    TS_ASSERT_EQUALS(x.GetName(), "constant value 1.200000");
+  }
+
+  void testPropertyConstructor() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto node = pm->GetNode("x", true);
+    FGParameterValue x("x", pm, nullptr);
+
+    TS_ASSERT(!x.IsConstant());
+    TS_ASSERT(!x.IsLateBound());
+    TS_ASSERT_EQUALS(x.GetName(), "x");
+
+    node->setDoubleValue(0.0);
+    TS_ASSERT_EQUALS(x.GetValue(), 0.0);
+    node->setDoubleValue(1.2);
+    TS_ASSERT_EQUALS(x.GetValue(), 1.2);
+  }
+
+  void testLateBoundPropertyConstructor() {
+    auto pm = make_shared<FGPropertyManager>();
+    FGParameterValue x("x", pm, nullptr);
+
+    TS_ASSERT(!x.IsConstant());
+    TS_ASSERT(x.IsLateBound());
+    TS_ASSERT_EQUALS(x.GetName(), "x");
+
+    auto node = pm->GetNode("x", true);
+    node->setDoubleValue(0.0);
+    TS_ASSERT_EQUALS(x.GetValue(), 0.0);
+    TS_ASSERT(!x.IsLateBound());
+    node->setDoubleValue(1.2);
+    TS_ASSERT_EQUALS(x.GetValue(), 1.2);
+  }
+
+  void testLateBoundPropertyIllegalAccess() {
+    auto pm = make_shared<FGPropertyManager>();
+    FGParameterValue x("x", pm, nullptr);
+
+    TS_ASSERT(!x.IsConstant());
+    TS_ASSERT(x.IsLateBound());
+    TS_ASSERT_EQUALS(x.GetName(), "x");
+    TS_ASSERT_THROWS(x.GetValue(), BaseException&);
+  }
+
+  void testXMLRealConstructor() {
+    auto pm = make_shared<FGPropertyManager>();
+    Element_ptr elm = readFromXML("<dummy> 1.2 </dummy>");
+    FGParameterValue x(elm, pm);
+
+    TS_ASSERT(x.IsConstant());
+    TS_ASSERT(!x.IsLateBound());
+    TS_ASSERT_EQUALS(x.GetValue(), 1.2);
+    TS_ASSERT_EQUALS(x.GetName(), "constant value 1.200000");
+  }
+
+  void testXMLPropertyConstructor() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto node = pm->GetNode("x", true);
+    Element_ptr elm = readFromXML("<dummy> x </dummy>");
+    FGParameterValue x(elm, pm);
+
+    TS_ASSERT(!x.IsConstant());
+    TS_ASSERT(!x.IsLateBound());
+    TS_ASSERT_EQUALS(x.GetName(), "x");
+
+    node->setDoubleValue(0.0);
+    TS_ASSERT_EQUALS(x.GetValue(), 0.0);
+    node->setDoubleValue(1.2);
+    TS_ASSERT_EQUALS(x.GetValue(), 1.2);
+  }
+
+  void testXMLLateBoundPropertyConstructor() {
+    auto pm = make_shared<FGPropertyManager>();
+    Element_ptr elm = readFromXML("<dummy> x </dummy>");
+    FGParameterValue x(elm, pm);
+
+    TS_ASSERT(!x.IsConstant());
+    TS_ASSERT(x.IsLateBound());
+    TS_ASSERT_EQUALS(x.GetName(), "x");
+
+    auto node = pm->GetNode("x", true);
+    node->setDoubleValue(0.0);
+    TS_ASSERT_EQUALS(x.GetValue(), 0.0);
+    TS_ASSERT(!x.IsLateBound());
+    node->setDoubleValue(1.2);
+    TS_ASSERT_EQUALS(x.GetValue(), 1.2);
+  }
+
+  void testXMLLateBoundPropertyIllegalAccess() {
+    auto pm = make_shared<FGPropertyManager>();
+    Element_ptr elm = readFromXML("<dummy> x </dummy>");
+    FGParameterValue x(elm, pm);
+
+    TS_ASSERT(!x.IsConstant());
+    TS_ASSERT(x.IsLateBound());
+    TS_ASSERT_EQUALS(x.GetName(), "x");
+    TS_ASSERT_THROWS(x.GetValue(), BaseException&);
+  }
+
+  void testXMLEmptyNameConstructor() {
+    auto pm = make_shared<FGPropertyManager>();
+    Element_ptr elm = readFromXML("<dummy/>");
+    TS_ASSERT_THROWS(FGParameterValue x(elm, pm), BaseException&);
+  }
+
+  void testXMLMultiLinesConstructor() {
+    auto pm = make_shared<FGPropertyManager>();
+    Element_ptr elm = readFromXML("<dummy>x\ny</dummy>");
+    TS_ASSERT_THROWS(FGParameterValue x(elm, pm), BaseException&);
+  }
+};

--- a/tests/unit_tests/FGPropertyValueTest.h
+++ b/tests/unit_tests/FGPropertyValueTest.h
@@ -66,6 +66,9 @@ public:
     TS_ASSERT_EQUALS(property.GetPrintableName(), std::string("x"));
     TS_ASSERT_EQUALS(property.IsConstant(), false);
     TS_ASSERT_EQUALS(property.IsLateBound(), true);
+    // The property manager does not contain the property "x" so GetValue()
+    // should throw an exception.
+    TS_ASSERT_THROWS(property.GetValue(), BaseException&);
   }
 
   void testInstantiateLateBound() {

--- a/tests/unit_tests/FGRealValueTest.h
+++ b/tests/unit_tests/FGRealValueTest.h
@@ -1,0 +1,17 @@
+#include <cxxtest/TestSuite.h>
+#include <math/FGRealValue.h>
+
+using namespace JSBSim;
+
+
+class FGRealValueTest : public CxxTest::TestSuite
+{
+public:
+  void testConstructor() {
+    FGRealValue x(1.0);
+
+    TS_ASSERT_EQUALS(x.GetValue(), 1.0);
+    TS_ASSERT_EQUALS(x.GetName(), "constant value 1.000000");
+    TS_ASSERT(x.IsConstant());
+  }
+};

--- a/tests/unit_tests/FGTableTest.h
+++ b/tests/unit_tests/FGTableTest.h
@@ -3,19 +3,11 @@
 
 #include <cxxtest/TestSuite.h>
 #include <math/FGTable.h>
-#include <input_output/FGXMLParse.h>
+#include "TestUtilities.h"
 
 const double epsilon = 100. * std::numeric_limits<double>::epsilon();
 
 using namespace JSBSim;
-
-
-Element_ptr readFromXML(const std::string& XML) {
-  std::istringstream data(XML);
-  FGXMLParse parser;
-  readXML(data, parser);
-  return parser.GetDocument();
-}
 
 
 class FGTable1DTest : public CxxTest::TestSuite
@@ -25,10 +17,12 @@ public:
     FGTable t1(1);
     TS_ASSERT_EQUALS(t1.GetNumRows(), 1);
     TS_ASSERT_EQUALS(t1.GetName(), std::string(""));
+    TS_ASSERT(!t1.IsConstant());
 
     FGTable t2(2);
     TS_ASSERT_EQUALS(t2.GetNumRows(), 2);
     TS_ASSERT_EQUALS(t2.GetName(), std::string(""));
+    TS_ASSERT(!t2.IsConstant());
   }
 
   void testPopulateAndGetElement() {
@@ -56,6 +50,7 @@ public:
     FGTable t(2);
     t << 1.0 << -1.0
       << 2.0 << 1.5;
+    TS_ASSERT(!t.IsConstant());
 
     FGTable t2(t);
     TS_ASSERT_EQUALS(t2.GetNumRows(), 2);
@@ -63,15 +58,18 @@ public:
     TS_ASSERT_EQUALS(t2.GetElement(1,1), -1.0);
     TS_ASSERT_EQUALS(t2.GetElement(2,0), 2.0);
     TS_ASSERT_EQUALS(t2.GetElement(2,1), 1.5);
+    TS_ASSERT(!t2.IsConstant());
 
     // Check that the data of the 2 tables is independent.
     FGTable temp(2);
     temp << 1.0 << -1.0;
+    TS_ASSERT(!temp.IsConstant());
 
     FGTable temp2(temp);
     // Alter the data of the 2 tables *after* the copy.
     temp << 2.0 << 1.5;
     temp2 << 2.5 << -3.2;
+    TS_ASSERT(!temp2.IsConstant());
 
     TS_ASSERT_EQUALS(temp.GetNumRows(), 2);
     TS_ASSERT_EQUALS(temp.GetElement(1,0), 1.0);
@@ -356,18 +354,22 @@ public:
     FGTable t_1x1(1,1);
     TS_ASSERT_EQUALS(t_1x1.GetNumRows(), 1);
     TS_ASSERT_EQUALS(t_1x1.GetName(), std::string(""));
+    TS_ASSERT(!t_1x1.IsConstant());
 
     FGTable t_2x1(2,1);
     TS_ASSERT_EQUALS(t_2x1.GetNumRows(), 2);
     TS_ASSERT_EQUALS(t_2x1.GetName(), std::string(""));
+    TS_ASSERT(!t_2x1.IsConstant());
 
     FGTable t_1x2(1,2);
     TS_ASSERT_EQUALS(t_1x2.GetNumRows(), 1);
     TS_ASSERT_EQUALS(t_1x2.GetName(), std::string(""));
+    TS_ASSERT(!t_1x2.IsConstant());
 
     FGTable t_2x2(2,2);
     TS_ASSERT_EQUALS(t_2x2.GetNumRows(), 2);
     TS_ASSERT_EQUALS(t_2x2.GetName(), std::string(""));
+    TS_ASSERT(!t_2x2.IsConstant());
   }
 
   void testPopulateAndGetElement() {
@@ -437,6 +439,7 @@ public:
     temp0 << 0.0 << 1.0
           << 2.0 << 3.0 << -1.0
           << 4.0 << -0.5 << 0.3;
+    TS_ASSERT(!temp0.IsConstant());
 
     FGTable t_2x2(temp0);
     TS_ASSERT_EQUALS(t_2x2.GetNumRows(), 2);
@@ -449,6 +452,7 @@ public:
     TS_ASSERT_EQUALS(t_2x2(2,0), 4.0);
     TS_ASSERT_EQUALS(t_2x2(2,1), -0.5);
     TS_ASSERT_EQUALS(t_2x2(2,2), 0.3);
+    TS_ASSERT(!t_2x2.IsConstant());
 
     FGTable temp1(2,2);
     temp1 << 0.0 << 1.0
@@ -462,6 +466,7 @@ public:
     TS_ASSERT_EQUALS(temp1(2,0), 10.0);
     TS_ASSERT_EQUALS(temp1(2,1), 11.0);
     TS_ASSERT_EQUALS(temp1(2,2), -12.0);
+    TS_ASSERT(!temp1.IsConstant());
 
     TS_ASSERT_EQUALS(t2.GetNumRows(), 2);
     TS_ASSERT_EQUALS(t2.GetName(), std::string(""));
@@ -473,6 +478,7 @@ public:
     TS_ASSERT_EQUALS(t2(2,0), 4.0);
     TS_ASSERT_EQUALS(t2(2,1), -0.5);
     TS_ASSERT_EQUALS(t2(2,2), 0.3);
+    TS_ASSERT(!t2.IsConstant());
   }
 
   void testGetValue() {
@@ -1182,6 +1188,7 @@ public:
     // Check breakpoints value
     TS_ASSERT_EQUALS(t_2x2x2(1,1), -1.0);
     TS_ASSERT_EQUALS(t_2x2x2(2,1), 0.5);
+    TS_ASSERT(!t_2x2x2.IsConstant());
 
     // Check the table values.
     TS_ASSERT_EQUALS(t_2x2x2.GetValue(2.0, 0.0, -1.0), 3.0);
@@ -1288,6 +1295,75 @@ public:
     TS_ASSERT_EQUALS(t_2x2x2.GetValue(), -1.5);
     TS_ASSERT_EQUALS(output->getDoubleValue(), -1.5);
   }
+
+  void testCopyConstructor() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto row = pm->GetNode("x", true);
+    auto column = pm->GetNode("y", true);
+    auto table = pm->GetNode("z", true);
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  <table name=\"test2\">"
+                                  "    <independentVar lookup=\"row\">x</independentVar>"
+                                  "    <independentVar lookup=\"column\">y</independentVar>"
+                                  "    <independentVar lookup=\"table\">z</independentVar>"
+                                  "    <tableData breakPoint=\"-1.0\">"
+                                  "            0.0  1.0\n"
+                                  "      2.0   3.0 -2.0\n"
+                                  "      4.0  -1.0  0.5\n"
+                                  "    </tableData>"
+                                  "    <tableData breakPoint=\"0.5\">"
+                                  "            0.5  1.5\n"
+                                  "      2.5   3.5 -2.5\n"
+                                  "      4.5  -1.5  1.0\n"
+                                  "    </tableData>"
+                                  "  </table>"
+                                  "</dummy>");
+    Element* el_table = elm->FindElement("table");
+    auto ref = std::make_unique<FGTable>(pm, el_table);
+    TS_ASSERT(!ref->IsConstant());
+    // Check that the property "test2" is now bound to the property manager
+    TS_ASSERT(pm->HasNode("test2"));
+    auto output = pm->GetNode("test2");
+
+    table->setDoubleValue(-1.0);
+    row->setDoubleValue(2.5);
+    column->setDoubleValue(0.5);
+    TS_ASSERT_EQUALS(ref->GetValue(), 0.3125);
+    TS_ASSERT_EQUALS(output->getDoubleValue(), 0.3125);
+
+    FGTable t_2x2x2(*ref.get());
+    // Delete the original table to make sure that `t_2x2x2` does not make use
+    // of any of `ref` data.
+    ref.reset();
+
+    TS_ASSERT_EQUALS(t_2x2x2.GetNumRows(), 2);
+    TS_ASSERT_EQUALS(t_2x2x2.GetName(), std::string("test2"));
+    TS_ASSERT(!t_2x2x2.IsConstant());
+    // Check breakpoints value
+    TS_ASSERT_EQUALS(t_2x2x2(1,1), -1.0);
+    TS_ASSERT_EQUALS(t_2x2x2(2,1), 0.5);
+
+    // Check the table values.
+    TS_ASSERT_EQUALS(t_2x2x2.GetValue(2.0, 0.0, -1.0), 3.0);
+    TS_ASSERT_EQUALS(t_2x2x2.GetValue(4.0, 0.0, -1.0), -1.0);
+    TS_ASSERT_EQUALS(t_2x2x2.GetValue(2.0, 1.0, -1.0), -2.0);
+    TS_ASSERT_EQUALS(t_2x2x2.GetValue(4.0, 1.0, -1.0), 0.5);
+    TS_ASSERT_EQUALS(t_2x2x2.GetValue(2.5, 0.5, 0.5), 3.5);
+    TS_ASSERT_EQUALS(t_2x2x2.GetValue(4.5, 0.5, 0.5), -1.5);
+    TS_ASSERT_EQUALS(t_2x2x2.GetValue(2.5, 1.5, 0.5), -2.5);
+    TS_ASSERT_EQUALS(t_2x2x2.GetValue(4.5, 1.5, 0.5), 1.0);
+
+    table->setDoubleValue(0.5);
+    row->setDoubleValue(4.0);
+    column->setDoubleValue(1.0);
+    TS_ASSERT_EQUALS(t_2x2x2.GetValue(), -0.0625);
+
+    // Check that the property `test2` has remained unchanged since the table
+    // `ref` was destroyed.
+    TS_ASSERT_EQUALS(output->getDoubleValue(), 0.3125);
+  }
 };
 
 
@@ -1331,6 +1407,63 @@ public:
     TS_ASSERT_THROWS(FGTable t_2x2(pm, el_table), BaseException&);
   }
 
+  void testMalformedData() {
+    auto pm = make_shared<FGPropertyManager>();
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  <table name=\"test\" type=\"internal\">"
+                                  "    <tableData>"
+                                  "      1.0/ -1.0\n"
+                                  "      2.0  1.5\n"
+                                  "    </tableData>"
+                                  "  </table>"
+                                  "</dummy>");
+    Element* el_table = elm->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_2x1(pm, el_table), BaseException&);
+  }
+
+  void testPropertyAlreadyTied() {
+    auto pm = make_shared<FGPropertyManager>();
+    static double value = 0;
+    pm->Tie("test", &value);
+
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  <table name=\"test\">"
+                                  "    <independentVar>x</independentVar>"
+                                  "    <tableData>"
+                                  "      1.0 -1.0\n"
+                                  "      2.0  1.5\n"
+                                  "    </tableData>"
+                                  "  </table>"
+                                  "</dummy>");
+    Element* el_table = elm->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_2x1(pm, el_table), BaseException&);
+  }
+
+  void testExtraPrefix() {
+    auto pm = make_shared<FGPropertyManager>();
+
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  <table name=\"test\">"
+                                  "    <independentVar>x</independentVar>"
+                                  "    <tableData>"
+                                  "      1.0 -1.0\n"
+                                  "      2.0  1.5\n"
+                                  "    </tableData>"
+                                  "  </table>"
+                                  "</dummy>");
+    Element* el_table = elm->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_2x1(pm, el_table, "0"), BaseException&);
+  }
+
   void test1DInternalMissingTableData() {
     auto pm = make_shared<FGPropertyManager>();
     // FGTable expects <table> to be the child of another XML element, hence the
@@ -1344,18 +1477,53 @@ public:
     TS_ASSERT_THROWS(FGTable t_2x1(pm, el_table), BaseException&);
   }
 
-  void test1DMissingTableData() {
+  void test1DInternalEmptyTableData() {
     auto pm = make_shared<FGPropertyManager>();
     // FGTable expects <table> to be the child of another XML element, hence the
     // <dummy> element.
     Element_ptr elm = readFromXML("<dummy>"
                                   "  <table name=\"test\" type=\"internal\">"
+                                  "    <tableData/>"
+                                  "  </table>"
+                                  "</dummy>");
+    Element* el_table = elm->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_2x1(pm, el_table), BaseException&);
+  }
+
+  void test1DMissingTableData() {
+    auto pm = make_shared<FGPropertyManager>();
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  <table name=\"test\">"
                                   "    <independentVar>x</independentVar>"
                                   "  </table>"
                                   "</dummy>");
     Element* el_table = elm->FindElement("table");
 
     TS_ASSERT_THROWS(FGTable t_2x1(pm, el_table), BaseException&);
+  }
+
+  void test1DEmptyTableData() {
+    auto pm = make_shared<FGPropertyManager>();
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  <table name=\"test\">"
+                                  "    <independentVar>x</independentVar>"
+                                  "    <tableData/>"
+                                  "  </table>"
+                                  "</dummy>");
+    Element* el_table = elm->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_2x1(pm, el_table), BaseException&);
+  }
+
+  void test1DRowsNotIncreasing() {
+    FGTable t(2);
+    t << 1.0 << -1.0;
+    TS_ASSERT_THROWS(t << 1.0, BaseException&);
   }
 
   void test1DMissingLookupAxis() {
@@ -1419,6 +1587,36 @@ public:
     el_table = elm2->FindElement("table");
 
     TS_ASSERT_THROWS(FGTable t_1x2(pm, el_table), BaseException&);
+
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm3 = readFromXML("<dummy>"
+                                  "  <table name=\"test2\" type=\"internal\">"
+                                  "    <tableData>"
+                                  "      1.0 -1.0\n"
+                                  "      2.0  1.5\n"
+                                  "      3.0  0.0 4.0\n"
+                                  "    </tableData>"
+                                  "  </table>"
+                                  "</dummy>");
+    el_table = elm3->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_3x1(pm, el_table), BaseException&);
+
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm4 = readFromXML("<dummy>"
+                                  "  <table name=\"test2\" type=\"internal\">"
+                                  "    <tableData>"
+                                  "      1.0 -1.0  2.3\n"
+                                  "      2.0  1.5 -7.1\n"
+                                  "      3.0  0.0  4.0\n"
+                                  "    </tableData>"
+                                  "  </table>"
+                                  "</dummy>");
+    el_table = elm4->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_3x2(pm, el_table), BaseException&);
   }
 
   void test2DMissingColumnLookupAxis1() {
@@ -1478,7 +1676,7 @@ public:
     TS_ASSERT_THROWS(FGTable t_2x2(pm, el_table), BaseException&);
   }
 
-  void test2DMissingData() {
+  void test2DMissingTableData() {
     auto pm = make_shared<FGPropertyManager>();
     // FGTable expects <table> to be the child of another XML element, hence the
     // <dummy> element.
@@ -1493,10 +1691,20 @@ public:
     TS_ASSERT_THROWS(FGTable t_2x2(pm, el_table), BaseException&);
   }
 
-  void test1DRowsNotIncreasing() {
-    FGTable t(2);
-    t << 1.0 << -1.0;
-    TS_ASSERT_THROWS(t << 1.0, BaseException&);
+  void test2DEmptyTableData() {
+    auto pm = make_shared<FGPropertyManager>();
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  <table name=\"test\">"
+                                  "    <independentVar lookup=\"row\">x</independentVar>"
+                                  "    <independentVar lookup=\"column\">y</independentVar>"
+                                  "    <tableData/>"
+                                  "  </table>"
+                                  "</dummy>");
+    Element* el_table = elm->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_2x2(pm, el_table), BaseException&);
   }
 
   void test2DColumnsNotIncreasing() {
@@ -1650,7 +1858,7 @@ public:
     TS_ASSERT_THROWS(FGTable t_2x2x2(pm, el_table), BaseException&);
   }
 
-  void test3DMissingData() {
+  void test3DMissingTableData() {
     auto pm = make_shared<FGPropertyManager>();
     // FGTable expects <table> to be the child of another XML element, hence the
     // <dummy> element.
@@ -1659,6 +1867,45 @@ public:
                                   "    <independentVar lookup=\"row\">x</independentVar>"
                                   "    <independentVar lookup=\"column\">y</independentVar>"
                                   "    <independentVar lookup=\"table\">z</independentVar>"
+                                  "  </table>"
+                                  "</dummy>");
+    Element* el_table = elm->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_2x2x2(pm, el_table), BaseException&);
+  }
+
+  void test3DEmptyTableData() {
+    auto pm = make_shared<FGPropertyManager>();
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  <table name=\"test\">"
+                                  "    <independentVar lookup=\"row\">x</independentVar>"
+                                  "    <independentVar lookup=\"column\">y</independentVar>"
+                                  "    <independentVar lookup=\"table\">z</independentVar>"
+                                  "    <tableData/>"
+                                  "  </table>"
+                                  "</dummy>");
+    Element* el_table = elm->FindElement("table");
+
+    TS_ASSERT_THROWS(FGTable t_2x2x2(pm, el_table), BaseException&);
+  }
+
+  void test3DEmptyTableData2() {
+    auto pm = make_shared<FGPropertyManager>();
+    // FGTable expects <table> to be the child of another XML element, hence the
+    // <dummy> element.
+    Element_ptr elm = readFromXML("<dummy>"
+                                  "  <table name=\"test\">"
+                                  "    <independentVar lookup=\"row\">x</independentVar>"
+                                  "    <independentVar lookup=\"column\">y</independentVar>"
+                                  "    <independentVar lookup=\"table\">z</independentVar>"
+                                  "    <tableData breakPoint=\"1.0\">"
+                                  "            0.0  1.0\n"
+                                  "      2.0   3.0 -2.0\n"
+                                  "      4.0  -1.0  0.5\n"
+                                  "    </tableData>"
+                                  "    <tableData/>"
                                   "  </table>"
                                   "</dummy>");
     Element* el_table = elm->FindElement("table");

--- a/tests/unit_tests/FGTableTest.h
+++ b/tests/unit_tests/FGTableTest.h
@@ -1414,7 +1414,7 @@ public:
     Element_ptr elm = readFromXML("<dummy>"
                                   "  <table name=\"test\" type=\"internal\">"
                                   "    <tableData>"
-                                  "      1.0/ -1.0\n"
+                                  "      1.0% -1.0\n"
                                   "      2.0  1.5\n"
                                   "    </tableData>"
                                   "  </table>"
@@ -1445,7 +1445,7 @@ public:
     TS_ASSERT_THROWS(FGTable t_2x1(pm, el_table), BaseException&);
   }
 
-  void testExtraPrefix() {
+  void testUnexpectedPrefix() {
     auto pm = make_shared<FGPropertyManager>();
 
     // FGTable expects <table> to be the child of another XML element, hence the

--- a/tests/unit_tests/TestUtilities.h
+++ b/tests/unit_tests/TestUtilities.h
@@ -1,0 +1,8 @@
+#include <input_output/FGXMLParse.h>
+
+JSBSim::Element_ptr readFromXML(const std::string& XML) {
+  std::istringstream data(XML);
+  JSBSim::FGXMLParse parser;
+  readXML(data, parser);
+  return parser.GetDocument();
+}


### PR DESCRIPTION
This PR adds 4 new unit tests for the following classes: `FGRealValue`, `FGParameter`, `FGParameterValue`, `FGCondition`.

A few modifications have been brought to the tested class in the process:
* Exceptions types are replaced by `JSBSim::BaseException` which is planned to be the base class for all exceptions thrown by JSBSim.
* `JSBSIM_API` decorations are added to the tested classes to avoid issues such as reported in #719 (some of the new unit tests were not compiling otherwise).
* Error handling is improved so that more user errors can be intercepted and properly reported.
* `assert(false);` are used to replace error management code that cannot be reached (for example, error management code that check if a variable has an illegal value despite the fact that that illegal value was intercepted earlier and an exception was thrown).