### PR TITLE
Fix discovery of document version number

### DIFF
--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -1030,18 +1030,21 @@ bool FGInitialCondition::Load(const SGPath& rstfile, bool useStoredPath)
   double version = HUGE_VAL;
   bool result = false;
 
-  if (document->HasAttribute("version"))
+  // If doc has an version, check it. Otherwise fall back to legacy.
+  if (document->HasAttribute("version")) {
     version = document->GetAttributeValueAsNumber("version");
+    
+    if (version >= 3.0) {
+      const string s("Only initialization file formats 1 and 2 are currently supported");
+      cerr << document->ReadFrom() << endl << s << endl;
+      throw BaseException(s);
+    } else if (version >= 2.0) {
+      result = Load_v2(document);
+    } else if (version >= 1.0) {
+      result = Load_v1(document);
+    }
 
-  if (version == HUGE_VAL) {
-    result = Load_v1(document); // Default to the old version
-  } else if (version >= 3.0) {
-    const string s("Only initialization file formats 1 and 2 are currently supported");
-    cerr << document->ReadFrom() << endl << s << endl;
-    throw BaseException(s);
-  } else if (version >= 2.0) {
-    result = Load_v2(document);
-  } else if (version >= 1.0) {
+  } else {
     result = Load_v1(document);
   }
 

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -1027,12 +1027,11 @@ bool FGInitialCondition::Load(const SGPath& rstfile, bool useStoredPath)
     throw BaseException(s.str());
   }
 
-  double version = HUGE_VAL;
   bool result = false;
 
   // If doc has an version, check it. Otherwise fall back to legacy.
   if (document->HasAttribute("version")) {
-    version = document->GetAttributeValueAsNumber("version");
+    double version = document->GetAttributeValueAsNumber("version");
     
     if (version >= 3.0) {
       const string s("Only initialization file formats 1 and 2 are currently supported");


### PR DESCRIPTION
The code at `initialization/FGInitialCondition.cpp:1036` is problematic for some newer compilers. I think `version` was coming back as `inf` or maybe `-inf` (I am not sure, it was not on my machine). Reports came in like this:
```
   In file aircraft/B747/reset00.xml: line 2

   Only initialization file formats 1 and 2 are currently supported
   FATAL ERROR: JSBSim terminated with an unknown exception.
```
I investigated and tried to figure the intent of the code. It feels like we should only check the version number if it was read in from the file, and otherwise just do a `Load_v1`. I moved the block around and eliminated the `if (version == HUGE_VAL)` line which looked fishy (exact FP comparisons are usually not portable).