### PR TITLE
C130.xml invalid location value fixed.

### DIFF
--- a/aircraft/C130/C130.xml
+++ b/aircraft/C130/C130.xml
@@ -112,7 +112,13 @@
     </ground_reactions>
     <propulsion>
         <engine file="t56">
+            <location unit="IN">
+                <x> 586.5 </x>
+                <y> -265 </y>
+                <z> -40 </z>
+            </location>
             <feed>0</feed>
+            <feed>4</feed>
             <thruster file="t56_prop">
                 <location unit="IN">
                     <x> 586.5 </x>
@@ -128,10 +134,11 @@
         </engine>
         <engine file="t56">
             <feed>1</feed>
+            <feed>4</feed>
             <thruster file="t56_prop">
                 <location unit="IN">
                     <x> 586.5 </x>
-                    <y> -265 </y>
+                    <y> 265 </y>
                     <z> -40 </z>
                 </location>
                 <orient unit="DEG">
@@ -143,6 +150,7 @@
         </engine>
         <engine file="t56">
             <feed>2</feed>
+            <feed>4</feed>
             <thruster file="t56_prop">
                 <location unit="IN">
                     <x> 586.5 </x>
@@ -158,6 +166,7 @@
         </engine>
         <engine file="t56">
             <feed>3</feed>
+            <feed>4</feed>
             <thruster file="t56_prop">
                 <location unit="IN">
                     <x> 586.5 </x>


### PR DESCRIPTION
I worked with various things. When I looked C130.xml realize that, main problem is not related with t56 motor. It is related with location of engine 2.

And also the other planes have an extra feed value. Now C130 works.