### PR TITLE
Add types hints to the Python module

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -465,7 +465,7 @@ jobs:
         working-directory: build
         run: ctest -j3 --output-on-failure
       - name: Build the source package for Python
-        if: env.release == 'true' && matrix.arch == 'x86_64'
+        if: matrix.arch == 'x86_64' # && env.release == 'true'
         working-directory: build/tests
         run: |
           echo "::group::Build the type hints stubs"
@@ -541,7 +541,7 @@ jobs:
             fdm.run()
 
   Python-Wheels:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     name: Build Python wheels
     needs: [Linux, Windows-MSVC, MacOSX]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -600,7 +600,8 @@ jobs:
           cmake --build . --target PythonJSBSim -- -j2
           cd tests
           stubgen -p jsbsim -o ../python
-          ll ../python/jsbsim
+          ls -l ../python/jsbsim
+          cat ../python/jsbsim/_jsbsim.pyi
           echo "::endgroup::"
       - name: Configure JSBSim (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -564,7 +564,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install Python packages
-        run: pip install -U cython 'numpy>=1.20'
+        run: pip install -U cython 'numpy>=1.20' mypy
       - name: Install Doxygen (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -585,16 +585,29 @@ jobs:
       - name: Configure JSBSim (BSD/Unix)
         if: runner.os != 'Windows'
         run: |
+          echo "::group::Run CMake"
           mkdir build && cd build
-          cmake ..
-          touch python/jsbsim/py.typed
+          cmake -DCYTHON_FLAGS="-X embedsignature=True" ..
+          echo "::endgroup::"
+
+          echo "::group::Prepare the package"
+          cd python
+          touch jsbsim/py.typed
+          cd ..
+          echo "::endgroup::"
+
+          echo "::group::Build the type hints stubs"
+          cmake --build . --target PythonJSBSim -- -j2
+          cd tests
+          stubgen -p jsbsim -o ../python
+          ll ../python/jsbsim
+          echo "::endgroup::"
       - name: Configure JSBSim (Windows)
         if: runner.os == 'Windows'
         run: |
           New-Item -Path .\build -ItemType Directory -Force
           cd build
           cmake ..
-          New-Item python/jsbsim/py.typed
           cmake --build . --target libJSBSim --config RelWithDebInfo
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -468,16 +468,22 @@ jobs:
         if: env.release == 'true' && matrix.arch == 'x86_64'
         working-directory: build/python
         run: |
-          cython --cplus _jsbsim.pyx -X embedsignature=True -o _jsbsim.cxx
+          echo "::group::Prepare the package"
           touch jsbsim/py.typed
+          echo "::endgroup::"
+
+          echo "::group::Build the type hints stubs"
+          cython --cplus _jsbsim.pyx -X embedsignature=True -o _jsbsim.cxx
           python -m build --wheel
-          ls
-          ls build
           cd build/lib*
           stubgen -p jsbsim -o ../..
           cd ../..
+          echo "::endgroup::"
+
+          echo "::group::Build the source package"
           rm -f _jsbsim.cxx  # Make sure that jsbsim.cxx is not stored in the source distribution
           python -m build --sdist
+          echo "::endgroup::"
 
     # On failure, upload logs
       - name: On failure - Upload logs

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: Install Python packages
-        run: pip install -U cython numpy pandas scipy wheel valgrindci 'setuptools>=60.0.0'
+        run: pip install -U cython 'numpy>=1.20' pandas scipy wheel valgrindci 'setuptools>=60.0.0'
       - name: Configure Julia
         if: matrix.build_julia == 'ON'
         run: |
@@ -268,7 +268,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: Install Python packages
-        run: pip install -U cython numpy pandas scipy wheel pywin32 'setuptools>=60.0.0'
+        run: pip install -U cython 'numpy>=1.20' pandas scipy wheel pywin32 'setuptools>=60.0.0'
       - name: Checkout JSBSim
         uses: actions/checkout@v3
       - name: Cache CTest cost data
@@ -417,7 +417,7 @@ jobs:
           python-version: '3.7'
       - name: Install Python packages
         if: matrix.arch == 'x86_64'
-        run: pip install -U cython numpy pandas scipy build 'setuptools>=60.0.0'
+        run: pip install -U cython 'numpy>=1.20' pandas scipy build 'setuptools>=60.0.0' mypy
       - name: Checkout JSBSim
         uses: actions/checkout@v3
       - name: Cache CTest cost data
@@ -468,7 +468,15 @@ jobs:
         if: env.release == 'true' && matrix.arch == 'x86_64'
         working-directory: build/python
         run: |
+          cython --cplus _jsbsim.pyx -X embedsignature=True -o _jsbsim.cxx
+          python -m build --wheel
+          ls
+          ls build
+          cd build/lib*
+          stubgen -p jsbsim -o ../..
+          cd ../..
           rm -f _jsbsim.cxx  # Make sure that jsbsim.cxx is not stored in the source distribution
+          rm -fR fpectl
           touch jsbsim/py.typed
           python -m build --sdist
 
@@ -493,7 +501,7 @@ jobs:
             build/python/dist/*.tar.gz
 
   Test-Build-PyPackage-From-Source:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     name: Build Python Module from Source
     needs: MacOSX
     strategy:
@@ -551,7 +559,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install Python packages
-        run: pip install -U cython numpy
+        run: pip install -U cython 'numpy>=1.20'
       - name: Install Doxygen (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -620,7 +628,7 @@ jobs:
           # Test virtual environment installation
           python -m venv test_venv
           test_venv\Scripts\activate.ps1
-          pip install numpy
+          pip install 'numpy>=1.20'
           pip install jsbsim --no-index -f wheelhouse
           python -c "import jsbsim;print(jsbsim.get_default_root_dir())"
           pip uninstall jsbsim -y
@@ -631,7 +639,7 @@ jobs:
           # Test virtual environment installation
           python -m venv test_venv
           source test_venv/bin/activate
-          pip install numpy
+          pip install 'numpy>=1.20'
           pip install jsbsim --no-index -f wheelhouse
           python -c "import jsbsim;print(jsbsim.get_default_root_dir())"
           pip uninstall jsbsim -y
@@ -737,7 +745,7 @@ jobs:
     # Deploy stable release to GitHub
       - name: Get JSBSim version
         run: |
-          pip install -U numpy
+          pip install -U 'numpy>=1.20'
           pip install jsbsim --no-index -f dist
           export VERSION=`pip show jsbsim | grep -i version | awk '{ print $2 }'`
           echo "VERSION=$VERSION" >> $GITHUB_ENV
@@ -834,7 +842,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: Install Python packages
-        run: pip install -U numpy sphinx
+        run: pip install -U 'numpy>=1.20' sphinx
       - name: Checkout JSBSim
         uses: actions/checkout@v3
       - name: Configure JSBSim

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -469,6 +469,7 @@ jobs:
         working-directory: build/python
         run: |
           rm -f _jsbsim.cxx  # Make sure that jsbsim.cxx is not stored in the source distribution
+          touch jsbsim/py.typed
           python -m build --sdist
 
     # On failure, upload logs
@@ -573,12 +574,14 @@ jobs:
         run: |
           mkdir build && cd build
           cmake ..
+          touch python/jsbsim/py.typed
       - name: Configure JSBSim (Windows)
         if: runner.os == 'Windows'
         run: |
           New-Item -Path .\build -ItemType Directory -Force
           cd build
           cmake ..
+          New-Item python/jsbsim/py.typed
           cmake --build . --target libJSBSim --config RelWithDebInfo
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -492,7 +492,7 @@ jobs:
 
       - name: Upload Files for Release
         uses: actions/upload-artifact@v3
-        if: env.release == 'true' && matrix.arch == 'x86_64'
+        if: matrix.arch == 'x86_64' # && env.release == 'true'
         with:
           name: ${{ runner.os }}.binaries
           path: |

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -465,7 +465,7 @@ jobs:
         working-directory: build
         run: ctest -j3 --output-on-failure
       - name: Build the source package for Python
-        if: matrix.arch == 'x86_64' # && env.release == 'true'
+        if: env.release == 'true' && matrix.arch == 'x86_64'
         working-directory: build/tests
         run: |
           echo "::group::Build the type hints stubs"
@@ -491,7 +491,7 @@ jobs:
 
       - name: Upload Files for Release
         uses: actions/upload-artifact@v3
-        if: matrix.arch == 'x86_64' # && env.release == 'true'
+        if: env.release == 'true' && matrix.arch == 'x86_64'
         with:
           name: ${{ runner.os }}.binaries
           path: |
@@ -500,7 +500,7 @@ jobs:
             build/python/dist/*.tar.gz
 
   Test-Build-PyPackage-From-Source:
-    # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     name: Build Python Module from Source
     needs: MacOSX
     strategy:
@@ -547,7 +547,7 @@ jobs:
           mypy test.py
 
   Python-Wheels:
-    # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     name: Build Python wheels
     needs: [Linux, Windows-MSVC, MacOSX]
     runs-on: ${{ matrix.os }}
@@ -645,7 +645,7 @@ jobs:
           echo "::group::Test type hints"
           echo "import jsbsim" > test.py
           mypy test.py
-          echo "::ungroup::"
+          echo "::endgroup::"
       - name: Test default root package detection (global & --user)
         run: |
           # Test global installation

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -477,7 +477,6 @@ jobs:
           stubgen -p jsbsim -o ../..
           cd ../..
           rm -f _jsbsim.cxx  # Make sure that jsbsim.cxx is not stored in the source distribution
-          rm -fR fpectl
           python -m build --sdist
 
     # On failure, upload logs

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -451,7 +451,7 @@ jobs:
           mkdir -p build && cd build
           julia -e "import Pkg;Pkg.add(\"CxxWrap\")"
           export CXXWRAP_PREFIX_PATH=`julia -e "using CxxWrap;print(CxxWrap.prefix_path())"`
-          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DBUILD_JULIA_PACKAGE=ON -DCMAKE_PREFIX_PATH=$CXXWRAP_PREFIX_PATH ..
+          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DBUILD_JULIA_PACKAGE=ON -DCYTHON_FLAGS="-X embedsignature=True" -DCMAKE_PREFIX_PATH=$CXXWRAP_PREFIX_PATH ..
       - name: Configure JSBSim (arm64)
         if: matrix.arch == 'arm64'
         run: |
@@ -466,21 +466,15 @@ jobs:
         run: ctest -j3 --output-on-failure
       - name: Build the source package for Python
         if: env.release == 'true' && matrix.arch == 'x86_64'
-        working-directory: build/python
+        working-directory: build/tests
         run: |
-          echo "::group::Prepare the package"
-          touch jsbsim/py.typed
-          echo "::endgroup::"
-
           echo "::group::Build the type hints stubs"
-          cython --cplus _jsbsim.pyx -X embedsignature=True -o _jsbsim.cxx
-          python -m build --wheel
-          cd build/lib*
-          stubgen -p jsbsim -o ../..
-          cd ../..
+          stubgen -p jsbsim -o ../python
           echo "::endgroup::"
 
           echo "::group::Build the source package"
+          cd ../python
+          touch jsbsim/py.typed
           rm -f _jsbsim.cxx  # Make sure that jsbsim.cxx is not stored in the source distribution
           python -m build --sdist
           echo "::endgroup::"
@@ -564,7 +558,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install Python packages
-        run: pip install -U cython 'numpy>=1.20' mypy
+        run: pip install -U cython 'numpy>=1.20'
       - name: Install Doxygen (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -582,27 +576,15 @@ jobs:
           # Set GENERATE_HTML and HAVE_DOT to NO
           perl -i -pe 's/^(GENERATE_HTML\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
           perl -i -pe 's/^(HAVE_DOT\s*=\s*)YES/\1NO/g' doc/JSBSim.dox.in
+      - name: Download source package
+        uses: actions/download-artifact@v3
+        with:
+          name: macOS.binaries
       - name: Configure JSBSim (BSD/Unix)
         if: runner.os != 'Windows'
         run: |
-          echo "::group::Run CMake"
           mkdir build && cd build
-          cmake -DCYTHON_FLAGS="-X embedsignature=True" ..
-          echo "::endgroup::"
-
-          echo "::group::Prepare the package"
-          cd python
-          touch jsbsim/py.typed
-          cd ..
-          echo "::endgroup::"
-
-          echo "::group::Build the type hints stubs"
-          cmake --build . --target PythonJSBSim -- -j2
-          cd tests
-          stubgen -p jsbsim -o ../python
-          ls -l ../python/jsbsim
-          cat ../python/jsbsim/_jsbsim.pyi
-          echo "::endgroup::"
+          cmake ..
       - name: Configure JSBSim (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -610,6 +592,11 @@ jobs:
           cd build
           cmake ..
           cmake --build . --target libJSBSim --config RelWithDebInfo
+      - name: Get Python package sources
+        working-directory: python/dist
+        run: |
+          tar zxvf *.tar.gz
+          cp -R JSBSim-*/jsbsim/*.pyi ../../build/python/jsbsim/.
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2
         env:

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -517,6 +517,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install Python packages
+        run: pip install -U cython 'numpy>=1.20' mypy
       - name: Download source package
         uses: actions/download-artifact@v3
         with:
@@ -539,6 +541,10 @@ jobs:
           fdm.run_ic()
           while fdm.get_sim_time() < 10:
             fdm.run()
+      - name: Test type hints
+        run: |
+          echo "import jsbsim" > test.py
+          mypy test.py
 
   Python-Wheels:
     # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
@@ -558,7 +564,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install Python packages
-        run: pip install -U cython 'numpy>=1.20'
+        run: pip install -U cython 'numpy>=1.20' mypy
       - name: Install Doxygen (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -631,8 +637,15 @@ jobs:
           package-dir: build/python
       - name: Test wheel package
         run: |
+          echo "::group::Test module execution"
           pip install jsbsim --no-index -f wheelhouse
           python -c "import jsbsim;print(jsbsim.FGAircraft.__doc__);fdm=jsbsim.FGFDMExec(None);fdm.load_script('scripts/Short_S23_1.xml');fdm.run_ic()"
+          echo "::endgroup::"
+
+          echo "::group::Test type hints"
+          echo "import jsbsim" > test.py
+          mypy test.py
+          echo "::ungroup::"
       - name: Test default root package detection (global & --user)
         run: |
           # Test global installation

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -583,20 +583,34 @@ jobs:
       - name: Configure JSBSim (BSD/Unix)
         if: runner.os != 'Windows'
         run: |
+          echo "::group::Run CMake"
           mkdir build && cd build
           cmake ..
+          echo "::endgroup::"
+
+          echo "::group::Get Python package sources"
+          touch python/jsbsim/py.typed
+          cd ../python/dist
+          tar zxvf *.tar.gz
+          cp -R JSBSim-*/jsbsim/*.pyi ../../build/python/jsbsim/.
+          echo "::endgroup::"
       - name: Configure JSBSim (Windows)
         if: runner.os == 'Windows'
         run: |
+          echo "::group::Run CMake"
           New-Item -Path .\build -ItemType Directory -Force
           cd build
           cmake ..
           cmake --build . --target libJSBSim --config RelWithDebInfo
-      - name: Get Python package sources
-        working-directory: python/dist
-        run: |
-          tar zxvf *.tar.gz
-          cp -R JSBSim-*/jsbsim/*.pyi ../../build/python/jsbsim/.
+          echo "::endgroup::"
+
+          echo "::group::Get Python package sources"
+          New-Item python\jsbsim\py.typed
+          cd ..\python/dist
+          $PyPackage = Get-ChildItem .\*.tar.gz -Name
+          tar zxvf $PyPackage
+          Copy-Item -Path .\JSBSim-*\jsbsim\*.pyi -Destination ..\..\build\python\jsbsim
+          echo "::endgroup::"
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2
         env:

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -469,6 +469,7 @@ jobs:
         working-directory: build/python
         run: |
           cython --cplus _jsbsim.pyx -X embedsignature=True -o _jsbsim.cxx
+          touch jsbsim/py.typed
           python -m build --wheel
           ls
           ls build
@@ -477,7 +478,6 @@ jobs:
           cd ../..
           rm -f _jsbsim.cxx  # Make sure that jsbsim.cxx is not stored in the source distribution
           rm -fR fpectl
-          touch jsbsim/py.typed
           python -m build --sdist
 
     # On failure, upload logs

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -37,7 +37,6 @@ import sys
 import numpy
 
 from typing import List, Tuple
-from numpy.typing import ArrayLike
 
 
 __version__='${PROJECT_VERSION}'
@@ -108,17 +107,17 @@ cdef class FGPropagate:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_Tl2b(self) -> ArrayLike:
+    def get_Tl2b(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGPropagate::GetTl2b)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetTl2b())
 
-    def get_Tec2b(self) -> ArrayLike:
+    def get_Tec2b(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGPropagate::GetTec2b)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetTec2b())
 
-    def get_uvw(self) -> ArrayLike:
+    def get_uvw(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGPropagate::GetUVW)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetUVW())
@@ -213,10 +212,10 @@ cdef class FGLGear:
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).GetBodyZForce()
 
-    def get_location(self) -> ArrayLike:
+    def get_location(self) -> numpy.ndarray:
         return _convertToNumpyVec(deref(self.thisptr).GetLocation())
 
-    def get_acting_location(self) -> ArrayLike:
+    def get_acting_location(self) -> numpy.ndarray:
         return _convertToNumpyVec(deref(self.thisptr).GetActingLocation())
 
 cdef class FGAuxiliary:
@@ -238,12 +237,12 @@ cdef class FGAuxiliary:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_Tw2b(self) -> ArrayLike:
+    def get_Tw2b(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGAuxiliary::GetTw2b)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetTw2b())
 
-    def get_Tb2w(self) -> ArrayLike:
+    def get_Tb2w(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGAuxiliary::GetTb2w)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetTb2w())
@@ -267,12 +266,12 @@ cdef class FGAerodynamics:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_moments_MRC(self) -> ArrayLike:
+    def get_moments_MRC(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGAerodynamics::GetMomentsMRC)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetMomentsMRC())
 
-    def get_forces(self) -> ArrayLike:
+    def get_forces(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGAerodynamics::GetForces)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetForces())
@@ -296,7 +295,7 @@ cdef class FGAircraft:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_xyz_rp(self) -> ArrayLike:
+    def get_xyz_rp(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGAircraft::GetXYZrp)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetXYZrp())
@@ -350,17 +349,17 @@ cdef class FGMassBalance:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_xyz_cg(self) -> ArrayLike:
+    def get_xyz_cg(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGMassBalance::GetXYZcg)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetXYZcg())
 
-    def get_J(self) -> ArrayLike:
+    def get_J(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGMassBalance::GetJ)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetJ())
 
-    def get_Jinv(self) -> ArrayLike:
+    def get_Jinv(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGMassBalance::GetJinv)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetJinv())
@@ -483,49 +482,49 @@ cdef class FGLinearization:
             deref(self.thisptr).WriteScicoslab(path.encode("utf-8"))
 
     @property
-    def x0(self) -> ArrayLike:
+    def x0(self) -> numpy.ndarray:
         """Initial state"""
         self.__intercept_invalid_pointer()
         return numpy.array(deref(self.thisptr).GetInitialState())
 
     @property
-    def u0(self) -> ArrayLike:
+    def u0(self) -> numpy.ndarray:
         """Initial input"""
         self.__intercept_invalid_pointer()
         return numpy.array(deref(self.thisptr).GetInitialInput())
 
     @property
-    def y0(self) -> ArrayLike:
+    def y0(self) -> numpy.ndarray:
         """Initial output"""
         self.__intercept_invalid_pointer()
         return numpy.array(deref(self.thisptr).GetInitialOutput())
 
     @property
-    def system_matrix(self) -> ArrayLike:
+    def system_matrix(self) -> numpy.ndarray:
         self.__intercept_invalid_pointer()
         cdef const vector[vector[double]]* cdef_A = &deref(self.thisptr).GetSystemMatrix()
         return numpy.array(deref(cdef_A))
 
     @property
-    def input_matrix(self) -> ArrayLike:
+    def input_matrix(self) -> numpy.ndarray:
         self.__intercept_invalid_pointer()
         cdef const vector[vector[double]]* cdef_B = &deref(self.thisptr).GetInputMatrix()
         return numpy.array(deref(cdef_B))
 
     @property
-    def output_matrix(self) -> ArrayLike:
+    def output_matrix(self) -> numpy.ndarray:
         self.__intercept_invalid_pointer()
         cdef const vector[vector[double]]* cdef_C = &deref(self.thisptr).GetOutputMatrix()
         return numpy.array(deref(cdef_C))
 
     @property
-    def feedforward_matrix(self) -> ArrayLike:
+    def feedforward_matrix(self) -> numpy.ndarray:
         self.__intercept_invalid_pointer()
         cdef const vector[vector[double]]* cdef_D = &deref(self.thisptr).GetFeedforwardMatrix()
         return numpy.array(deref(cdef_D))
 
     @property
-    def state_space(self) -> Tuple[ArrayLike]:
+    def state_space(self) -> Tuple[numpy.ndarray]:
         return (self.system_matrix, self.input_matrix, self.output_matrix, self.feedforward_matrix)
 
     @property

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -36,6 +36,10 @@ import sys
 
 import numpy
 
+from typing import List, Tuple
+from numpy.typing import ArrayLike
+
+
 __version__='${PROJECT_VERSION}'
 
 
@@ -59,7 +63,7 @@ trimfailure_error = <PyObject*>TrimFailureError
 geographic_error = <PyObject*>GeographicError
 
 
-def get_default_root_dir():
+def get_default_root_dir() -> str:
     """Return the root dir to default aircraft data."""
     for path in site.getsitepackages() + [site.USER_SITE]:
         root_dir = os.path.join(path, 'jsbsim')
@@ -69,7 +73,7 @@ def get_default_root_dir():
     raise IOError("Can't find the default root directory")
 
 
-def _append_xml(name):
+def _append_xml(name: str) -> str:
     if len(name) < 4 or name[-4:] != '.xml':
         return name+'.xml'
     return name
@@ -94,27 +98,27 @@ cdef class FGPropagate:
         if fdmex is not None:
             self.thisptr.reset(new c_FGPropagate(fdmex.thisptr))
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_Tl2b(self):
+    def get_Tl2b(self) -> ArrayLike:
         """@Dox(JSBSim::FGPropagate::GetTl2b)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetTl2b())
 
-    def get_Tec2b(self):
+    def get_Tec2b(self) -> ArrayLike:
         """@Dox(JSBSim::FGPropagate::GetTec2b)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetTec2b())
 
-    def get_uvw(self):
+    def get_uvw(self) -> ArrayLike:
         """@Dox(JSBSim::FGPropagate::GetUVW)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetUVW())
@@ -128,17 +132,17 @@ cdef class FGPropertyManager:
     def __cinit__(self, *args, **kwargs):
         self.thisptr.reset(new c_FGPropertyManager())
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def hasNode(self, path):
+    def hasNode(self, path: str) -> bool:
         """@Dox(JSBSim::FGPropertyManager::HasNode)"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).HasNode(path.encode())
@@ -152,24 +156,24 @@ cdef class FGGroundReactions:
         if fdmex is not None:
             self.thisptr.reset(new c_FGGroundReactions(fdmex.thisptr))
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_gear_unit(self, gear):
+    def get_gear_unit(self, gear: int) -> FGLGear:
         """@Dox(JSBSim::FGGroundReactions::GetGearUnit)"""
         self.__intercept_invalid_pointer()
         lgear = FGLGear()
         lgear.thisptr = deref(self.thisptr).GetGearUnit(gear)
         return lgear
 
-    def get_num_gear_units(self):
+    def get_num_gear_units(self) -> int:
         """@Dox(JSBSim::FGGroundReactions::GetNumGearUnits)"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).GetNumGearUnits()
@@ -179,40 +183,40 @@ cdef class FGLGear:
 
     cdef shared_ptr[c_FGLGear] thisptr
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_steer_norm(self):
+    def get_steer_norm(self) -> float:
         """@Dox(JSBSim::FGLGear::GetSteerNorm)"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).GetSteerNorm()
 
-    def get_body_x_force(self):
+    def get_body_x_force(self) -> float:
         """@Dox(JSBSim::FGLGear::GetBodyXForce)"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).GetBodyXForce()
 
-    def get_body_y_force(self):
+    def get_body_y_force(self) -> float:
         """@Dox(JSBSim::FGLGear::GetBodyYForce)"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).GetBodyYForce()
 
-    def get_body_z_force(self):
+    def get_body_z_force(self) -> float:
         """@Dox(JSBSim::FGLGear::GetBodyZForce)"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).GetBodyZForce()
 
-    def get_location(self):
+    def get_location(self) -> ArrayLike:
         return _convertToNumpyVec(deref(self.thisptr).GetLocation())
 
-    def get_acting_location(self):
+    def get_acting_location(self) -> ArrayLike:
         return _convertToNumpyVec(deref(self.thisptr).GetActingLocation())
 
 cdef class FGAuxiliary:
@@ -224,22 +228,22 @@ cdef class FGAuxiliary:
         if fdmex is not None:
             self.thisptr.reset(new c_FGAuxiliary(fdmex.thisptr))
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_Tw2b(self):
+    def get_Tw2b(self) -> ArrayLike:
         """@Dox(JSBSim::FGAuxiliary::GetTw2b)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetTw2b())
 
-    def get_Tb2w(self):
+    def get_Tb2w(self) -> ArrayLike:
         """@Dox(JSBSim::FGAuxiliary::GetTb2w)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetTb2w())
@@ -253,22 +257,22 @@ cdef class FGAerodynamics:
         if fdmex is not None:
             self.thisptr.reset(new c_FGAerodynamics(fdmex.thisptr))
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_moments_MRC(self):
+    def get_moments_MRC(self) -> ArrayLike:
         """@Dox(JSBSim::FGAerodynamics::GetMomentsMRC)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetMomentsMRC())
 
-    def get_forces(self):
+    def get_forces(self) -> ArrayLike:
         """@Dox(JSBSim::FGAerodynamics::GetForces)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetForces())
@@ -282,17 +286,17 @@ cdef class FGAircraft:
         if fdmex is not None:
             self.thisptr.reset(new c_FGAircraft(fdmex.thisptr))
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_xyz_rp(self):
+    def get_xyz_rp(self) -> ArrayLike:
         """@Dox(JSBSim::FGAircraft::GetXYZrp)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetXYZrp())
@@ -302,27 +306,27 @@ cdef class FGAtmosphere:
 
     cdef shared_ptr[c_FGAtmosphere] thisptr
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def set_temperature(self, t, h, unit):
+    def set_temperature(self, t: float, h: float, unit: eTemperature) -> None:
         """@Dox(JSBSim::FGAtmosphere::SetTemperature)"""
         self.__intercept_invalid_pointer()
         deref(self.thisptr).SetTemperature(t, h, unit)
 
-    def get_temperature(self, h):
+    def get_temperature(self, h: float) -> float:
         """@Dox(JSBSim::FGAtmosphere::GetTemperature(double))"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).GetTemperature(h)
 
-    def set_pressure_SL(self, unit, p):
+    def set_pressure_SL(self, unit: ePressure, p: float) -> None:
         """@Dox(JSBSim::FGAtmosphere::SetPressureSL)"""
         self.__intercept_invalid_pointer()
         deref(self.thisptr).SetPressureSL(unit, p)
@@ -336,27 +340,27 @@ cdef class FGMassBalance:
         if fdmex is not None:
             self.thisptr.reset(new c_FGMassBalance(fdmex.thisptr))
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def get_xyz_cg(self):
+    def get_xyz_cg(self) -> ArrayLike:
         """@Dox(JSBSim::FGMassBalance::GetXYZcg)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyVec(deref(self.thisptr).GetXYZcg())
 
-    def get_J(self):
+    def get_J(self) -> ArrayLike:
         """@Dox(JSBSim::FGMassBalance::GetJ)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetJ())
 
-    def get_Jinv(self):
+    def get_Jinv(self) -> ArrayLike:
         """@Dox(JSBSim::FGMassBalance::GetJinv)"""
         self.__intercept_invalid_pointer()
         return _convertToNumpyMat(deref(self.thisptr).GetJinv())
@@ -370,25 +374,25 @@ cdef class FGJSBBase:
         if type(self) is FGJSBBase: # Check if it is called from a derived class
             self.baseptr = new c_FGJSBBase()
 
-    def __dealloc__(self):
+    def __dealloc__(self) -> None:
         if type(self) is FGJSBBase:
             del self.baseptr
 
     @property
-    def debug_lvl(self):
+    def debug_lvl(self) -> None:
         return self.baseptr.debug_lvl
 
     @debug_lvl.setter
-    def debug_lvl(self, dbglvl):
+    def debug_lvl(self, dbglvl: int) -> None:
         self.baseptr.debug_lvl = dbglvl
 
-    def get_version(self):
+    def get_version(self) -> str:
         """@Dox(JSBSim::FGJSBBase::GetVersion)"""
         return self.baseptr.GetVersion().decode('utf-8')
 
-    def disable_highlighting(self):
+    def disable_highlighting(self) -> None:
         """@Dox(JSBSim::FGJSBBase::disableHighLighting)"""
-        return self.baseptr.disableHighLighting()
+        self.baseptr.disableHighLighting()
 
 cdef class FGPropulsion:
     """@Dox(JSBSim::FGPropulsion)"""
@@ -399,34 +403,34 @@ cdef class FGPropulsion:
         if fdmex is not None:
             self.thisptr.reset(new c_FGPropulsion(fdmex.thisptr))
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def init_running(self, n):
+    def init_running(self, n: int) -> None:
         """@Dox(JSBSim::FGPropulsion::InitRunning)"""
         self.__intercept_invalid_pointer()
         deref(self.thisptr).InitRunning(n)
 
-    def get_num_engines(self):
+    def get_num_engines(self) -> int:
         """@Dox(JSBSim::FGPropulsion::GetNumEngines)"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).GetNumEngines()
 
-    def get_engine(self, idx):
+    def get_engine(self, idx: int) -> FGEngine:
         """@Dox(JSBSim::FGPropulsion::GetEngine)"""
         self.__intercept_invalid_pointer()
         engine = FGEngine()
         engine.thisptr = deref(self.thisptr).GetEngine(idx)
         return engine
 
-    def get_steady_state(self):
+    def get_steady_state(self) -> bool:
         """@Dox(JSBSim::FGPropulsion::GetSteadyState)"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).GetSteadyState()
@@ -436,17 +440,17 @@ cdef class FGEngine:
 
     cdef shared_ptr[c_FGEngine] thisptr
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def init_running(self):
+    def init_running(self) -> int:
         """@Dox(JSBSim::FGEngine::InitRunning)"""
         self.__intercept_invalid_pointer()
         return deref(self.thisptr).InitRunning()
@@ -460,17 +464,17 @@ cdef class FGLinearization:
         if fdmex is not None:
             self.thisptr.reset(new c_FGLinearization(fdmex.thisptr))
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Check if the object is initialized."""
         if self.thisptr:
             return True
         return False
 
-    def __intercept_invalid_pointer(self):
+    def __intercept_invalid_pointer(self) -> None:
         if not self.thisptr:
             raise AttributeError("Object is not initialized")
 
-    def write_scicoslab(self, path):
+    def write_scicoslab(self, path: str) -> None:
         """@Dox(JSBSim::FGLinearization::WriteScicoslab)"""
         self.__intercept_invalid_pointer()
         if path is None:
@@ -479,88 +483,88 @@ cdef class FGLinearization:
             deref(self.thisptr).WriteScicoslab(path.encode("utf-8"))
 
     @property
-    def x0(self):
+    def x0(self) -> ArrayLike:
         """Initial state"""
         self.__intercept_invalid_pointer()
         return numpy.array(deref(self.thisptr).GetInitialState())
 
     @property
-    def u0(self):
+    def u0(self) -> ArrayLike:
         """Initial input"""
         self.__intercept_invalid_pointer()
         return numpy.array(deref(self.thisptr).GetInitialInput())
 
     @property
-    def y0(self):
+    def y0(self) -> ArrayLike:
         """Initial output"""
         self.__intercept_invalid_pointer()
         return numpy.array(deref(self.thisptr).GetInitialOutput())
 
     @property
-    def system_matrix(self):
+    def system_matrix(self) -> ArrayLike:
         self.__intercept_invalid_pointer()
         cdef const vector[vector[double]]* cdef_A = &deref(self.thisptr).GetSystemMatrix()
         return numpy.array(deref(cdef_A))
 
     @property
-    def input_matrix(self):
+    def input_matrix(self) -> ArrayLike:
         self.__intercept_invalid_pointer()
         cdef const vector[vector[double]]* cdef_B = &deref(self.thisptr).GetInputMatrix()
         return numpy.array(deref(cdef_B))
 
     @property
-    def output_matrix(self):
+    def output_matrix(self) -> ArrayLike:
         self.__intercept_invalid_pointer()
         cdef const vector[vector[double]]* cdef_C = &deref(self.thisptr).GetOutputMatrix()
         return numpy.array(deref(cdef_C))
 
     @property
-    def feedforward_matrix(self):
+    def feedforward_matrix(self) -> ArrayLike:
         self.__intercept_invalid_pointer()
         cdef const vector[vector[double]]* cdef_D = &deref(self.thisptr).GetFeedforwardMatrix()
         return numpy.array(deref(cdef_D))
 
     @property
-    def state_space(self):
+    def state_space(self) -> Tuple[ArrayLike]:
         return (self.system_matrix, self.input_matrix, self.output_matrix, self.feedforward_matrix)
 
     @property
-    def x_names(self):
+    def x_names(self) -> Tuple[str]:
         """State names"""
         self.__intercept_invalid_pointer()
         cdef vector[string] names = deref(self.thisptr).GetStateNames()
         return tuple(name.decode("utf-8") for name in names)
 
     @property
-    def u_names(self):
+    def u_names(self) -> Tuple[str]:
         "Input names"
         self.__intercept_invalid_pointer()
         cdef vector[string] names = deref(self.thisptr).GetInputNames()
         return tuple(name.decode("utf-8") for name in names)
 
     @property
-    def y_names(self):
+    def y_names(self) -> Tuple[str]:
         """Output names"""
         self.__intercept_invalid_pointer()
         cdef vector[string] names = deref(self.thisptr).GetOutputNames()
         return tuple(name.decode("utf-8") for name in names)
 
     @property
-    def x_units(self):
+    def x_units(self) -> Tuple[str]:
         """State units"""
         self.__intercept_invalid_pointer()
         cdef vector[string] units = deref(self.thisptr).GetStateUnits()
         return tuple(unit.decode("utf-8") for unit in units)
 
     @property
-    def u_units(self):
+    def u_units(self) -> Tuple[str]:
         """Input unit"""
         self.__intercept_invalid_pointer()
         cdef vector[string] units = deref(self.thisptr).GetInputUnits()
         return tuple(unit.decode("utf-8") for unit in units)
 
     @property
-    def y_units(self):
+    def y_units(self) -> Tuple[str]:
         """Output units"""
         self.__intercept_invalid_pointer()
         cdef vector[string] units = deref(self.thisptr).GetOutputUnits()
@@ -599,10 +603,10 @@ cdef class FGFDMExec(FGJSBBase):
         self.set_aircraft_path("aircraft")
         self.set_systems_path("systems")
 
-    def __dealloc__(self):
+    def __dealloc__(self) -> None:
         del self.thisptr
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "FGFDMExec \n" \
             "root dir\t:\t{0}\n" \
             "aircraft path\t:\t{1}\n" \
@@ -616,30 +620,31 @@ cdef class FGFDMExec(FGJSBBase):
                 self.get_systems_path(),
                 self.get_output_path())
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> float:
         _key = key.strip()
         pm = self.get_property_manager()
         if not pm.hasNode(_key):
             raise KeyError("No property named {}".format(_key))
         return self.get_property_value(_key)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: float) -> None:
         self.set_property_value(key.strip(), value)
 
-    def run(self):
+    def run(self) -> bool:
         """@Dox(JSBSim::FGFDMExec::Run)"""
         return self.thisptr.Run()
 
-    def run_ic(self):
+    def run_ic(self) -> bool:
         """@Dox(JSBSim::FGFDMExec::RunIC)"""
         return  self.thisptr.RunIC()
 
-    def load_model(self, model, add_model_to_path=True):
+    def load_model(self, model: str, add_model_to_path: bool = True) -> bool:
         """@Dox(JSBSim::FGFDMExec::LoadModel(const std::string &, bool))"""
         return self.thisptr.LoadModel(model.encode(), add_model_to_path)
 
-    def load_model_with_paths(self, model, aircraft_path,
-                   engine_path, systems_path, add_model_to_path=True):
+    def load_model_with_paths(self, model: str, aircraft_path: str,
+                   engine_path: str, systems_path: str,
+                   add_model_to_path: bool = True) -> bool:
         """@Dox(JSBSim::FGFDMExec::LoadModel(const SGPath &, const SGPath &,
                                              const SGPath &, const std::string &,
                                              bool))"""
@@ -648,7 +653,7 @@ cdef class FGFDMExec(FGJSBBase):
                                       c_SGPath(systems_path.encode(), NULL),
                                       model.encode(), add_model_to_path)
 
-    def load_script(self, script, delta_t=0.0, initfile=""):
+    def load_script(self, script: str, delta_t: float = 0.0, initfile:str = "") -> bool:
         """@Dox(JSBSim::FGFDMExec::LoadScript) """
         scriptfile = os.path.join(self.get_root_dir(), script)
         if not os.path.exists(scriptfile):
@@ -657,187 +662,187 @@ cdef class FGFDMExec(FGJSBBase):
         return self.thisptr.LoadScript(c_SGPath(script.encode(), NULL), delta_t,
                                        c_SGPath(initfile.encode(),NULL))
 
-    def set_engine_path(self, path):
+    def set_engine_path(self, path: str) -> bool:
         """@Dox(JSBSim::FGFDMExec::SetEnginePath) """
         return self.thisptr.SetEnginePath(c_SGPath(path.encode(), NULL))
 
-    def set_aircraft_path(self, path):
+    def set_aircraft_path(self, path: str) -> bool:
         """@Dox(JSBSim::FGFDMExec::SetAircraftPath)"""
         return self.thisptr.SetAircraftPath(c_SGPath(path.encode(), NULL))
 
-    def set_systems_path(self, path):
+    def set_systems_path(self, path: str) -> bool:
         """@Dox(JSBSim::FGFDMExec::SetSystemsPath) """
         return self.thisptr.SetSystemsPath(c_SGPath(path.encode(), NULL))
 
-    def set_output_path(self, path):
+    def set_output_path(self, path: str) -> bool:
         """@Dox(JSBSim::FGFDMExec::SetOutputPath) """
         return self.thisptr.SetOutputPath(c_SGPath(path.encode(), NULL))
 
-    def set_root_dir(self, path):
+    def set_root_dir(self, path: str) -> None:
         """@Dox(JSBSim::FGFDMExec::SetRootDir)"""
         self.thisptr.SetRootDir(c_SGPath(path.encode(), NULL))
 
-    def get_engine_path(self):
+    def get_engine_path(self) -> str:
         """@Dox(JSBSim::FGFDMExec::GetEnginePath)"""
         return self.thisptr.GetEnginePath().utf8Str().decode('utf-8')
 
-    def get_aircraft_path(self):
+    def get_aircraft_path(self) -> str:
         """@Dox(JSBSim::FGFDMExec::GetAircraftPath)"""
         return self.thisptr.GetAircraftPath().utf8Str().decode('utf-8')
 
-    def get_systems_path(self):
+    def get_systems_path(self) -> str:
         """@Dox(JSBSim::FGFDMExec::GetSystemsPath)"""
         return self.thisptr.GetSystemsPath().utf8Str().decode('utf-8')
 
-    def get_output_path(self):
+    def get_output_path(self) -> str:
         """@Dox(JSBSim::FGFDMExec::GetOutputPath)"""
         return self.thisptr.GetOutputPath().utf8Str().decode('utf-8')
 
-    def get_full_aircraft_path(self):
+    def get_full_aircraft_path(self) -> str:
         """@Dox(JSBSim::FGFDMExec::GetFullAircraftPath)"""
         return self.thisptr.GetFullAircraftPath().utf8Str().decode('utf-8')
 
-    def get_root_dir(self):
+    def get_root_dir(self) -> str:
         """@Dox(JSBSim::FGFDMExec::GetRootDir)"""
         return self.thisptr.GetRootDir().utf8Str().decode('utf-8')
 
-    def get_property_value(self, name):
+    def get_property_value(self, name: str) -> float:
         """@Dox(JSBSim::FGFDMExec::GetPropertyValue) """
         return self.thisptr.GetPropertyValue(name.encode())
 
-    def set_property_value(self, name, value):
+    def set_property_value(self, name: str, value: float) -> None:
         """@Dox(JSBSim::FGFDMExec::SetPropertyValue)"""
         self.thisptr.SetPropertyValue(name.encode(), value)
 
-    def get_model_name(self):
+    def get_model_name(self) -> str:
         """@Dox(JSBSim::FGFDMExec::GetModelName)"""
         return self.thisptr.GetModelName().decode()
 
-    def set_output_directive(self, fname):
+    def set_output_directive(self, fname: str) -> bool:
         """@Dox(JSBSim::FGFDMExec::SetOutputDirectives)"""
         return self.thisptr.SetOutputDirectives(c_SGPath(fname.encode(), NULL))
 
-    # def force_output(self, index):
+    # def force_output(self, index: int) -> None:
     #     """@Dox(JSBSim::FGFDMExec::ForceOutput)"""
     #     self.thisptr.ForceOutput(index)
 
-    def set_logging_rate(self, rate):
+    def set_logging_rate(self, rate: float) -> None:
         """@Dox(JSBSim::FGFDMExec::SetLoggingRate)"""
         self.thisptr.SetLoggingRate(rate)
 
-    def set_output_filename(self, n, fname):
+    def set_output_filename(self, n: int, fname: str) -> bool:
         """@Dox(JSBSim::FGFDMExec::SetOutputFileName)"""
         return self.thisptr.SetOutputFileName(n, fname.encode())
 
-    def get_output_filename(self, n):
+    def get_output_filename(self, n: int) -> str:
         """@Dox(JSBSim::FGFDMExec::GetOutputFileName)"""
         return self.thisptr.GetOutputFileName(n).decode()
 
-    def do_trim(self, mode):
+    def do_trim(self, mode: int) -> None:
         """@Dox(JSBSim::FGFDMExec::DoTrim) """
         self.thisptr.DoTrim(mode)
 
-    def disable_output(self):
+    def disable_output(self) -> None:
         """@Dox(JSBSim::FGFDMExec::DisableOutput)"""
         self.thisptr.DisableOutput()
 
-    def enable_output(self):
+    def enable_output(self) -> None:
         """@Dox(JSBSim::FGFDMExec::EnableOutput)"""
         self.thisptr.EnableOutput()
 
-    def hold(self):
+    def hold(self) -> None:
         """@Dox(JSBSim::FGFDMExec::Hold)"""
         self.thisptr.Hold()
 
-    def enable_increment_then_hold(self, time_steps):
+    def enable_increment_then_hold(self, time_steps: int) -> None:
         """@Dox(JSBSim::FGFDMExec::EnableIncrementThenHold)"""
         self.thisptr.EnableIncrementThenHold(time_steps)
 
-    def check_incremental_hold(self):
+    def check_incremental_hold(self) -> None:
         """@Dox(JSBSim::FGFDMExec::CheckIncrementalHold)"""
         self.thisptr.CheckIncrementalHold()
 
-    def resume(self):
+    def resume(self) -> None:
         """@Dox(JSBSim::FGFDMExec::Resume)"""
         self.thisptr.Resume()
 
-    def holding(self):
+    def holding(self) -> bool:
         """@Dox(JSBSim::FGFDMExec::Holding)"""
         return self.thisptr.Holding()
 
-    def reset_to_initial_conditions(self, mode):
+    def reset_to_initial_conditions(self, mode: int) -> None:
         """@Dox(JSBSim::FGFDMExec::ResetToInitialConditions)"""
         self.thisptr.ResetToInitialConditions(mode)
 
-    def set_debug_level(self, level):
+    def set_debug_level(self, level: int) -> None:
         """@Dox(JSBSim::FGFDMExec::SetDebugLevel)"""
         self.thisptr.SetDebugLevel(level)
 
-    def query_property_catalog(self, check):
+    def query_property_catalog(self, check: str) -> str:
         """@Dox(JSBSim::FGFDMExec::QueryPropertyCatalog)"""
         return (self.thisptr.QueryPropertyCatalog(check.encode())).decode('utf-8')
 
-    def get_property_catalog(self):
+    def get_property_catalog(self) -> List[str]:
         """Retrieves the property catalog as a list."""
         return self.query_property_catalog('').rstrip().split('\n')
 
-    def print_property_catalog(self):
+    def print_property_catalog(self) -> None:
         """@Dox(JSBSim::FGFDMExec::PrintPropertyCatalog)"""
         self.thisptr.PrintPropertyCatalog()
 
-    def print_simulation_configuration(self):
+    def print_simulation_configuration(self) -> None:
         """@Dox(JSBSim::FGFDMExec::PrintSimulationConfiguration)"""
         self.thisptr.PrintSimulationConfiguration()
 
-    def set_trim_status(self, status):
+    def set_trim_status(self, status: bool) -> None:
         """@Dox(JSBSim::FGFDMExec::SetTrimStatus)"""
         self.thisptr.SetTrimStatus(status)
 
-    def get_trim_status(self):
+    def get_trim_status(self) -> bool:
         """@Dox(JSBSim::FGFDMExec::GetTrimStatus)"""
         return self.thisptr.GetTrimStatus()
 
-    def get_propulsion_tank_report(self):
+    def get_propulsion_tank_report(self) -> str:
         """@Dox(JSBSim::FGFDMExec::GetPropulsionTankReport)"""
         return self.thisptr.GetPropulsionTankReport().decode()
 
-    def get_sim_time(self):
+    def get_sim_time(self) -> float:
         """@Dox(JSBSim::FGFDMExec::GetSimTime)"""
         return self.thisptr.GetSimTime()
 
-    def get_delta_t(self):
+    def get_delta_t(self) -> float:
         """@Dox(JSBSim::FGFDMExec::GetDeltaT)"""
         return self.thisptr.GetDeltaT()
 
-    def suspend_integration(self):
+    def suspend_integration(self) -> None:
         """@Dox(JSBSim::FGFDMExec::SuspendIntegration)"""
         self.thisptr.SuspendIntegration()
 
-    def resume_integration(self):
+    def resume_integration(self) -> None:
         """@Dox(JSBSim::FGFDMExec::ResumeIntegration)"""
         self.thisptr.ResumeIntegration()
 
-    def integration_suspended(self):
+    def integration_suspended(self) -> bool:
         """@Dox(JSBSim::FGFDMExec::IntegrationSuspended)"""
         return self.thisptr.IntegrationSuspended()
 
-    def set_sim_time(self, time):
+    def set_sim_time(self, time: float) -> bool:
         """@Dox(JSBSim::FGFDMExec::Setsim_time)"""
         return self.thisptr.Setsim_time(time)
 
-    def set_dt(self, dt):
+    def set_dt(self, dt: float) -> None:
         """@Dox(JSBSim::FGFDMExec::Setdt)"""
         self.thisptr.Setdt(dt)
 
-    def incr_time(self):
+    def incr_time(self) -> float:
         """@Dox(JSBSim::FGFDMExec::IncrTime)"""
         return self.thisptr.IncrTime()
 
-    def get_debug_level(self):
+    def get_debug_level(self) -> int:
         """@Dox(JSBSim::FGFDMExec::GetDebugLevel) """
         return self.thisptr.GetDebugLevel()
 
-    def load_ic(self, rstfile, useStoredPath):
+    def load_ic(self, rstfile: str, useStoredPath: bool) -> bool:
         reset_file = _append_xml(rstfile)
         if useStoredPath and not os.path.isabs(reset_file):
             reset_file = os.path.join(self.get_full_aircraft_path(), reset_file)
@@ -847,55 +852,55 @@ cdef class FGFDMExec(FGJSBBase):
         return deref(self.thisptr.GetIC()).Load(c_SGPath(rstfile.encode(), NULL),
                                                 useStoredPath)
 
-    def get_propagate(self):
+    def get_propagate(self) -> FGPropagate:
         """@Dox(JSBSim::FGFDMExec::GetPropagate)"""
         propagate = FGPropagate(None)
         propagate.thisptr = self.thisptr.GetPropagate()
         return propagate
 
-    def get_property_manager(self):
+    def get_property_manager(self) -> FGPropertyManager:
         """@Dox(JSBSim::FGFDMExec::GetPropertyManager)"""
         pm = FGPropertyManager()
         pm.thisptr = self.thisptr.GetPropertyManager()
         return pm
 
-    def get_ground_reactions(self):
+    def get_ground_reactions(self) -> FGGroundReactions:
         """@Dox(JSBSim::FGFDMExec::GetGroundReactions)"""
         grndreact = FGGroundReactions(None)
         grndreact.thisptr = self.thisptr.GetGroundReactions()
         return grndreact
 
-    def get_auxiliary(self):
+    def get_auxiliary(self) -> FGAuxiliary:
         """@Dox(JSBSim::FGFDMExec::GetAuxiliary)"""
         auxiliary = FGAuxiliary(None)
         auxiliary.thisptr = self.thisptr.GetAuxiliary()
         return auxiliary
 
-    def get_aerodynamics(self):
+    def get_aerodynamics(self) -> FGAerodynamics:
         """@Dox(JSBSim::FGFDMExec::GetAerodynamics)"""
         aerodynamics = FGAerodynamics(None)
         aerodynamics.thisptr = self.thisptr.GetAerodynamics()
         return aerodynamics
 
-    def get_aircraft(self):
+    def get_aircraft(self) -> FGAircraft:
         """@Dox(JSBSim::FGFDMExec::GetAircraft)"""
         aircraft = FGAircraft(None)
         aircraft.thisptr = self.thisptr.GetAircraft()
         return aircraft
 
-    def get_mass_balance(self):
+    def get_mass_balance(self) -> FGMassBalance:
         """@Dox(JSBSim::FGFDMExec::GetMassBalance)"""
         massbalance = FGMassBalance(None)
         massbalance.thisptr = self.thisptr.GetMassBalance()
         return massbalance
 
-    def get_atmosphere(self):
+    def get_atmosphere(self) -> FGAtmosphere:
         """@Dox(JSBSim::FGFDMExec::GetAtmosphere)"""
         atmosphere = FGAtmosphere()
         atmosphere.thisptr = self.thisptr.GetAtmosphere()
         return atmosphere
 
-    def get_propulsion(self):
+    def get_propulsion(self) -> FGPropulsion:
         """@Dox(JSBSim::FGFDMExec::GetPropulsion)"""
         propulsion = FGPropulsion(None)
         propulsion.thisptr = self.thisptr.GetPropulsion()

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -205,7 +205,7 @@ else:
 # Prepare the list of XML data files (aircraft, engines, ...)
 package_data_files = ['_jsbsim.pxd', 'engine/*.xml', 'scripts/*.xml', 'systems/*.xml',
                       'aircraft/*.xml', 'LICENSE.txt', 'libexpat-LICENSE.txt',
-                      'GeographicLib-LICENSE.txt', 'py.typed']
+                      'GeographicLib-LICENSE.txt', 'py.typed', '*.pyi']
 
 # Iterate over the aircraft folders
 for d in os.scandir('jsbsim/aircraft'):

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -257,4 +257,5 @@ setup(
     python_requires=">=3.7",
     packages=['jsbsim'],
     package_data={'jsbsim': package_data_files},
+    zip_safe=False,  # needed for mypy to find the type hints stubs
     **setup_kwargs)

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -205,7 +205,7 @@ else:
 # Prepare the list of XML data files (aircraft, engines, ...)
 package_data_files = ['_jsbsim.pxd', 'engine/*.xml', 'scripts/*.xml', 'systems/*.xml',
                       'aircraft/*.xml', 'LICENSE.txt', 'libexpat-LICENSE.txt',
-                      'GeographicLib-LICENSE.txt']
+                      'GeographicLib-LICENSE.txt', 'py.typed']
 
 # Iterate over the aircraft folders
 for d in os.scandir('jsbsim/aircraft'):
@@ -252,7 +252,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules"
     ],
     scripts=['JSBSim.py'],
-    install_requires=['numpy'],
+    install_requires=['numpy>=1.20'],
     ext_modules=[Extension('jsbsim._jsbsim', language='c++', **ext_kwargs)],
     python_requires=">=3.7",
     packages=['jsbsim'],


### PR DESCRIPTION
As per @Dobid's feature request in issue #750, this PR adds type hints for the JSBSim Python module.

After the merge of this PR types hints will be added to the Python module as per the [PEP 561 – Distributing and Packaging Type Information](https://peps.python.org/pep-0561/). Basically this means that types stubs (i.e. files `*.pyi` and `py.typed`) are generated by the `stubgen` utility from the [mypy project](https://github.com/python/mypy) and included in the wheels that are built by our CI workflow.

Fixes #750.