### PR TITLE
Simplify `FGCondition`

### DIFF
--- a/src/math/FGCondition.cpp
+++ b/src/math/FGCondition.cpp
@@ -77,7 +77,7 @@ FGCondition::FGCondition(Element* element, std::shared_ptr<FGPropertyManager> Pr
 
   for (unsigned int i=0; i<element->GetNumDataLines(); i++) {
     string data = element->GetDataLine(i);
-    conditions.push_back(unique_ptr<FGCondition>(new FGCondition(data, PropertyManager, element)));
+    conditions.push_back(make_shared<FGCondition>(data, PropertyManager, element));
   }
 
   Element* condition_element = element->GetElement();
@@ -93,7 +93,7 @@ FGCondition::FGCondition(Element* element, std::shared_ptr<FGPropertyManager> Pr
       throw BaseException("FGCondition: unrecognized tag:'" + tagName + "'");
     }
 
-    conditions.push_back(make_unique<FGCondition>(condition_element, PropertyManager));
+    conditions.push_back(make_shared<FGCondition>(condition_element, PropertyManager));
     condition_element = element->GetNextElement();
   }
 

--- a/src/math/FGCondition.h
+++ b/src/math/FGCondition.h
@@ -65,13 +65,13 @@ class JSBSIM_API FGCondition : public FGJSBBase
 {
 public:
   FGCondition(Element* element, std::shared_ptr<FGPropertyManager> PropertyManager);
+  FGCondition(const std::string& test, std::shared_ptr<FGPropertyManager> PropertyManager,
+              Element* el);
 
   bool Evaluate(void);
   void PrintCondition(std::string indent="  ");
 
 private:
-  FGCondition(const std::string& test, std::shared_ptr<FGPropertyManager> PropertyManager,
-              Element* el);
 
   enum eComparison {ecUndef=0, eEQ, eNE, eGT, eGE, eLT, eLE};
   enum eLogic {elUndef=0, eAND, eOR};
@@ -81,8 +81,7 @@ private:
   FGParameter_ptr TestParam2;
   eComparison Comparison;
   std::string conditional;
-
-  std::vector <std::unique_ptr<FGCondition>> conditions;
+  std::vector<std::shared_ptr<FGCondition>> conditions;
 
   void Debug(int from);
 };

--- a/src/math/FGCondition.h
+++ b/src/math/FGCondition.h
@@ -37,8 +37,6 @@ SENTRY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <map>
-
 #include "FGJSBBase.h"
 #include "math/FGPropertyValue.h"
 
@@ -67,7 +65,6 @@ class JSBSIM_API FGCondition : public FGJSBBase
 {
 public:
   FGCondition(Element* element, std::shared_ptr<FGPropertyManager> PropertyManager);
-  ~FGCondition(void);
 
   bool Evaluate(void);
   void PrintCondition(std::string indent="  ");
@@ -78,7 +75,6 @@ private:
 
   enum eComparison {ecUndef=0, eEQ, eNE, eGT, eGE, eLT, eLE};
   enum eLogic {elUndef=0, eAND, eOR};
-  std::map <std::string, eComparison> mComparison;
   eLogic Logic;
 
   FGPropertyValue_ptr TestParam1;
@@ -86,8 +82,7 @@ private:
   eComparison Comparison;
   std::string conditional;
 
-  std::vector <FGCondition*> conditions;
-  void InitializeConditionals(void);
+  std::vector <std::unique_ptr<FGCondition>> conditions;
 
   void Debug(int from);
 };

--- a/tests/unit_tests/FGConditionTest.h
+++ b/tests/unit_tests/FGConditionTest.h
@@ -10,7 +10,7 @@ using namespace JSBSim;
 class FGConditionTest : public CxxTest::TestSuite
 {
 public:
-  void testEqualConstant() {
+  void testXMLEqualConstant() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     const array<string, 3> XML{"<dummy> x == 1.0 </dummy>",
@@ -27,7 +27,21 @@ public:
     }
   }
 
-  void testNotEqualConstant() {
+  void testEqualConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> conditions{"x == 1.0", "x EQ 1.0", "x eq 1.0"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testXMLNotEqualConstant() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     const array<string, 3> XML{"<dummy> x != 1.0 </dummy>",
@@ -44,7 +58,21 @@ public:
     }
   }
 
-  void testGreaterThanConstant() {
+  void testNotEqualConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> conditions{"x != 1.0", "x NE 1.0", "x ne 1.0"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testXMLGreaterThanConstant() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     const array<string, 3> XML{"<dummy> x &gt; 1.0 </dummy>",
@@ -63,7 +91,23 @@ public:
     }
   }
 
-  void testGreaterOrEqualConstant() {
+  void testGreaterThanConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> conditions{"x > 1.0", "x GT 1.0", "x gt 1.0"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testXMLGreaterOrEqualConstant() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     const array<string, 3> XML{"<dummy> x &gt;= 1.0 </dummy>",
@@ -82,7 +126,23 @@ public:
     }
   }
 
-  void testLowerThanConstant() {
+  void testGreaterOrEqualConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> conditions{"x >= 1.0", "x GE 1.0", "x ge 1.0"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testXMLLowerThanConstant() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     const array<string, 3> XML{"<dummy> x &lt; 1.0 </dummy>",
@@ -101,7 +161,23 @@ public:
     }
   }
 
-  void testLowerOrEqualConstant() {
+  void testLowerThanConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> conditions{"x < 1.0", "x LT 1.0", "x lt 1.0"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testXMLLowerOrEqualConstant() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     const array<string, 3> XML{"<dummy> x &lt;= 1.0 </dummy>",
@@ -120,7 +196,23 @@ public:
     }
   }
 
-  void testEqualProperty() {
+  void testLowerOrEqualConstant() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    const array<string, 3> conditions{"x <= 1.0", "x LE 1.0", "x le 1.0"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testXMLEqualProperty() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     auto y = pm->GetNode("y", true);
@@ -145,7 +237,29 @@ public:
     }
   }
 
-  void testNotEqualProperty() {
+  void testEqualProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> conditions{"x == y", "x EQ y", "x eq y"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testXMLNotEqualProperty() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     auto y = pm->GetNode("y", true);
@@ -170,7 +284,29 @@ public:
     }
   }
 
-  void testGreaterThanProperty() {
+  void testNotEqualProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> conditions{"x != y", "x NE y", "x ne y"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testXMLGreaterThanProperty() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     auto y = pm->GetNode("y", true);
@@ -199,7 +335,33 @@ public:
     }
   }
 
-  void testGreaterOrEqualProperty() {
+  void testGreaterThanProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> conditions{"x > y", "x GT y", "x gt y"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(-1.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testXMLGreaterOrEqualProperty() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     auto y = pm->GetNode("y", true);
@@ -228,7 +390,33 @@ public:
     }
   }
 
-  void testLowerThanProperty() {
+  void testGreaterOrEqualProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> conditions{"x >= y", "x GE y", "x ge y"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(-1.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(cond.Evaluate());
+    }
+  }
+
+  void testXMLLowerThanProperty() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     auto y = pm->GetNode("y", true);
@@ -257,7 +445,33 @@ public:
     }
   }
 
-  void testLowerOrEqualProperty() {
+  void testLowerThanProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> conditions{"x < y", "x LT y", "x lt y"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
+
+      x->setDoubleValue(-1.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(0.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testXMLLowerOrEqualProperty() {
     auto pm = make_shared<FGPropertyManager>();
     auto x = pm->GetNode("x", true);
     auto y = pm->GetNode("y", true);
@@ -267,6 +481,32 @@ public:
     for(const string& line: XML) {
       Element_ptr elm = readFromXML(line);
       FGCondition cond(elm, pm);
+
+      x->setDoubleValue(-1.0);
+      y->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(0.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(!cond.Evaluate());
+
+      x->setDoubleValue(0.0);
+      y->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(1.0);
+      TS_ASSERT(cond.Evaluate());
+      x->setDoubleValue(2.0);
+      TS_ASSERT(!cond.Evaluate());
+    }
+  }
+
+  void testLowerOrEqualProperty() {
+    auto pm = make_shared<FGPropertyManager>();
+    auto x = pm->GetNode("x", true);
+    auto y = pm->GetNode("y", true);
+    const array<string, 3> conditions{"x <= y", "x LE y", "x le y"};
+    for(const string& line: conditions) {
+      FGCondition cond(line, pm, nullptr);
 
       x->setDoubleValue(-1.0);
       y->setDoubleValue(0.0);


### PR DESCRIPTION
The class `FGCondition` is currently using a `std::map` to convert strings such as `<`, `==`, `GT`, etc. to an `enum eComparison` that is later used to perform the comparison:

https://github.com/JSBSim-Team/jsbsim/blob/7b1549cf3428ad3cbb70e03d1cca7585df02e7ac/src/math/FGCondition.cpp#L200-L226

The problem is that a `std::map` instance `mComparison` is created by the method `FGCondition::InitializeConditionals()` for every single instance of `FGCondition`: there are as many copies of the map object `mComparison` than there are instances of `FGCondition`. This is suboptimal.

This PR uses a `static constexpr` object that is created once and only once during compilation. This PR is therefore a proof of concept of a replacement of a `static std::map<>` member by a `static constexpr std::array<std::pair<const char*, T>,N>` member which does not need to be populated by a special method `InitializeXYZ()` before being used, avoiding race conditions issues in the process.

The opportunity of this PR is also taken to replace the usage of `new` and `delete` by modern C++14 memory management (i.e. `std::shared_ptr<>` and `std::make_shared<>`).

The constructor `FGCondition(const std::string& test, std::shared_ptr<FGPropertyManager> PropertyManager, Element* el)` is also made `public` again in the process so that it can be used by `std::make_shared<>`. As a consequence, the unit test `FGConditionTest` is extended to test the new `public` constructor.