### PR TITLE
UnrealEngine TurboProp Plane implementation Fixes

### DIFF
--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
@@ -1102,7 +1102,7 @@ void UJSBSimMovementComponent::DrawDebugMessage()
 	DebugMessage += LINE_TERMINATOR;
 	int32 NumGears = Gears.Num();
 	DebugMessage += FString::Printf(TEXT("Landing Gears (%d) : "), NumGears) + LINE_TERMINATOR;
-	for (int32 i = 0; i < NumTanks; i++)
+	for (int32 i = 0; i < NumGears; i++)
 	{
 		if (Gears[i].IsBogey)
 		{

--- a/src/models/propulsion/FGTurboProp.h
+++ b/src/models/propulsion/FGTurboProp.h
@@ -124,7 +124,7 @@ public:
   double getOilTemp_degF (void) {return KelvinToFahrenheit(OilTemp_degK);}
 
   inline bool GetGeneratorPower(void) const { return GeneratorPower; }
-  inline bool GetCondition(void) const { return Condition; }
+  inline int GetCondition(void) const { return Condition; }
 
   void SetPhase( phaseType p ) { phase = p; }
   void SetReverse(bool reversed) { Reversed = reversed; }
@@ -176,7 +176,7 @@ private:
 
   bool EngStarting;            // logicaly output - TRUE if engine is starting
   bool GeneratorPower;
-  bool Condition;
+  int Condition;
   int thrusterType;            // the attached thruster
 
   double Off(void);

--- a/src/models/propulsion/FGTurboProp.h
+++ b/src/models/propulsion/FGTurboProp.h
@@ -124,7 +124,7 @@ public:
   double getOilTemp_degF (void) {return KelvinToFahrenheit(OilTemp_degK);}
 
   inline bool GetGeneratorPower(void) const { return GeneratorPower; }
-  inline int GetCondition(void) const { return Condition; }
+  inline bool GetCondition(void) const { return Condition; }
 
   void SetPhase( phaseType p ) { phase = p; }
   void SetReverse(bool reversed) { Reversed = reversed; }
@@ -176,7 +176,7 @@ private:
 
   bool EngStarting;            // logicaly output - TRUE if engine is starting
   bool GeneratorPower;
-  int Condition;
+  bool Condition;
   int thrusterType;            // the attached thruster
 
   double Off(void);


### PR DESCRIPTION
I'm trying to implement TurboProp and rocket support in UnrealEngine Plugin, it is simple fix not a "matah" thing (meant meritorious in Turkish).

I look up the Condition. It's possible values are 0 and 1. Also following error taken in UE5:

```
Build started...
1>------ Skipped Build: Project: UE5, Configuration: BuiltWithUnrealBuildTool Win64 ------
1>Project not selected to build for this solution configuration
2>------ Build started: Project: UEReferenceApp, Configuration: Development_Editor x64 ------
2>Using bundled DotNet SDK
2>Log file: C:\Users\Zaryob\AppData\Local\UnrealBuildTool\Log.txt
2>Using 'git status' to determine working set for adaptive non-unity build (D:\Development\Adal\jsbsim).
2>Building UEReferenceAppEditor...
2>Using Visual Studio 2022 14.34.31937 toolchain (C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.34.31933) and Windows 10.0.22621.0 SDK (C:\Program Files (x86)\Windows Kits\10).
2>[Adaptive Build] Excluded from JSBSimFlightDynamicsModel unity file: JSBSimMovementComponent.cpp
2>Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
2>  Executing up to 8 processes, one per physical core
2>  Requested 1.5 GB free memory per action, 2.35 GB available: limiting max parallel actions to 1
2>Building 4 actions with 1 process...
2>[1/4] Compile JSBSimMovementComponent.cpp
2>D:\Development\Adal\jsbsim\UnrealEngine\Plugins\JSBSimFlightDynamicsModel\Source\JSBSimFlightDynamicsModel\Private\JSBSimMovementComponent.cpp(1024): error C4800: Implicit conversion from 'int' to bool. Possible information loss
2>D:\Development\Adal\jsbsim\UnrealEngine\Plugins\JSBSimFlightDynamicsModel\Source\JSBSimFlightDynamicsModel\Private\JSBSimMovementComponent.cpp(1024): note: consider using explicit cast or comparison to 0 to avoid this warning
2>C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.MakeFile.Targets(44,5): error MSB3073: The command "D:\EpicGames\UE_5.0\Engine\Build\BatchFiles\Build.bat UEReferenceAppEditor Win64 Development -Project="D:\Development\Adal\jsbsim\UnrealEngine\UEReferenceApp.uproject" -WaitMutex -FromMsBuild" exited with code 6.
2>Done building project "UEReferenceApp.vcxproj" -- FAILED.
========== Build: 0 succeeded, 1 failed, 0 up-to-date, 1 skipped ==========
========== Elapsed 00:07.220 ==========
```

It converted to boolean to fix this build time error.