### PR TITLE
Locale independent numbers parsing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 ################################################################################
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 # MSVC specific compile definitions
 set(MSVC_COMPILE_DEFINITIONS _USE_MATH_DEFINES NOMINMAX _HAS_STD_BYTE=0)
 
@@ -118,10 +120,10 @@ foreach(COMPILE_DEF ${COMPILE_DEFINITIONS})
   endforeach(TARGET_OBJECT)
 endforeach(COMPILE_DEF)
 
-set_target_properties (libJSBSim PROPERTIES
-                                 OUTPUT_NAME JSBSim
-                                 VERSION ${LIBRARY_VERSION}
-                                 TARGET_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(libJSBSim PROPERTIES
+                                OUTPUT_NAME JSBSim
+                                VERSION ${LIBRARY_VERSION}
+                                TARGET_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Manage link libraries
 set(JSBSIM_LINK_LIBRARIES ${ALL_LINK_LIBRARIES} PARENT_SCOPE)
@@ -139,9 +141,9 @@ elseif(UNIX)
 endif()
 
 if(BUILD_SHARED_LIBS)
-  set_target_properties (libJSBSim PROPERTIES
-                                   SOVERSION ${LIBRARY_SOVERSION}
-                                   FRAMEWORK ON)
+  set_target_properties(libJSBSim PROPERTIES
+                                  SOVERSION ${LIBRARY_SOVERSION}
+                                  FRAMEWORK ON)
   install(TARGETS libJSBSim LIBRARY DESTINATION lib
                             NAMELINK_SKIP
                             COMPONENT runtime

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,11 +4,10 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 # Define some commons compile flags.                                           #
 ################################################################################
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 # MSVC specific compile definitions
-set(MSVC_COMPILE_DEFINITIONS _USE_MATH_DEFINES NOMINMAX _HAS_STD_BYTE=0)
+set(MSVC_COMPILE_DEFINITIONS _USE_MATH_DEFINES NOMINMAX)
 
 ################################################################################
 # Init the list of libraries that JSBSim links with                            #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,9 +4,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 # Define some commons compile flags.                                           #
 ################################################################################
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 # MSVC specific compile definitions
-set(MSVC_COMPILE_DEFINITIONS _USE_MATH_DEFINES NOMINMAX)
+set(MSVC_COMPILE_DEFINITIONS _USE_MATH_DEFINES NOMINMAX _HAS_STD_BYTE=0)
 
 ################################################################################
 # Init the list of libraries that JSBSim links with                            #

--- a/src/input_output/CMakeLists.txt
+++ b/src/input_output/CMakeLists.txt
@@ -14,7 +14,8 @@ set(SOURCES FGGroundCallback.cpp
             FGModelLoader.cpp
             FGInputType.cpp
             FGInputSocket.cpp
-            FGUDPInputSocket.cpp)
+            FGUDPInputSocket.cpp
+            string_utilities.cpp)
 
 set(HEADERS FGGroundCallback.h
             FGPropertyManager.h

--- a/src/input_output/FGInputSocket.cpp
+++ b/src/input_output/FGInputSocket.cpp
@@ -136,7 +136,7 @@ void FGInputSocket::Read(bool Holding)
       // now parse individual line
       vector <string> tokens = split(line,' ');
 
-      string command="", argument="", str_value="";
+      string command, argument, str_value;
       if (!tokens.empty()) {
         command = to_lower(tokens[0]);
         if (tokens.size() > 1) {
@@ -168,8 +168,19 @@ void FGInputSocket::Read(bool Holding)
           socket->Reply("Not a leaf property\r\n");
           break;
         } else {
-          double value = atof(str_value.c_str());
-          node->setDoubleValue(value);
+          if (is_number(trim(str_value))) {
+            try {
+              double value = atof_locale_c(str_value);
+              node->setDoubleValue(value);
+            } catch(BaseException& e) {
+              socket->Reply(e.what());
+              break;
+            }
+          }
+          else {
+            socket->Reply("Invalid number\r\n");
+            break;
+          }
         }
         socket->Reply("set successful\r\n");
 

--- a/src/input_output/FGXMLElement.cpp
+++ b/src/input_output/FGXMLElement.cpp
@@ -293,12 +293,12 @@ double Element::GetAttributeValueAsNumber(const string& attr)
   else {
     double number=0;
     if (is_number(trim(attribute)))
-      number = atof(attribute.c_str());
+      number = atof_locale_c(attribute);
     else {
       std::stringstream s;
       s << ReadFrom() << "Expecting numeric attribute value, but got: " << attribute;
       cerr << s.str() << endl;
-      throw invalid_argument(s.str());
+      throw BaseException(s.str());
     }
 
     return (number);
@@ -347,12 +347,12 @@ double Element::GetDataAsNumber(void)
   if (data_lines.size() == 1) {
     double number=0;
     if (is_number(trim(data_lines[0])))
-      number = atof(data_lines[0].c_str());
+      number = atof_locale_c(data_lines[0]);
     else {
       std::stringstream s;
       s << ReadFrom() << "Expected numeric value, but got: " << data_lines[0];
       cerr << s.str() << endl;
-      throw invalid_argument(s.str());
+      throw BaseException(s.str());
     }
 
     return number;

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -1,0 +1,70 @@
+/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+ Module:       string_utilities.cpp
+ Author:       Bertrand Coconnier
+ Date started: 12/28/22
+ Purpose:      Utilities to manipulate strings.
+
+ ------------- Copyright (C) 2022 Bertrand Coconnier -------------
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2 of the License, or (at your option) any
+ later version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ details.
+
+ You should have received a copy of the GNU Lesser General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc., 59
+ Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+ Further information about the GNU Lesser General Public License can also be
+ found on the world wide web at http://www.gnu.org.
+
+FUNCTIONAL DESCRIPTION
+--------------------------------------------------------------------------------
+This is the place where you create output routines to dump data for perusal
+later.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+INCLUDES
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+#include <charconv>
+#include <sstream>
+#include <stdexcept>
+#include <system_error>
+
+#include "FGJSBBase.h"
+#include "string_utilities.h"
+
+double atof_locale_c(const std::string& input)
+{
+  const char* first = input.c_str();
+  const char* last = first + input.size();
+  double value = 0.0;
+
+  // Skip leading whitespaces
+  while (isspace(*first)) ++first;
+  //Ignoring the leading '+' sign
+  if (*first == '+') ++first;
+
+  std::from_chars_result result = std::from_chars(first, last, value);
+
+  if (result.ec == std::errc())
+    return value;
+
+  // Error management
+  std::stringstream s;
+
+  if (result.ec == std::errc::invalid_argument)
+    s << "Expecting numeric attribute value, but got: " << input;
+  else if (result.ec == std::errc::result_out_of_range)
+    s << "This number is too large: " << input;
+
+  std::cerr << s.str() << std::endl;
+  throw JSBSim::BaseException(s.str());
+}

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -85,7 +85,7 @@ double atof_locale_c(const std::string& input)
 
   CNumericLocale numeric_c;
   errno = 0;          // Reset the error code
-  double value = _strtod_l(first, nullptr, numeric_c.Locale);
+  double value = strtod_l(first, nullptr, numeric_c.Locale);
 
   // Error management
   std::stringstream s;

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -55,20 +55,24 @@ double atof_locale_c(const std::string& input)
 
 #ifdef _WIN32
   _locale_t lc_numeric_c = _create_locale(LC_NUMERIC, "C");
+  errno = 0;
   double value = _strtod_l(first, nullptr, lc_numeric_c);
+  int error = errno;
   _free_locale(lc_numeric_c);
 #else
-  locale_t lc_numeric_c = newlocale(LC_NUMERIC_MASK, "C", LC_GLOBAL_LOCALE);
+  locale_t lc_numeric_c = newlocale(LC_NUMERIC_MASK, "C", 0);
+  errno = 0;
   double value = strtod_l(first, nullptr, lc_numeric_c);
+  int error = errno;
   freelocale(lc_numeric_c);
 #endif
 
   // Error management
   std::stringstream s;
 
-  if (fabs(value) == HUGE_VAL && errno == ERANGE)
+  if (fabs(value) == HUGE_VAL && error == ERANGE)
     s << "This number is too large: " << input;
-  else if (fabs(value) == 0 && errno == EINVAL)
+  else if (fabs(value) == 0 && error == EINVAL)
     s << "Expecting numeric attribute value, but got: " << input;
   else
     return value;

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -34,10 +34,10 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <errno.h>
-#ifdef _WIN32
-#include <locale.h>
-#else
+#ifdef __APPLE__
 #include <xlocale.h>
+#else
+#include <locale.h>
 #endif
 #include <sstream>
 

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -44,6 +44,10 @@ INCLUDES
 #include "FGJSBBase.h"
 #include "string_utilities.h"
 
+/* This function is a locale independent version of atof().
+ * Whatever is the current locale of the application, atof_locale_c() reads
+ * numbers assuming that the decimal point is the period (.)
+ */
 double atof_locale_c(const std::string& input)
 {
   const char* first = input.c_str();
@@ -55,15 +59,15 @@ double atof_locale_c(const std::string& input)
 
 #ifdef _WIN32
   _locale_t lc_numeric_c = _create_locale(LC_NUMERIC, "C");
-  errno = 0;
+  errno = 0;          // Reset the error code
   double value = _strtod_l(first, nullptr, lc_numeric_c);
-  int error = errno;
+  int error = errno;  // Save the error code
   _free_locale(lc_numeric_c);
 #else
   locale_t lc_numeric_c = newlocale(LC_NUMERIC_MASK, "C", 0);
-  errno = 0;
+  errno = 0;          // Reset the error code
   double value = strtod_l(first, nullptr, lc_numeric_c);
-  int error = errno;
+  int error = errno;  // Save the error code
   freelocale(lc_numeric_c);
 #endif
 

--- a/src/input_output/string_utilities.h
+++ b/src/input_output/string_utilities.h
@@ -50,7 +50,7 @@ INCLUDES
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-JSBSIM_API bool is_number(const std::string& str);
+JSBSIM_API double atof_locale_c(const std::string& input);
 
 #if !defined(BASE)
   extern std::string& trim_left(std::string& str);
@@ -59,6 +59,7 @@ JSBSIM_API bool is_number(const std::string& str);
   extern std::string& trim_all_space(std::string& str);
   extern std::string& to_upper(std::string& str);
   extern std::string& to_lower(std::string& str);
+  extern bool is_number(const std::string& str);
   std::vector <std::string> split(std::string str, char d);
 
   extern std::string replace(std::string str, const std::string& old, const std::string& newstr);

--- a/src/input_output/string_utilities.h
+++ b/src/input_output/string_utilities.h
@@ -50,6 +50,7 @@ INCLUDES
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+JSBSIM_API bool is_number(const std::string& str);
 JSBSIM_API double atof_locale_c(const std::string& input);
 
 #if !defined(BASE)
@@ -59,7 +60,6 @@ JSBSIM_API double atof_locale_c(const std::string& input);
   extern std::string& trim_all_space(std::string& str);
   extern std::string& to_upper(std::string& str);
   extern std::string& to_lower(std::string& str);
-  extern bool is_number(const std::string& str);
   std::vector <std::string> split(std::string str, char d);
 
   extern std::string replace(std::string str, const std::string& old, const std::string& newstr);

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -600,10 +600,24 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
       double stddev = 1.0;
       string mean_attr = element->GetAttributeValue("mean");
       string stddev_attr = element->GetAttributeValue("stddev");
-      if (!mean_attr.empty())
-        mean = atof(mean_attr.c_str());
-      if (!stddev_attr.empty())
-        stddev = atof(stddev_attr.c_str());
+      if (!mean_attr.empty()) {
+        if (is_number(trim(mean_attr)))
+          mean = atof_locale_c(mean_attr);
+        else {
+          cerr << element->ReadFrom()
+               << "Expecting a number, but got: " << mean_attr <<endl;
+          throw BaseException("Invalid number");
+        }
+      }
+      if (!stddev_attr.empty()) {
+        if (is_number(trim(stddev_attr)))
+          stddev = atof_locale_c(stddev_attr);
+        else {
+          cerr << element->ReadFrom()
+               << "Expecting a number, but got: " << stddev_attr <<endl;
+          throw BaseException("Invalid number");
+        }
+      }
       auto generator(makeRandomGenerator(element, fdmex));
       auto f = [generator, mean, stddev]()->double {
                  double value = generator->GetNormalRandomNumber();
@@ -616,10 +630,24 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
       double upper = 1.0;
       string lower_attr = element->GetAttributeValue("lower");
       string upper_attr = element->GetAttributeValue("upper");
-      if (!lower_attr.empty())
-        lower = atof(lower_attr.c_str());
-      if (!upper_attr.empty())
-        upper = atof(upper_attr.c_str());
+      if (!lower_attr.empty()) {
+        if (is_number(trim(lower_attr)))
+          lower = atof_locale_c(lower_attr);
+        else {
+          cerr << element->ReadFrom()
+               << "Expecting a number, but got: " << lower_attr <<endl;
+          throw BaseException("Invalid number");
+        }
+      }
+      if (!upper_attr.empty()) {
+        if (is_number(trim(upper_attr)))
+          upper = atof_locale_c(upper_attr);
+        else {
+          cerr << element->ReadFrom()
+               << "Expecting a number, but got: " << upper_attr <<endl;
+          throw BaseException("Invalid number");
+        }
+      }
       auto generator(makeRandomGenerator(element, fdmex));
       double a = 0.5*(upper-lower);
       double b = 0.5*(upper+lower);

--- a/src/models/flight_control/FGSwitch.cpp
+++ b/src/models/flight_control/FGSwitch.cpp
@@ -87,9 +87,10 @@ FGSwitch::FGSwitch(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
     value = test_element->GetAttributeValue("value");
     current_test->setTestValue(value, Name, PropertyManager, test_element);
     current_test->Default = true;
-    if (delay > 0 && is_number(value)) {        // If there is a delay, initialize the
+    if (delay > 0 && is_number(trim(value))) {  // If there is a delay, initialize the
+      double v = atof_locale_c(value);
       for (unsigned int i=0; i<delay-1; i++) {  // delay buffer to the default value
-        output_array[i] = atof(value.c_str());  // for the switch if that value is a number.
+        output_array[i] = v;                    // for the switch if that value is a number.
       }
     }
     tests.push_back(current_test);

--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -487,8 +487,8 @@ bool FGTurbine::Load(FGFDMExec* exec, Element *el)
   JSBSim::Element* tsfcElement = el->FindElement("tsfc");
   if (tsfcElement) {
     string value = tsfcElement->GetDataLine();
-    if (is_number(value))
-      TSFC = std::make_unique<FGSimplifiedTSFC>(this, atof(value.c_str()));
+    if (is_number(trim(value)))
+      TSFC = std::make_unique<FGSimplifiedTSFC>(this, atof_locale_c(value));
     else
       TSFC = std::make_unique<FGFunction>(FDMExec, tsfcElement, to_string(EngineNumber));
   }
@@ -496,8 +496,8 @@ bool FGTurbine::Load(FGFDMExec* exec, Element *el)
   JSBSim::Element* atsfcElement = el->FindElement("atsfc");
   if (atsfcElement) {
     string value = atsfcElement->GetDataLine();
-    if (is_number(value))
-      ATSFC = std::make_unique<FGRealValue>(atof(value.c_str()));
+    if (is_number(trim(value)))
+      ATSFC = std::make_unique<FGRealValue>(atof_locale_c(value));
     else
       ATSFC = std::make_unique<FGFunction>(FDMExec, atsfcElement, to_string((int)EngineNumber));
   }

--- a/tests/unit_tests/StringUtilitiesTest.h
+++ b/tests/unit_tests/StringUtilitiesTest.h
@@ -3,6 +3,7 @@
 #define BASE
 #include <input_output/string_utilities.h>
 #undef BASE
+#include "FGJSBBase.h"
 
 class StringUtilitiesTest : public CxxTest::TestSuite
 {
@@ -85,6 +86,14 @@ public:
                              std::string("ab")), std::string("xabzzu"));
     TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("b"),
                              std::string("w")), std::string("xyzzu"));
+  }
+
+  void testAtofLocaleC() {
+    TS_ASSERT_EQUALS(atof_locale_c("+1  "), 1.0);
+    TS_ASSERT_EQUALS(atof_locale_c(" 123.4"), 123.4);
+    TS_ASSERT_THROWS(atof_locale_c("XYZ"), JSBSim::BaseException&);
+    TS_ASSERT_THROWS(atof_locale_c("1E+999"), JSBSim::BaseException&);
+    TS_ASSERT_EQUALS(atof_locale_c("-3.14e-2"), -0.0314);
   }
 
 private:

--- a/tests/unit_tests/StringUtilitiesTest.h
+++ b/tests/unit_tests/StringUtilitiesTest.h
@@ -91,9 +91,12 @@ public:
   void testAtofLocaleC() {
     TS_ASSERT_EQUALS(atof_locale_c("+1  "), 1.0);
     TS_ASSERT_EQUALS(atof_locale_c(" 123.4"), 123.4);
-    TS_ASSERT_THROWS(atof_locale_c("XYZ"), JSBSim::BaseException&);
-    TS_ASSERT_THROWS(atof_locale_c("1E+999"), JSBSim::BaseException&);
     TS_ASSERT_EQUALS(atof_locale_c("-3.14e-2"), -0.0314);
+    TS_ASSERT_EQUALS(atof_locale_c("1E-999"), 0.0);
+    TS_ASSERT_EQUALS(atof_locale_c("-1E-999"), 0.0);
+    TS_ASSERT_EQUALS(atof_locale_c("0.0"), 0.0);
+    TS_ASSERT_THROWS(atof_locale_c("1E+999"), JSBSim::BaseException&);
+    TS_ASSERT_THROWS(atof_locale_c("-1E+999"), JSBSim::BaseException&);
   }
 
 private:


### PR DESCRIPTION
Following the discussion in issue #795, the calls to `atof()` are replaced by a new function `atof_locale_c` that parses numbers assuming the decimal separator is the period `.` whatever is the current locale.

The code uses `strtod_l` that is not part of the C/C++ standard however the code compiles on all platforms that JSBSim supports.