### PR TITLE
Better #include for expat.h

### DIFF
--- a/src/simgear/xml/easyxml.cxx
+++ b/src/simgear/xml/easyxml.cxx
@@ -19,7 +19,7 @@ INCLUDES
 #include <string.h>
 
 #include "easyxml.hxx"
-#include <expat.h>
+#include "expat.h"
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Since expat.h is in the current directory, changed angle brackets to quotes to match the best practice.
In the case when we don't have a `-Isrc/simgear/xml` directive, this change also removes a build failure for some compilers.