### PR TITLE
Avoid non physical values for the ambient pressure and temperature

### DIFF
--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -254,6 +254,16 @@ protected:
   /// Converts from PSF (pounds per square foot) to one of several unit systems.
   double ConvertFromPSF(double t, ePressure unit=ePSF) const;
 
+  /// Check that the pressure is within plausible boundaries.
+  /// @param msg Message to display if the pressure is out of boundaries
+  /// @param quiet Don't display the message if set to true
+  double ValidatePressure(double p, const string& msg, bool quiet=false) const;
+
+  /// Check that the temperature is within plausible boundaries.
+  /// @param msg Message to display if the pressure is out of boundaries
+  /// @param quiet Don't display the message if set to true
+  double ValidateTemperature(double t, const string& msg, bool quiet=false) const;
+
   /// @name ISA constants
   //@{
   /// Universal gas constant - ft*lbf/R/mol

--- a/tests/TestStdAtmosphere.py
+++ b/tests/TestStdAtmosphere.py
@@ -412,5 +412,10 @@ class TestStdAtmosphere(JSBSimTestCase):
         self.assertGreater(fdm['atmosphere/pressure-altitude'], 900000.)
         self.assertLess(fdm['atmosphere/pressure-altitude'], fdm['ic/h-sl-ft'])
 
+        fdm['atmosphere/P-sl-psf'] = 0.0
+        fdm.run()
+        self.assertAlmostEqual(fdm['atmosphere/P-sl-psf']*1E17, 2.08854342)
+        self.assertAlmostEqual(fdm['atmosphere/P-psf']*1E17, 2.08854342)
+
 
 RunTest(TestStdAtmosphere)

--- a/tests/TestStdAtmosphere.py
+++ b/tests/TestStdAtmosphere.py
@@ -384,4 +384,33 @@ class TestStdAtmosphere(JSBSimTestCase):
             self.assertAlmostEqual(rhov/rhoa, ppm*1E-6)
             self.assertAlmostEqual(fdm['atmosphere/vapor-fraction-ppm']/ppm, 1.0)
 
+    def test_temperature_lower_limit(self):
+        fdm = self.create_fdm()
+        fdm.load_model('ball')
+        fdm['ic/h-sl-ft'] = 500000.
+        fdm.run_ic()
+
+        fdm['atmosphere/delta-T'] = -4000.
+        fdm.run()
+        self.assertAlmostEqual(fdm['atmosphere/T-R'], 1.8)
+
+        fdm['atmosphere/delta-T'] = 0.0
+        fdm['atmosphere/SL-graded-delta-T'] = -4000.
+        fdm.run()
+        self.assertAlmostEqual(fdm['atmosphere/T-sl-R'], fdm['atmosphere/T-R'])
+
+        fdm['atmosphere/delta-T'] = -4000.
+        fdm.run()
+        self.assertAlmostEqual(fdm['atmosphere/T-sl-R'], 1.8)
+
+    def test_pressure_lower_limit(self):
+        fdm = self.create_fdm()
+        fdm.load_model('ball')
+        fdm['ic/h-sl-ft'] = 1E7
+        fdm.run_ic()
+        self.assertAlmostEqual(fdm['atmosphere/P-psf']*1E17, 2.08854342)
+        self.assertGreater(fdm['atmosphere/pressure-altitude'], 900000.)
+        self.assertLess(fdm['atmosphere/pressure-altitude'], fdm['ic/h-sl-ft'])
+
+
 RunTest(TestStdAtmosphere)


### PR DESCRIPTION
This PR is addressing the bugs reported in the issue #815. As discussed, it caps pressure and temperature to small values:
* 1K which is, according to Wikipedia, the temperature at the [coolest natural place currently known in the Universe](https://en.wikipedia.org/wiki/Coldest_place_in_the_universe).
* 1E-15Pa which is, according to Wikipedia, the pressure in outer space between stars in the Milky Way

JSBSim caps the pressure and temperature to the above mentioned values, issues an error message and continues execution.

I took this opportunity to add checks for other seting methods in `FGAtmosphere` and `FGStandardAtmosphere`.