### PR TITLE
Remove the flag `BASE` from `string_utilities.h`

### DIFF
--- a/src/FGJSBBase.cpp
+++ b/src/FGJSBBase.cpp
@@ -35,8 +35,6 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#define BASE
-
 #include "FGJSBBase.h"
 #include "models/FGAtmosphere.h"
 

--- a/src/input_output/FGXMLElement.cpp
+++ b/src/input_output/FGXMLElement.cpp
@@ -28,6 +28,7 @@
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+#include <iostream>
 #include <sstream>  // for assembling the error messages / what of exceptions.
 #include <stdexcept>  // using domain_error, invalid_argument, and length_error.
 #include "FGXMLElement.h"

--- a/src/input_output/FGfdmSocket.cpp
+++ b/src/input_output/FGfdmSocket.cpp
@@ -51,6 +51,8 @@ INCLUDES
 #include <unistd.h>
 #endif
 #include <iomanip>
+#include <iostream>
+#include <sstream>
 #include <cstring>
 #include "FGfdmSocket.h"
 

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -35,12 +35,14 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <errno.h>
+#include <iostream>
+#include <sstream>
+#include <stdio.h>
 #ifdef __APPLE__
 #include <xlocale.h>
 #else
 #include <locale.h>
 #endif
-#include <sstream>
 
 #include "FGJSBBase.h"
 #include "string_utilities.h"
@@ -51,6 +53,7 @@ typedef _locale_t locale_t;
 #define strtod_l _strtod_l
 #endif
 
+namespace JSBSim {
 struct CNumericLocale
 {
   CNumericLocale()
@@ -100,3 +103,92 @@ double atof_locale_c(const std::string& input)
   std::cerr << s.str() << std::endl;
   throw JSBSim::BaseException(s.str());
 }
+
+
+std::string& trim_left(std::string& str)
+{
+  while (!str.empty() && isspace((unsigned char)str[0])) {
+    str = str.erase(0,1);
+  }
+  return str;
+}
+
+std::string& trim_right(std::string& str)
+{
+  while (!str.empty() && isspace((unsigned char)str[str.size()-1])) {
+    str = str.erase(str.size()-1,1);
+  }
+  return str;
+}
+
+std::string& trim(std::string& str)
+{
+  if (str.empty()) return str;
+  std::string temp_str = trim_right(str);
+  return str = trim_left(temp_str);
+}
+
+std::string& trim_all_space(std::string& str)
+{
+  for (size_t i=0; i<str.size(); i++) {
+    if (isspace((unsigned char)str[i])) {
+      str = str.erase(i,1);
+      --i;
+    }
+  }
+  return str;
+}
+
+std::string& to_upper(std::string& str)
+{
+  for (size_t i=0; i<str.size(); i++) str[i] = toupper(str[i]);
+  return str;
+}
+
+std::string& to_lower(std::string& str)
+{
+  for (size_t i=0; i<str.size(); i++) str[i] = tolower(str[i]);
+  return str;
+}
+
+bool is_number(const std::string& str)
+{
+  if (str.empty())
+    return false;
+  else
+    return (str.find_first_not_of("+-.0123456789Ee") == std::string::npos);
+}
+
+std::vector <std::string> split(std::string str, char d)
+{
+  std::vector <std::string> str_array;
+  size_t index=0;
+  std::string temp = "";
+
+  trim(str);
+  index = str.find(d);
+  while (index != std::string::npos) {
+    temp = str.substr(0,index);
+    trim(temp);
+    if (!temp.empty()) str_array.push_back(temp);
+    str = str.erase(0,index+1);
+    index = str.find(d);
+  }
+  if (!str.empty()) {
+    temp = trim(str);
+    if (!temp.empty()) str_array.push_back(temp);
+  }
+
+  return str_array;
+}
+
+std::string replace(std::string str, const std::string& oldstr, const std::string& newstr)
+{
+  std::string temp = str;
+  size_t old_idx = str.find(oldstr);
+  if (old_idx != std::string::npos) {
+    temp = str.replace(old_idx, 1, newstr);
+  }
+  return temp;
+}
+};

--- a/src/input_output/string_utilities.h
+++ b/src/input_output/string_utilities.h
@@ -39,121 +39,26 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <string>
-#include <sstream>
-#include <iostream>
 #include <vector>
-#include <stdio.h>
-
-#include "JSBSim_API.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-JSBSIM_API bool is_number(const std::string& str);
-JSBSIM_API double atof_locale_c(const std::string& input);
+namespace JSBSim {
+double atof_locale_c(const std::string& input);
 
-#if !defined(BASE)
-  extern std::string& trim_left(std::string& str);
-  extern std::string& trim_right(std::string& str);
-  extern std::string& trim(std::string& str);
-  extern std::string& trim_all_space(std::string& str);
-  extern std::string& to_upper(std::string& str);
-  extern std::string& to_lower(std::string& str);
-  std::vector <std::string> split(std::string str, char d);
+std::string& trim_left(std::string& str);
+std::string& trim_right(std::string& str);
+std::string& trim(std::string& str);
+std::string& trim_all_space(std::string& str);
+std::string& to_upper(std::string& str);
+std::string& to_lower(std::string& str);
+bool is_number(const std::string& str);
+std::vector <std::string> split(std::string str, char d);
 
-  extern std::string replace(std::string str, const std::string& old, const std::string& newstr);
-#else
-  #include <cctype>
-
-  std::string& trim_left(std::string& str)
-  {
-    while (!str.empty() && isspace((unsigned char)str[0])) {
-      str = str.erase(0,1);
-    }
-    return str;
-  }
-
-  std::string& trim_right(std::string& str)
-  {
-    while (!str.empty() && isspace((unsigned char)str[str.size()-1])) {
-      str = str.erase(str.size()-1,1);
-    }
-    return str;
-  }
-
-  std::string& trim(std::string& str)
-  {
-    if (str.empty()) return str;
-    std::string temp_str = trim_right(str);
-    return str = trim_left(temp_str);
-  }
-
-  std::string& trim_all_space(std::string& str)
-  {
-    for (size_t i=0; i<str.size(); i++) {
-      if (isspace((unsigned char)str[i])) {
-        str = str.erase(i,1);
-        --i;
-      }
-    }
-    return str;
-  }
-
-  std::string& to_upper(std::string& str)
-  {
-    for (size_t i=0; i<str.size(); i++) str[i] = toupper(str[i]);
-    return str;
-  }
-
-  std::string& to_lower(std::string& str)
-  {
-    for (size_t i=0; i<str.size(); i++) str[i] = tolower(str[i]);
-    return str;
-  }
-
-  bool is_number(const std::string& str)
-  {
-    if (str.empty())
-      return false;
-    else
-      return (str.find_first_not_of("+-.0123456789Ee") == std::string::npos);
-  }
-
-  std::vector <std::string> split(std::string str, char d)
-  {
-    std::vector <std::string> str_array;
-    size_t index=0;
-    std::string temp = "";
-
-    trim(str);
-    index = str.find(d);
-    while (index != std::string::npos) {
-      temp = str.substr(0,index);
-      trim(temp);
-      if (!temp.empty()) str_array.push_back(temp);
-      str = str.erase(0,index+1);
-      index = str.find(d);
-    }
-    if (!str.empty()) {
-      temp = trim(str);
-      if (!temp.empty()) str_array.push_back(temp);
-    }
-
-    return str_array;
-  }
-
-  std::string replace(std::string str, const std::string& oldstr, const std::string& newstr)
-  {
-    std::string temp = str;
-    size_t old_idx = str.find(oldstr);
-    if (old_idx != std::string::npos) {
-      temp = str.replace(old_idx, 1, newstr);
-    }
-    return temp;
-  }
-
-#endif
+std::string replace(std::string str, const std::string& old, const std::string& newstr);
+};
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/input_output/string_utilities.h
+++ b/src/input_output/string_utilities.h
@@ -46,18 +46,16 @@ CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 namespace JSBSim {
-double atof_locale_c(const std::string& input);
-
-std::string& trim_left(std::string& str);
-std::string& trim_right(std::string& str);
-std::string& trim(std::string& str);
-std::string& trim_all_space(std::string& str);
-std::string& to_upper(std::string& str);
-std::string& to_lower(std::string& str);
-bool is_number(const std::string& str);
-std::vector <std::string> split(std::string str, char d);
-
-std::string replace(std::string str, const std::string& old, const std::string& newstr);
+JSBSIM_API double atof_locale_c(const std::string& input);
+JSBSIM_API std::string& trim_left(std::string& str);
+JSBSIM_API std::string& trim_right(std::string& str);
+JSBSIM_API std::string& trim(std::string& str);
+JSBSIM_API std::string& trim_all_space(std::string& str);
+JSBSIM_API std::string& to_upper(std::string& str);
+JSBSIM_API std::string& to_lower(std::string& str);
+JSBSIM_API bool is_number(const std::string& str);
+JSBSIM_API std::vector <std::string> split(std::string str, char d);
+JSBSIM_API std::string replace(std::string str, const std::string& old, const std::string& newstr);
 };
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/simgear/xml/easyxml.cxx
+++ b/src/simgear/xml/easyxml.cxx
@@ -23,6 +23,7 @@ INCLUDES
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 #include "FGJSBBase.h"
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -19,11 +19,13 @@ set(UNIT_TESTS FGColumnVector3Test
                FGConditionTest
                FGPropertyManagerTest)
 
-add_library(string_utilities STATIC ${PROJECT_SOURCE_DIR}/src/input_output/string_utilities.cpp)
+if(WIN32 AND BUILD_SHARED_LIBS)
+  add_library(string_utilities STATIC ${PROJECT_SOURCE_DIR}/src/input_output/string_utilities.cpp)
+endif()
 
 foreach(test ${UNIT_TESTS})
   cxxtest_add_test(${test}1 ${test}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${test}.h)
-  if (test STREQUAL "StringUtilitiesTest")
+  if (WIN32 AND BUILD_SHARED_LIBS AND test STREQUAL "StringUtilitiesTest")
     target_link_libraries(${test}1 libJSBSim string_utilities)
   else()
     target_link_libraries(${test}1 libJSBSim)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(UNIT_TESTS FGColumnVector3Test
 
 if(WIN32 AND BUILD_SHARED_LIBS)
   add_library(string_utilities STATIC ${PROJECT_SOURCE_DIR}/src/input_output/string_utilities.cpp)
+  target_compile_definitions(string_utilities PRIVATE JSBSIM_STATIC_LINK)
 endif()
 
 foreach(test ${UNIT_TESTS})

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -19,22 +19,9 @@ set(UNIT_TESTS FGColumnVector3Test
                FGConditionTest
                FGPropertyManagerTest)
 
-# Windows cannot access the functions in `string_utilities.h` when JSBSim is
-# compiled as a DLL. Rather than adding `JSBSIM_API` to all of these functions
-# just for the sake of using them in unit tests, we are compiling `string_utilities.h`
-# as a static library and linking it to the unit tests.
-if(WIN32 AND BUILD_SHARED_LIBS)
-  add_library(string_utilities STATIC ${PROJECT_SOURCE_DIR}/src/input_output/string_utilities.cpp)
-  target_compile_definitions(string_utilities PRIVATE JSBSIM_STATIC_LINK)
-endif()
-
 foreach(test ${UNIT_TESTS})
   cxxtest_add_test(${test}1 ${test}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${test}.h)
-  if (WIN32 AND BUILD_SHARED_LIBS)
-    target_link_libraries(${test}1 libJSBSim string_utilities)
-  else()
-    target_link_libraries(${test}1 libJSBSim)
-  endif()
+  target_link_libraries(${test}1 libJSBSim)
   add_coverage(${test}1)
 endforeach()
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -19,6 +19,10 @@ set(UNIT_TESTS FGColumnVector3Test
                FGConditionTest
                FGPropertyManagerTest)
 
+# Windows cannot access the functions in `string_utilities.h` when JSBSim is
+# compiled as a DLL. Rather than adding `JSBSIM_API` to all of these functions
+# just for the sake of using them in unit tests, we are compiling `string_utilities.h`
+# as a static library and linking it to the unit tests.
 if(WIN32 AND BUILD_SHARED_LIBS)
   add_library(string_utilities STATIC ${PROJECT_SOURCE_DIR}/src/input_output/string_utilities.cpp)
   target_compile_definitions(string_utilities PRIVATE JSBSIM_STATIC_LINK)
@@ -26,7 +30,7 @@ endif()
 
 foreach(test ${UNIT_TESTS})
   cxxtest_add_test(${test}1 ${test}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${test}.h)
-  if (WIN32 AND BUILD_SHARED_LIBS AND test STREQUAL "StringUtilitiesTest")
+  if (WIN32 AND BUILD_SHARED_LIBS)
     target_link_libraries(${test}1 libJSBSim string_utilities)
   else()
     target_link_libraries(${test}1 libJSBSim)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -19,9 +19,15 @@ set(UNIT_TESTS FGColumnVector3Test
                FGConditionTest
                FGPropertyManagerTest)
 
+add_library(string_utilities STATIC ${PROJECT_SOURCE_DIR}/src/input_output/string_utilities.cpp)
+
 foreach(test ${UNIT_TESTS})
   cxxtest_add_test(${test}1 ${test}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${test}.h)
-  target_link_libraries(${test}1 libJSBSim)
+  if (test STREQUAL "StringUtilitiesTest")
+    target_link_libraries(${test}1 libJSBSim string_utilities)
+  else()
+    target_link_libraries(${test}1 libJSBSim)
+  endif()
   add_coverage(${test}1)
 endforeach()
 

--- a/tests/unit_tests/StringUtilitiesTest.h
+++ b/tests/unit_tests/StringUtilitiesTest.h
@@ -1,8 +1,6 @@
 #include <string>
 #include <cxxtest/TestSuite.h>
-#define BASE
 #include <input_output/string_utilities.h>
-#undef BASE
 #include "FGJSBBase.h"
 
 class StringUtilitiesTest : public CxxTest::TestSuite
@@ -12,60 +10,60 @@ public:
     const std::string s_ref(" \t  xx\t\tyy  zz \t  ");
     const std::string all_spaces("  \t \t\t  ");
     std::string s = s_ref;
-    TS_ASSERT_EQUALS(trim_left(s), std::string("xx\t\tyy  zz \t  "));
-    TS_ASSERT_EQUALS(trim_left(empty), empty);
+    TS_ASSERT_EQUALS(JSBSim::trim_left(s), std::string("xx\t\tyy  zz \t  "));
+    TS_ASSERT_EQUALS(JSBSim::trim_left(empty), empty);
     s = all_spaces;
-    TS_ASSERT_EQUALS(trim_left(s), empty);
+    TS_ASSERT_EQUALS(JSBSim::trim_left(s), empty);
     s = s_ref;
-    TS_ASSERT_EQUALS(trim_right(s), std::string(" \t  xx\t\tyy  zz"));
-    TS_ASSERT_EQUALS(trim_right(empty), empty);
+    TS_ASSERT_EQUALS(JSBSim::trim_right(s), std::string(" \t  xx\t\tyy  zz"));
+    TS_ASSERT_EQUALS(JSBSim::trim_right(empty), empty);
     s = all_spaces;
-    TS_ASSERT_EQUALS(trim_right(s), empty);
+    TS_ASSERT_EQUALS(JSBSim::trim_right(s), empty);
     s = s_ref;
-    TS_ASSERT_EQUALS(trim(s), std::string("xx\t\tyy  zz"));
-    TS_ASSERT_EQUALS(trim(empty), empty);
+    TS_ASSERT_EQUALS(JSBSim::trim(s), std::string("xx\t\tyy  zz"));
+    TS_ASSERT_EQUALS(JSBSim::trim(empty), empty);
     s = all_spaces;
-    TS_ASSERT_EQUALS(trim(s), empty);
+    TS_ASSERT_EQUALS(JSBSim::trim(s), empty);
     s = s_ref;
-    TS_ASSERT_EQUALS(trim_all_space(s), std::string("xxyyzz"));
-    TS_ASSERT_EQUALS(trim_all_space(empty), empty);
+    TS_ASSERT_EQUALS(JSBSim::trim_all_space(s), std::string("xxyyzz"));
+    TS_ASSERT_EQUALS(JSBSim::trim_all_space(empty), empty);
     s = all_spaces;
-    TS_ASSERT_EQUALS(trim_all_space(s), empty);
+    TS_ASSERT_EQUALS(JSBSim::trim_all_space(s), empty);
   }
 
   void testStringCase() {
     const std::string s_ref(" MiXed\tCaSE; ");
     std::string s = s_ref;
-    TS_ASSERT_EQUALS(to_upper(s), std::string(" MIXED\tCASE; "));
-    TS_ASSERT_EQUALS(to_upper(empty), empty);
+    TS_ASSERT_EQUALS(JSBSim::to_upper(s), std::string(" MIXED\tCASE; "));
+    TS_ASSERT_EQUALS(JSBSim::to_upper(empty), empty);
     s = s_ref;
-    TS_ASSERT_EQUALS(to_lower(s), std::string(" mixed\tcase; "));
-    TS_ASSERT_EQUALS(to_lower(empty), empty);
+    TS_ASSERT_EQUALS(JSBSim::to_lower(s), std::string(" mixed\tcase; "));
+    TS_ASSERT_EQUALS(JSBSim::to_lower(empty), empty);
   }
 
   void testNumberString() {
-    TS_ASSERT(is_number("1.0"));
-    TS_ASSERT(is_number("1526"));
-    TS_ASSERT(is_number(".01256"));
-    TS_ASSERT(is_number("-1.0e+1"));
-    TS_ASSERT(!is_number(empty));
-    TS_ASSERT(!is_number("125x5#"));
+    TS_ASSERT(JSBSim::is_number("1.0"));
+    TS_ASSERT(JSBSim::is_number("1526"));
+    TS_ASSERT(JSBSim::is_number(".01256"));
+    TS_ASSERT(JSBSim::is_number("-1.0e+1"));
+    TS_ASSERT(!JSBSim::is_number(empty));
+    TS_ASSERT(!JSBSim::is_number("125x5#"));
   }
 
   void testSplit() {
-    std::vector <std::string> list = split(empty,',');
+    std::vector <std::string> list = JSBSim::split(empty,',');
     TS_ASSERT_EQUALS(list.size(), 0);
-    list = split(std::string(",,,,,"),',');
+    list = JSBSim::split(std::string(",,,,,"),',');
     TS_ASSERT_EQUALS(list.size(), 0);
-    list = split(std::string(" xx yy zz "),',');
+    list = JSBSim::split(std::string(" xx yy zz "),',');
     TS_ASSERT_EQUALS(list.size(), 1);
     TS_ASSERT_EQUALS(list[0], std::string("xx yy zz"));
-    list = split(std::string(" xx yy zz "),' ');
+    list = JSBSim::split(std::string(" xx yy zz "),' ');
     TS_ASSERT_EQUALS(list.size(), 3);
     TS_ASSERT_EQUALS(list[0], std::string("xx"));
     TS_ASSERT_EQUALS(list[1], std::string("yy"));
     TS_ASSERT_EQUALS(list[2], std::string("zz"));
-    list = split(",xx,,yy,zz,",',');
+    list = JSBSim::split(",xx,,yy,zz,",',');
     TS_ASSERT_EQUALS(list.size(), 3);
     TS_ASSERT_EQUALS(list[0], std::string("xx"));
     TS_ASSERT_EQUALS(list[1], std::string("yy"));
@@ -73,30 +71,34 @@ public:
   }
 
   void testReplace() {
-    TS_ASSERT_EQUALS(replace(empty, std::string("x"), std::string("a")), empty);
-    TS_ASSERT_EQUALS(replace(std::string(" xyzzu "), std::string("x"),
+    TS_ASSERT_EQUALS(JSBSim::replace(empty, std::string("x"), std::string("a")), empty);
+    TS_ASSERT_EQUALS(JSBSim::replace(std::string(" xyzzu "), std::string("x"),
                              std::string("a")), std::string(" ayzzu "));
-    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("x"),
+    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("x"),
                              std::string("a")), std::string("ayzzu"));
-    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("u"),
+    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("u"),
                              std::string("a")), std::string("xyzza"));
-    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("z"),
+    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("z"),
                              std::string("y")), std::string("xyyzu"));
-    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("yzz"),
+    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("yzz"),
                              std::string("ab")), std::string("xabzzu"));
-    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("b"),
+    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("b"),
                              std::string("w")), std::string("xyzzu"));
   }
 
   void testAtofLocaleC() {
-    TS_ASSERT_EQUALS(atof_locale_c("+1  "), 1.0);
-    TS_ASSERT_EQUALS(atof_locale_c(" 123.4"), 123.4);
-    TS_ASSERT_EQUALS(atof_locale_c("-3.14e-2"), -0.0314);
-    TS_ASSERT_EQUALS(atof_locale_c("1E-999"), 0.0);
-    TS_ASSERT_EQUALS(atof_locale_c("-1E-999"), 0.0);
-    TS_ASSERT_EQUALS(atof_locale_c("0.0"), 0.0);
-    TS_ASSERT_THROWS(atof_locale_c("1E+999"), JSBSim::BaseException&);
-    TS_ASSERT_THROWS(atof_locale_c("-1E+999"), JSBSim::BaseException&);
+    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("+1  "), 1.0);
+    TS_ASSERT_EQUALS(JSBSim::atof_locale_c(" 123.4"), 123.4);
+    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("-3.14e-2"), -0.0314);
+    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("1E-999"), 0.0);
+    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("-1E-999"), 0.0);
+    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("0.0"), 0.0);
+    TS_ASSERT_THROWS(JSBSim::atof_locale_c("1E+999"), JSBSim::BaseException&);
+    TS_ASSERT_THROWS(JSBSim::atof_locale_c("-1E+999"), JSBSim::BaseException&);
+    setlocale(LC_NUMERIC, "fr_FR");
+    TS_ASSERT_EQUALS(atof("1,2"), 1.2);
+    TS_ASSERT_EQUALS(atof("1.2"), 1.0);
+    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("1.2"), 1.2);
   }
 
 private:

--- a/tests/unit_tests/StringUtilitiesTest.h
+++ b/tests/unit_tests/StringUtilitiesTest.h
@@ -95,10 +95,6 @@ public:
     TS_ASSERT_EQUALS(JSBSim::atof_locale_c("0.0"), 0.0);
     TS_ASSERT_THROWS(JSBSim::atof_locale_c("1E+999"), JSBSim::BaseException&);
     TS_ASSERT_THROWS(JSBSim::atof_locale_c("-1E+999"), JSBSim::BaseException&);
-    setlocale(LC_NUMERIC, "fr_FR");
-    TS_ASSERT_EQUALS(atof("1,2"), 1.2);
-    TS_ASSERT_EQUALS(atof("1.2"), 1.0);
-    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("1.2"), 1.2);
   }
 
 private:

--- a/tests/unit_tests/StringUtilitiesTest.h
+++ b/tests/unit_tests/StringUtilitiesTest.h
@@ -1,7 +1,9 @@
 #include <string>
 #include <cxxtest/TestSuite.h>
-#include <input_output/string_utilities.h>
 #include "FGJSBBase.h"
+#include <input_output/string_utilities.h>
+
+using namespace JSBSim;
 
 class StringUtilitiesTest : public CxxTest::TestSuite
 {
@@ -10,60 +12,60 @@ public:
     const std::string s_ref(" \t  xx\t\tyy  zz \t  ");
     const std::string all_spaces("  \t \t\t  ");
     std::string s = s_ref;
-    TS_ASSERT_EQUALS(JSBSim::trim_left(s), std::string("xx\t\tyy  zz \t  "));
-    TS_ASSERT_EQUALS(JSBSim::trim_left(empty), empty);
+    TS_ASSERT_EQUALS(trim_left(s), std::string("xx\t\tyy  zz \t  "));
+    TS_ASSERT_EQUALS(trim_left(empty), empty);
     s = all_spaces;
-    TS_ASSERT_EQUALS(JSBSim::trim_left(s), empty);
+    TS_ASSERT_EQUALS(trim_left(s), empty);
     s = s_ref;
-    TS_ASSERT_EQUALS(JSBSim::trim_right(s), std::string(" \t  xx\t\tyy  zz"));
-    TS_ASSERT_EQUALS(JSBSim::trim_right(empty), empty);
+    TS_ASSERT_EQUALS(trim_right(s), std::string(" \t  xx\t\tyy  zz"));
+    TS_ASSERT_EQUALS(trim_right(empty), empty);
     s = all_spaces;
-    TS_ASSERT_EQUALS(JSBSim::trim_right(s), empty);
+    TS_ASSERT_EQUALS(trim_right(s), empty);
     s = s_ref;
-    TS_ASSERT_EQUALS(JSBSim::trim(s), std::string("xx\t\tyy  zz"));
-    TS_ASSERT_EQUALS(JSBSim::trim(empty), empty);
+    TS_ASSERT_EQUALS(trim(s), std::string("xx\t\tyy  zz"));
+    TS_ASSERT_EQUALS(trim(empty), empty);
     s = all_spaces;
-    TS_ASSERT_EQUALS(JSBSim::trim(s), empty);
+    TS_ASSERT_EQUALS(trim(s), empty);
     s = s_ref;
-    TS_ASSERT_EQUALS(JSBSim::trim_all_space(s), std::string("xxyyzz"));
-    TS_ASSERT_EQUALS(JSBSim::trim_all_space(empty), empty);
+    TS_ASSERT_EQUALS(trim_all_space(s), std::string("xxyyzz"));
+    TS_ASSERT_EQUALS(trim_all_space(empty), empty);
     s = all_spaces;
-    TS_ASSERT_EQUALS(JSBSim::trim_all_space(s), empty);
+    TS_ASSERT_EQUALS(trim_all_space(s), empty);
   }
 
   void testStringCase() {
     const std::string s_ref(" MiXed\tCaSE; ");
     std::string s = s_ref;
-    TS_ASSERT_EQUALS(JSBSim::to_upper(s), std::string(" MIXED\tCASE; "));
-    TS_ASSERT_EQUALS(JSBSim::to_upper(empty), empty);
+    TS_ASSERT_EQUALS(to_upper(s), std::string(" MIXED\tCASE; "));
+    TS_ASSERT_EQUALS(to_upper(empty), empty);
     s = s_ref;
-    TS_ASSERT_EQUALS(JSBSim::to_lower(s), std::string(" mixed\tcase; "));
-    TS_ASSERT_EQUALS(JSBSim::to_lower(empty), empty);
+    TS_ASSERT_EQUALS(to_lower(s), std::string(" mixed\tcase; "));
+    TS_ASSERT_EQUALS(to_lower(empty), empty);
   }
 
   void testNumberString() {
-    TS_ASSERT(JSBSim::is_number("1.0"));
-    TS_ASSERT(JSBSim::is_number("1526"));
-    TS_ASSERT(JSBSim::is_number(".01256"));
-    TS_ASSERT(JSBSim::is_number("-1.0e+1"));
-    TS_ASSERT(!JSBSim::is_number(empty));
-    TS_ASSERT(!JSBSim::is_number("125x5#"));
+    TS_ASSERT(is_number("1.0"));
+    TS_ASSERT(is_number("1526"));
+    TS_ASSERT(is_number(".01256"));
+    TS_ASSERT(is_number("-1.0e+1"));
+    TS_ASSERT(!is_number(empty));
+    TS_ASSERT(!is_number("125x5#"));
   }
 
   void testSplit() {
-    std::vector <std::string> list = JSBSim::split(empty,',');
+    std::vector <std::string> list = split(empty,',');
     TS_ASSERT_EQUALS(list.size(), 0);
-    list = JSBSim::split(std::string(",,,,,"),',');
+    list = split(std::string(",,,,,"),',');
     TS_ASSERT_EQUALS(list.size(), 0);
-    list = JSBSim::split(std::string(" xx yy zz "),',');
+    list = split(std::string(" xx yy zz "),',');
     TS_ASSERT_EQUALS(list.size(), 1);
     TS_ASSERT_EQUALS(list[0], std::string("xx yy zz"));
-    list = JSBSim::split(std::string(" xx yy zz "),' ');
+    list = split(std::string(" xx yy zz "),' ');
     TS_ASSERT_EQUALS(list.size(), 3);
     TS_ASSERT_EQUALS(list[0], std::string("xx"));
     TS_ASSERT_EQUALS(list[1], std::string("yy"));
     TS_ASSERT_EQUALS(list[2], std::string("zz"));
-    list = JSBSim::split(",xx,,yy,zz,",',');
+    list = split(",xx,,yy,zz,",',');
     TS_ASSERT_EQUALS(list.size(), 3);
     TS_ASSERT_EQUALS(list[0], std::string("xx"));
     TS_ASSERT_EQUALS(list[1], std::string("yy"));
@@ -71,30 +73,30 @@ public:
   }
 
   void testReplace() {
-    TS_ASSERT_EQUALS(JSBSim::replace(empty, std::string("x"), std::string("a")), empty);
-    TS_ASSERT_EQUALS(JSBSim::replace(std::string(" xyzzu "), std::string("x"),
+    TS_ASSERT_EQUALS(replace(empty, std::string("x"), std::string("a")), empty);
+    TS_ASSERT_EQUALS(replace(std::string(" xyzzu "), std::string("x"),
                              std::string("a")), std::string(" ayzzu "));
-    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("x"),
+    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("x"),
                              std::string("a")), std::string("ayzzu"));
-    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("u"),
+    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("u"),
                              std::string("a")), std::string("xyzza"));
-    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("z"),
+    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("z"),
                              std::string("y")), std::string("xyyzu"));
-    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("yzz"),
+    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("yzz"),
                              std::string("ab")), std::string("xabzzu"));
-    TS_ASSERT_EQUALS(JSBSim::replace(std::string("xyzzu"), std::string("b"),
+    TS_ASSERT_EQUALS(replace(std::string("xyzzu"), std::string("b"),
                              std::string("w")), std::string("xyzzu"));
   }
 
   void testAtofLocaleC() {
-    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("+1  "), 1.0);
-    TS_ASSERT_EQUALS(JSBSim::atof_locale_c(" 123.4"), 123.4);
-    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("-3.14e-2"), -0.0314);
-    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("1E-999"), 0.0);
-    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("-1E-999"), 0.0);
-    TS_ASSERT_EQUALS(JSBSim::atof_locale_c("0.0"), 0.0);
-    TS_ASSERT_THROWS(JSBSim::atof_locale_c("1E+999"), JSBSim::BaseException&);
-    TS_ASSERT_THROWS(JSBSim::atof_locale_c("-1E+999"), JSBSim::BaseException&);
+    TS_ASSERT_EQUALS(atof_locale_c("+1  "), 1.0);
+    TS_ASSERT_EQUALS(atof_locale_c(" 123.4"), 123.4);
+    TS_ASSERT_EQUALS(atof_locale_c("-3.14e-2"), -0.0314);
+    TS_ASSERT_EQUALS(atof_locale_c("1E-999"), 0.0);
+    TS_ASSERT_EQUALS(atof_locale_c("-1E-999"), 0.0);
+    TS_ASSERT_EQUALS(atof_locale_c("0.0"), 0.0);
+    TS_ASSERT_THROWS(atof_locale_c("1E+999"), BaseException&);
+    TS_ASSERT_THROWS(atof_locale_c("-1E+999"), BaseException&);
   }
 
 private:


### PR DESCRIPTION
For some reasons the file `string_utilities.h` was meant to be used both as a header and as a c++ source file. The flag `BASE` had to be defined when the source code of the functions was to be compiled. Otherwise, when `BASE` was not defined, only the function signatures were used as if the file was a "pure" header file. This was [like so since the file `string_utilities.h` had been included in JSBSim in June 2009](https://github.com/JSBSim-Team/jsbsim/blob/3ea027107b974a485ba8cc1c3c058a1d7b098963/src/input_output/string_utilities.h).

This PR is meant to remove this unusual process: `string_utilities` is split into a pair of `.h` and `.cpp` files just like the rest of the code base.
* Only function signatures are kept in `string_utilities.h`
* The C++ code is moved in `string_utilities.cpp`
* The flag `BASE` is removed from the code base.
* All the functions from `string_utilities.h` are prepended by `JSBSIM_API` to allow calling them in unit tests while JSBSim is compiled as a DLL.
* Because all the functions are now exported, they have been moved to the `JSBSim` namespace to avoid name collisions with other libraries.