### PR TITLE
Fix wind initial conditions

### DIFF
--- a/src/FGJSBBase.h
+++ b/src/FGJSBBase.h
@@ -333,10 +333,10 @@ protected:
   static constexpr double hptoftlbssec = 550.0;
   static constexpr double psftoinhg = 0.014138;
   static constexpr double psftopa = 47.88;
-  static constexpr double ktstofps = 1.68781;
+  static constexpr double fttom = 0.3048;
+  static constexpr double ktstofps = 1852./(3600*fttom);
   static constexpr double fpstokts = 1.0 / ktstofps;
   static constexpr double inchtoft = 1.0/12.0;
-  static constexpr double fttom = 0.3048;
   static constexpr double m3toft3 = 1.0/(fttom*fttom*fttom);
   static constexpr double in3tom3 = inchtoft*inchtoft*inchtoft/m3toft3;
   static constexpr double inhgtopa = 3386.38;

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -581,7 +581,7 @@ void FGInitialCondition::SetWindDownKtsIC(double wD)
   const FGMatrix33& Tb2l = orientation.GetTInv();
   FGColumnVector3 _vt_NED = Tb2l * Tw2b * FGColumnVector3(vt, 0., 0.);
 
-  _vt_NED(eW) = vUVW_NED(eW) + wD;
+  _vt_NED(eW) = vUVW_NED(eW) + wD * ktstofps;
   vt = _vt_NED.Magnitude();
 
   calcAeroAngles(_vt_NED);
@@ -919,19 +919,15 @@ double FGInitialCondition::GetWindDirDegIC(void) const
   FGColumnVector3 _vt_NED = Tb2l * Tw2b * FGColumnVector3(vt, 0., 0.);
   FGColumnVector3 _vWIND_NED = _vt_NED - vUVW_NED;
 
-  return _vWIND_NED(eV) == 0.0 ? 0.0
-                               : atan2(_vWIND_NED(eV), _vWIND_NED(eU))*radtodeg;
+  return atan2(_vWIND_NED(eV), _vWIND_NED(eU))*radtodeg;
 }
 
 //******************************************************************************
 
-double FGInitialCondition::GetNEDWindFpsIC(int idx) const
-{
+FGColumnVector3 FGInitialCondition::GetWindNEDFpsIC(void) const {
   const FGMatrix33& Tb2l = orientation.GetTInv();
   FGColumnVector3 _vt_NED = Tb2l * Tw2b * FGColumnVector3(vt, 0., 0.);
-  FGColumnVector3 _vWIND_NED = _vt_NED - vUVW_NED;
-
-  return _vWIND_NED(idx);
+  return _vt_NED - vUVW_NED;
 }
 
 //******************************************************************************
@@ -1032,7 +1028,7 @@ bool FGInitialCondition::Load(const SGPath& rstfile, bool useStoredPath)
   // If doc has an version, check it. Otherwise fall back to legacy.
   if (document->HasAttribute("version")) {
     double version = document->GetAttributeValueAsNumber("version");
-    
+
     if (version >= 3.0) {
       const string s("Only initialization file formats 1 and 2 are currently supported");
       cerr << document->ReadFrom() << endl << s << endl;

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -919,7 +919,8 @@ double FGInitialCondition::GetWindDirDegIC(void) const
   FGColumnVector3 _vt_NED = Tb2l * Tw2b * FGColumnVector3(vt, 0., 0.);
   FGColumnVector3 _vWIND_NED = _vt_NED - vUVW_NED;
 
-  return atan2(_vWIND_NED(eV), _vWIND_NED(eU))*radtodeg;
+  return _vWIND_NED.Magnitude(eU, eV) == 0.0 ? 0.0
+                              : atan2(_vWIND_NED(eV), _vWIND_NED(eU))*radtodeg;
 }
 
 //******************************************************************************

--- a/src/initialization/FGInitialCondition.h
+++ b/src/initialization/FGInitialCondition.h
@@ -489,23 +489,19 @@ public:
 
   /** Gets the initial wind velocity in the NED local frame
       @return Initial wind velocity in NED frame in feet/second */
-  const FGColumnVector3 GetWindNEDFpsIC(void) const {
-    const FGMatrix33& Tb2l = orientation.GetTInv();
-    FGColumnVector3 _vt_NED = Tb2l * Tw2b * FGColumnVector3(vt, 0., 0.);
-    return _vt_NED - vUVW_NED;
-  }
+  FGColumnVector3 GetWindNEDFpsIC(void) const;
 
   /** Gets the initial wind velocity in local frame.
       @return Initial wind velocity toward north in feet/second */
-  double GetWindNFpsIC(void) const { return GetNEDWindFpsIC(eX); }
+  double GetWindNFpsIC(void) const { return GetWindNEDFpsIC()(eX); }
 
   /** Gets the initial wind velocity in local frame.
       @return Initial wind velocity eastwards in feet/second */
-  double GetWindEFpsIC(void) const { return GetNEDWindFpsIC(eY); }
+  double GetWindEFpsIC(void) const { return GetWindNEDFpsIC()(eY); }
 
   /** Gets the initial wind velocity in local frame.
       @return Initial wind velocity downwards in feet/second */
-  double GetWindDFpsIC(void) const { return GetNEDWindFpsIC(eZ); }
+  double GetWindDFpsIC(void) const { return GetWindNEDFpsIC()(eZ); }
 
   /** Gets the initial total wind velocity in feet/sec.
       @return Initial wind velocity in feet/second */
@@ -679,7 +675,7 @@ public:
       @param index of the engine to be checked
       @return true if the engine is running. */
   bool IsEngineRunning(unsigned int n) const { return (enginesRunning & (1 << n)) != 0; }
-  
+
   /** Does initialization file call for trim ?
       @return Trim type, if any requested (version 1). */
   int TrimRequested(void) const { return trimRequested; }
@@ -719,7 +715,6 @@ private:
   void SetBodyVelFpsIC(int idx, double vel);
   void SetNEDVelFpsIC(int idx, double vel);
   double GetBodyWindFpsIC(int idx) const;
-  double GetNEDWindFpsIC(int idx) const;
   double GetBodyVelFpsIC(int idx) const;
   void calcAeroAngles(const FGColumnVector3& _vt_BODY);
   void calcThetaBeta(double alfa, const FGColumnVector3& _vt_NED);

--- a/src/initialization/FGInitialCondition.h
+++ b/src/initialization/FGInitialCondition.h
@@ -505,7 +505,7 @@ public:
 
   /** Gets the initial total wind velocity in feet/sec.
       @return Initial wind velocity in feet/second */
-  double GetWindFpsIC(void)  const;
+  double GetWindFpsIC(void) const;
 
   /** Gets the initial wind direction.
       @return Initial wind direction in feet/second */

--- a/src/input_output/FGXMLElement.cpp
+++ b/src/input_output/FGXMLElement.cpp
@@ -124,7 +124,7 @@ Element::Element(const string& nm)
     convert["N"]["LBS"] = 0.22482;
     convert["LBS"]["N"] = 1.0/convert["N"]["LBS"];
     // Velocity
-    convert["KTS"]["FT/SEC"] = 1.68781;
+    convert["KTS"]["FT/SEC"] = 1.6878098571;
     convert["FT/SEC"]["KTS"] = 1.0/convert["KTS"]["FT/SEC"];
     convert["M/S"]["FT/S"] = 3.2808399;
     convert["M/S"]["KTS"] = convert["M/S"]["FT/S"]/convert["KTS"]["FT/SEC"];

--- a/tests/TestInitialConditions.py
+++ b/tests/TestInitialConditions.py
@@ -28,10 +28,11 @@ from JSBSim_utils import append_xml, ExecuteUntil, JSBSimTestCase, RunTest, Copy
 import fpectl
 
 # Values copied from FGJSBBase.cpp and FGXMLElement.cpp
+ktstofps = 1852.0 / (3600.0 * 0.3048)
 convtoft = {'FT': 1.0, 'M': 3.2808399, 'IN': 1.0/12.0}
-convtofps = {'FT/SEC': 1.0, 'KTS': 1.68781, 'M/S': 3.2808399}
+convtofps = {'FT/SEC': 1.0, 'KTS': ktstofps, 'M/S': 3.2808399}
 convtodeg = {'DEG': 1.0, 'RAD': 57.295779513082320876798154814105}
-convtokts = {'KTS': 1.0, 'FT/SEC': 1.0/1.68781, 'M/S': 3.2808399/1.68781}
+convtokts = {'KTS': 1.0, 'FT/SEC': 1.0/ktstofps, 'M/S': 3.2808399/ktstofps}
 
 
 class TestInitialConditions(JSBSimTestCase):

--- a/tests/unit_tests/FGInitialConditionTest.h
+++ b/tests/unit_tests/FGInitialConditionTest.h
@@ -9,6 +9,7 @@ using namespace JSBSim;
 
 const double epsilon = 100. * std::numeric_limits<double>::epsilon();
 const FGColumnVector3 zero {0.0, 0.0, 0.0};
+constexpr double ktstofps = 1852./(3600*0.3048);
 
 class FGInitialConditionTest : public CxxTest::TestSuite
 {
@@ -330,5 +331,32 @@ public:
       TS_ASSERT_DELTA(ic.GetThetaDegIC(), 0.0, epsilon);
       TS_ASSERT_DELTA(ic.GetPsiDegIC(), psi, epsilon*10.);
     }
+  }
+
+  void testWindVelocity() {
+    FGFDMExec fdmex;
+    FGInitialCondition ic(&fdmex);
+
+    ic.SetWindDownKtsIC(1.0);
+    TS_ASSERT_DELTA(ic.GetWindDFpsIC(), ktstofps, epsilon);
+
+    ic.SetWindNEDFpsIC(1.0, 2.0, 3.0);
+    TS_ASSERT_VECTOR_EQUALS(ic.GetWindNEDFpsIC(), FGColumnVector3(1.0, 2.0, 3.0));
+    TS_ASSERT_DELTA(ic.GetWindNFpsIC(), 1.0, epsilon);
+    TS_ASSERT_DELTA(ic.GetWindEFpsIC(), 2.0, epsilon);
+    TS_ASSERT_DELTA(ic.GetWindDFpsIC(), 3.0, epsilon);
+    TS_ASSERT_DELTA(ic.GetWindFpsIC(), sqrt(5.0), epsilon);
+    TS_ASSERT_DELTA(ic.GetWindDirDegIC(), atan2(2.0, 1.0)*180./M_PI, epsilon);
+
+    double mag = ic.GetWindFpsIC();
+    ic.SetWindDirDegIC(30.);
+    TS_ASSERT_DELTA(ic.GetWindNFpsIC(), 0.5*mag*sqrt(3.0), epsilon);
+    TS_ASSERT_DELTA(ic.GetWindEFpsIC(), 0.5*mag, epsilon);
+    TS_ASSERT_DELTA(ic.GetWindDFpsIC(), 3.0, epsilon);
+
+    ic.SetWindMagKtsIC(7.0);
+    TS_ASSERT_DELTA(ic.GetWindNFpsIC(), 3.5*sqrt(3.0)*ktstofps, epsilon);
+    TS_ASSERT_DELTA(ic.GetWindEFpsIC(), 3.5*ktstofps, epsilon);
+    TS_ASSERT_DELTA(ic.GetWindDFpsIC(), 3.0, epsilon);
   }
 };


### PR DESCRIPTION
This PR fixes a 12+ years old bug where the input value was not converted from kts to ft/s.
```diff
void FGInitialCondition::SetWindDownKtsIC(double wD)
{
  const FGMatrix33& Tb2l = orientation.GetTInv();
  FGColumnVector3 _vt_NED = Tb2l * Tw2b * FGColumnVector3(vt, 0., 0.);

-  _vt_NED(eW) = vUVW_NED(eW) + wD;
+  _vt_NED(eW) = vUVW_NED(eW) + wD * ktstofps;
```
The PR contains an update to the unit test `FGInitialConditionsTest.h` to prevent regressions. I also took this opportunity to fix a couple of details:
* The constant `ktstofps` is computed to the floating point precision of `double` (thanks to the C++ `constexpr` feature, the computation is done at compile time, i.e. once for all)
* The private method `GetNEDWindFpsIC` has been removed as it was redundant with `GetWindNEDFpsIC`.