### PR TITLE
Fixes for gcc-13

### DIFF
--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -1033,16 +1033,18 @@ bool FGInitialCondition::Load(const SGPath& rstfile, bool useStoredPath)
   if (document->HasAttribute("version"))
     version = document->GetAttributeValueAsNumber("version");
 
-  if (version == HUGE_VAL) {
+    if (version >= 3.0) {
+      const string s("Only initialization file formats 1 and 2 are currently supported");
+      cerr << document->ReadFrom() << endl << s << endl;
+      throw BaseException(s);
+    } else if (version >= 2.0) {
+      result = Load_v2(document);
+    } else if (version >= 1.0) {
+      result = Load_v1(document);
+    }
+
+  } else {
     result = Load_v1(document); // Default to the old version
-  } else if (version >= 3.0) {
-    const string s("Only initialization file formats 1 and 2 are currently supported");
-    cerr << document->ReadFrom() << endl << s << endl;
-    throw BaseException(s);
-  } else if (version >= 2.0) {
-    result = Load_v2(document);
-  } else if (version >= 1.0) {
-    result = Load_v1(document);
   }
 
   // Check to see if any engines are specified to be initialized in a running state

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -1030,7 +1030,7 @@ bool FGInitialCondition::Load(const SGPath& rstfile, bool useStoredPath)
   double version = HUGE_VAL;
   bool result = false;
 
-  if (document->HasAttribute("version"))
+  if (document->HasAttribute("version")) {
     version = document->GetAttributeValueAsNumber("version");
 
     if (version >= 3.0) {

--- a/src/simgear/xml/easyxml.cxx
+++ b/src/simgear/xml/easyxml.cxx
@@ -19,7 +19,7 @@ INCLUDES
 #include <string.h>
 
 #include "easyxml.hxx"
-#include <expat.h>
+#include "expat.h"
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
The code at `initialization/FBInitialCondition.cpp:1036` is problematic for some newer compilers. I think `version` was coming back as `inf` or maybe `-inf` (I am not sure, it was not on my machine). Reports came in like this:
```
   In file aircraft/B747/reset00.xml: line 2

   Only initialization file formats 1 and 2 are currently supported
   FATAL ERROR: JSBSim terminated with an unknown exception.
```
I investigated and tried to figure the intent of the code. It feels like we should only check the version number if it was read in from the file, and otherwise just do a `Load_v1`. I moved the block around and eliminated the `if (version == HUGE_VAL)` line which looked fishy.

Also a patch I had lying around for making sure we use our `expat.h` and not one lying around on the system.

Feel free to squash or edit these commits. 