### PR TITLE
Add a unit test for `FGAtmosphere`

### DIFF
--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -225,7 +225,7 @@ double FGAtmosphere::ConvertToRankine(double t, eTemperature unit) const
     targetTemp = t*1.8;
     break;
   default:
-    break;
+    throw BaseException("Undefined temperature unit given");
   }
 
   return targetTemp;
@@ -251,7 +251,7 @@ double FGAtmosphere::ConvertFromRankine(double t, eTemperature unit) const
     targetTemp = t/1.8;
     break;
   default:
-    break;
+    throw BaseException("Undefined temperature unit given");
   }
 
   return targetTemp;
@@ -277,7 +277,7 @@ double FGAtmosphere::ConvertToPSF(double p, ePressure unit) const
     targetPressure = p*70.7180803;
     break;
   default:
-    throw("Undefined pressure unit given");
+    throw BaseException("Undefined pressure unit given");
   }
 
   return targetPressure;
@@ -301,7 +301,7 @@ double FGAtmosphere::ConvertFromPSF(double p, ePressure unit) const
     targetPressure = p/70.7180803;
     break;
   default:
-    throw("Undefined pressure unit given");
+    throw BaseException("Undefined pressure unit given");
   }
 
   return targetPressure;

--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -51,15 +51,13 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-// Atmosphere constants in British units converted from the SI values specified in the 
+// Atmosphere constants in British units converted from the SI values specified in the
 // ISA document - https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770009539.pdf
 double FGAtmosphere::Reng = Rstar / Mair;
 
 const double FGAtmosphere::StdDaySLsoundspeed = sqrt(SHRatio*Reng*StdDaySLtemperature);
 
-FGAtmosphere::FGAtmosphere(FGFDMExec* fdmex) : FGModel(fdmex),
-                                               PressureAltitude(0.0),      // ft
-                                               DensityAltitude(0.0)       // ft
+FGAtmosphere::FGAtmosphere(FGFDMExec* fdmex) : FGModel(fdmex)
 {
   Name = "FGAtmosphere";
 
@@ -80,11 +78,11 @@ bool FGAtmosphere::InitModel(void)
 {
   if (!FGModel::InitModel()) return false;
 
-  Calculate(0.0);
   SLtemperature = Temperature = StdDaySLtemperature;
   SLpressure = Pressure = StdDaySLpressure;
   SLdensity = Density = Pressure/(Reng*Temperature);
   SLsoundspeed = Soundspeed = StdDaySLsoundspeed;
+  Calculate(0.0);
 
   return true;
 }
@@ -158,7 +156,7 @@ void FGAtmosphere::Calculate(double altitude)
   Pressure = ValidatePressure(p, "", true);
 
   if (!PropertyManager->HasNode("atmosphere/override/density"))
-    Density = GetDensity(altitude);
+    Density = Pressure/(Reng*Temperature);
   else
     Density = node->GetDouble("atmosphere/override/density");
 

--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -53,9 +53,7 @@ CLASS IMPLEMENTATION
 
 // Atmosphere constants in British units converted from the SI values specified in the
 // ISA document - https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770009539.pdf
-double FGAtmosphere::Reng = Rstar / Mair;
-
-const double FGAtmosphere::StdDaySLsoundspeed = sqrt(SHRatio*Reng*StdDaySLtemperature);
+const double FGAtmosphere::StdDaySLsoundspeed = sqrt(SHRatio*Reng0*StdDaySLtemperature);
 
 FGAtmosphere::FGAtmosphere(FGFDMExec* fdmex) : FGModel(fdmex)
 {
@@ -175,6 +173,7 @@ void FGAtmosphere::SetPressureSL(ePressure unit, double pressure)
   double press = ConvertToPSF(pressure, unit);
 
   SLpressure = ValidatePressure(press, "Sea Level pressure");
+  SLdensity = GetDensity(0.0);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -202,6 +201,8 @@ void FGAtmosphere::SetTemperatureSL(double t, eTemperature unit)
   double temp = ConvertToRankine(t, unit);
 
   SLtemperature = ValidateTemperature(temp, "Sea Level temperature");
+  SLdensity = GetDensity(0.0);
+  SLsoundspeed = GetSoundSpeed(0.0);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -90,7 +90,7 @@ public:
 
   /** Runs the atmosphere forces model; called by the Executive.
       Can pass in a value indicating if the executive is directing the simulation to Hold.
-      @param Holding if true, the executive has been directed to hold the sim from 
+      @param Holding if true, the executive has been directed to hold the sim from
                      advancing time. Some models may ignore this flag, such as the Input
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
@@ -111,7 +111,7 @@ public:
   /// Returns the actual modeled temperature in degrees Rankine at a specified altitude.
   /// @param altitude The altitude above sea level (ASL) in feet.
   /// @return Modeled temperature in degrees Rankine at the specified altitude.
-  virtual double GetTemperature(double altitude) const = 0; 
+  virtual double GetTemperature(double altitude) const = 0;
 
   /// Returns the actual, modeled sea level temperature in degrees Rankine.
   /// @return The modeled temperature in degrees Rankine at sea level.
@@ -184,7 +184,7 @@ public:
 
   /// Returns the speed of sound in ft/sec at a given altitude in ft.
   virtual double GetSoundSpeed(double altitude) const;
-  
+
   /// Returns the sea level speed of sound in ft/sec.
   virtual double GetSoundSpeedSL(void) const { return SLsoundspeed; }
 
@@ -215,15 +215,23 @@ public:
   static const double StdDaySLsoundspeed;
 
 protected:
-  double    SLtemperature,    SLdensity,    SLpressure,    SLsoundspeed; // Sea level conditions
-  double      Temperature,      Density,      Pressure,      Soundspeed; // Current actual conditions at altitude
-
-  double PressureAltitude;
-  double DensityAltitude;
+  // Sea level conditions
+  double SLtemperature = 1.0;
+  double SLdensity = 1.0;
+  double SLpressure = 1.0;
+  double SLsoundspeed = 1.0;
+  // Current actual conditions at altitude
+  double Temperature = 1.0;
+  double Density = 0.0;
+  double Pressure = 0.0;
+  double Soundspeed = 0.0;
+  double PressureAltitude = 0.0;
+  double DensityAltitude = 0.0;
 
   static constexpr double SutherlandConstant = 198.72;  // deg Rankine
   static constexpr double Beta = 2.269690E-08; // slug/(sec ft R^0.5)
-  double Viscosity, KinematicViscosity;
+  double Viscosity = 0.0;
+  double KinematicViscosity = 0.0;
 
   /// Calculate the atmosphere for the given altitude.
   virtual void Calculate(double altitude);
@@ -244,7 +252,7 @@ protected:
 
   /// Converts to Rankine from one of several unit systems.
   double ConvertToRankine(double t, eTemperature unit) const;
-  
+
   /// Converts from Rankine to one of several unit systems.
   double ConvertFromRankine(double t, eTemperature unit) const;
 

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -216,12 +216,12 @@ public:
 
 protected:
   // Sea level conditions
-  double SLtemperature = 1.0;
+  double SLtemperature = 1.8;
   double SLdensity = 1.0;
   double SLpressure = 1.0;
   double SLsoundspeed = 1.0;
   // Current actual conditions at altitude
-  double Temperature = 1.0;
+  double Temperature = 1.8;
   double Density = 0.0;
   double Pressure = 0.0;
   double Soundspeed = 0.0;

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -73,7 +73,7 @@ CLASS DOCUMENTATION
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class FGAtmosphere : public FGModel {
+class JSBSIM_API FGAtmosphere : public FGModel {
 public:
 
   /// Enums for specifying temperature units.

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -285,10 +285,12 @@ protected:
   */
   static constexpr double g0 = 9.80665 / fttom;
   /// Specific gas constant for air - ft*lbf/slug/R
-  static double Reng;
+  static constexpr double Reng0 = Rstar / Mair;
   //@}
 
   static constexpr double SHRatio = 1.4;
+
+  double Reng = Reng0;
 
   virtual void bind(void);
   void Debug(int from) override;

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -17,7 +17,8 @@ set(UNIT_TESTS FGColumnVector3Test
                FGParameterTest
                FGParameterValueTest
                FGConditionTest
-               FGPropertyManagerTest)
+               FGPropertyManagerTest
+               FGAtmosphereTest)
 
 foreach(test ${UNIT_TESTS})
   cxxtest_add_test(${test}1 ${test}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${test}.h)

--- a/tests/unit_tests/FGAtmosphereTest.h
+++ b/tests/unit_tests/FGAtmosphereTest.h
@@ -1,0 +1,424 @@
+#include <limits>
+#include <cxxtest/TestSuite.h>
+
+#include <FGFDMExec.h>
+#include <models/FGAtmosphere.h>
+
+const double epsilon = 100. * std::numeric_limits<double>::epsilon();
+
+using namespace JSBSim;
+
+class DummyAtmosphere : public FGAtmosphere
+{
+public:
+  DummyAtmosphere(FGFDMExec* fdm, double t_lapse_rate, double p_lapse_rate)
+    : FGAtmosphere(fdm), a_t(t_lapse_rate), a_p(p_lapse_rate)
+  {}
+
+  using FGAtmosphere::GetTemperature;
+  using FGAtmosphere::GetPressure;
+
+  double GetTemperature(double altitude) const override
+  {
+    return SLtemperature+a_t*altitude;
+  }
+  void SetTemperature(double t, double h, eTemperature unit) override
+  {
+    Temperature = ConvertToRankine(t, unit)-a_t*h;
+  }
+  double GetPressure(double altitude) const override
+  {
+    return SLpressure+a_p*altitude;
+  }
+  double GetR(void) const { return Reng; }
+  double GetGamma(void) const { return SHRatio; }
+  double GetBeta(void) const { return Beta; }
+  double GetSutherlandConstant(void) const { return SutherlandConstant; }
+private:
+  double a_t, a_p;
+};
+
+class FGAtmosphereTest : public CxxTest::TestSuite
+{
+public:
+  void testDefaultValuesBeforeInit() {
+    FGFDMExec fdmex;
+    auto atm = DummyAtmosphere(&fdmex, 1.0, 1.0);
+
+    const double R = atm.GetR();
+    const double gamma = atm.GetGamma();
+    TS_ASSERT_DELTA(gamma, 1.4, epsilon);
+
+    TS_ASSERT_EQUALS(atm.GetTemperatureSL(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetTemperature(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetTemperature(0.0), 1.0);
+    TS_ASSERT_EQUALS(atm.GetTemperatureRatio(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetTemperatureRatio(0.0), 1.0);
+
+    TS_ASSERT_EQUALS(atm.GetPressureSL(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetPressure(), 0.0);
+    TS_ASSERT_EQUALS(atm.GetPressure(0.0), 1.0);
+    TS_ASSERT_EQUALS(atm.GetPressureRatio(), 0.0);
+
+    const double rho = 1.0/R;
+    TS_ASSERT_EQUALS(atm.GetDensitySL(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetDensity(), 0.0);
+    TS_ASSERT_EQUALS(atm.GetDensity(0.0), rho);
+    TS_ASSERT_EQUALS(atm.GetDensityRatio(), 0.0);
+
+    const double a = sqrt(gamma*R);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeedSL(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeed(), 0.0);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeed(0.0), a);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeedRatio(), 0.0);
+
+    TS_ASSERT_EQUALS(atm.GetDensityAltitude(), 0.0);
+    TS_ASSERT_EQUALS(atm.GetPressureAltitude(), 0.0);
+
+    TS_ASSERT_EQUALS(atm.GetAbsoluteViscosity(), 0.0);
+    TS_ASSERT_EQUALS(atm.GetKinematicViscosity(), 0.0);
+  }
+
+  void testDefaultValuesAfterInit() {
+    FGFDMExec fdmex;
+    auto atm = DummyAtmosphere(&fdmex, 1.0, 1.0);
+
+    TS_ASSERT(atm.InitModel());
+
+    TS_ASSERT_EQUALS(atm.GetTemperatureSL(), FGAtmosphere::StdDaySLtemperature);
+    TS_ASSERT_EQUALS(atm.GetTemperature(), FGAtmosphere::StdDaySLtemperature);
+    TS_ASSERT_EQUALS(atm.GetTemperature(0.0), FGAtmosphere::StdDaySLtemperature);
+    TS_ASSERT_EQUALS(atm.GetTemperatureRatio(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetTemperatureRatio(0.0), 1.0);
+    TS_ASSERT_EQUALS(atm.GetPressureSL(), FGAtmosphere::StdDaySLpressure);
+    TS_ASSERT_EQUALS(atm.GetPressure(), FGAtmosphere::StdDaySLpressure);
+    TS_ASSERT_EQUALS(atm.GetPressure(0.0), FGAtmosphere::StdDaySLpressure);
+    TS_ASSERT_EQUALS(atm.GetPressureRatio(), 1.0);
+
+    const double R = atm.GetR();
+    const double gamma = atm.GetGamma();
+    TS_ASSERT_DELTA(gamma, 1.4, epsilon);
+    const double T = atm.GetTemperature();
+    const double SLdensity = FGAtmosphere::StdDaySLpressure/(R*T);
+    TS_ASSERT_EQUALS(atm.GetDensity(), SLdensity);
+    TS_ASSERT_EQUALS(atm.GetDensity(0.0), SLdensity);
+    TS_ASSERT_EQUALS(atm.GetDensitySL(), SLdensity);
+    TS_ASSERT_EQUALS(atm.GetDensityRatio(), 1.0);
+
+    const double SLsoundspeed = sqrt(gamma*R*T);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeed(), SLsoundspeed);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeed(0.0), SLsoundspeed);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeedSL(), SLsoundspeed);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeedRatio(), 1.0);
+
+    TS_ASSERT_EQUALS(atm.GetDensityAltitude(), 0.0);
+    TS_ASSERT_EQUALS(atm.GetPressureAltitude(), 0.0);
+
+    const double beta = atm.GetBeta();
+    const double k = atm.GetSutherlandConstant();
+    const double mu = beta*T*sqrt(T)/(k+T);
+    const double nu = mu/SLdensity;
+    TS_ASSERT_DELTA(atm.GetAbsoluteViscosity(), mu, epsilon);
+    TS_ASSERT_DELTA(atm.GetKinematicViscosity(), nu, epsilon);
+  }
+
+  void testGetAltitudeParameters() {
+    FGFDMExec fdmex;
+    auto atm = DummyAtmosphere(&fdmex, 0.1, 1.0);
+    TS_ASSERT(atm.InitModel());
+
+    const double R = atm.GetR();
+    const double gamma = atm.GetGamma();
+    const double T0 = FGAtmosphere::StdDaySLtemperature;
+    const double P0 = FGAtmosphere::StdDaySLpressure;
+    const double rho0 = P0/(R*T0);
+    const double a0 = sqrt(gamma*R*T0);
+    const double beta = atm.GetBeta();
+    const double k = atm.GetSutherlandConstant();
+    const double mu0 = beta*T0*sqrt(T0)/(k+T0);
+    const double nu0 = mu0/rho0;
+
+    for(double h=-1000.0; h<10000; h+= 1000) {
+      double T = T0 + 0.1*h;
+      double P = P0 + 1.0*h;
+
+      TS_ASSERT_DELTA(atm.GetTemperature(h), T, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperature(0.0), T0);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio(h), T/T0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperatureRatio(0.0), 1.0);
+      TS_ASSERT_DELTA(atm.GetPressure(h), P, epsilon);
+      TS_ASSERT_EQUALS(atm.GetPressure(0.0), P0);
+
+      double rho = P/(R*T);
+      TS_ASSERT_DELTA(atm.GetDensity(h), rho, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensity(0.0), rho0, epsilon);
+
+      double a = sqrt(gamma*R*T);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(h), a, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(0.0), a0, epsilon);
+
+      // Local values must remain unchanged
+      TS_ASSERT_EQUALS(atm.GetTemperatureSL(), T0);
+      TS_ASSERT_EQUALS(atm.GetTemperature(), T0);
+      TS_ASSERT_EQUALS(atm.GetTemperatureRatio(), 1.0);
+      TS_ASSERT_EQUALS(atm.GetPressureSL(), P0);
+      TS_ASSERT_EQUALS(atm.GetPressure(), P0);
+      TS_ASSERT_EQUALS(atm.GetPressureRatio(), 1.0);
+      TS_ASSERT_DELTA(atm.GetDensity(), rho0, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensitySL(), rho0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetDensityRatio(), 1.0);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(), a0, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedSL(), a0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetSoundSpeedRatio(), 1.0);
+      TS_ASSERT_EQUALS(atm.GetDensityAltitude(), 0.0);
+      TS_ASSERT_EQUALS(atm.GetPressureAltitude(), 0.0);
+      TS_ASSERT_DELTA(atm.GetAbsoluteViscosity(), mu0, epsilon);
+      TS_ASSERT_DELTA(atm.GetKinematicViscosity(), nu0, epsilon);
+    }
+  }
+
+  void testRun() {
+    FGFDMExec fdmex;
+    auto atm = DummyAtmosphere(&fdmex, 0.1, 1.0);
+    TS_ASSERT(atm.InitModel());
+
+    const double R = atm.GetR();
+    const double gamma = atm.GetGamma();
+    const double T0 = FGAtmosphere::StdDaySLtemperature;
+    const double P0 = FGAtmosphere::StdDaySLpressure;
+    const double rho0 = P0/(R*T0);
+    const double a0 = sqrt(gamma*R*T0);
+    const double beta = atm.GetBeta();
+    const double k = atm.GetSutherlandConstant();
+
+    for(double h=-1000.0; h<10000; h+= 1000) {
+      atm.in.altitudeASL = h;
+      TS_ASSERT(atm.Run(false) == false);
+
+      double T = T0 + 0.1*h;
+      TS_ASSERT_EQUALS(atm.GetTemperatureSL(), T0);
+      TS_ASSERT_DELTA(atm.GetTemperature(), T, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperature(0.0), T0);
+      TS_ASSERT_DELTA(atm.GetTemperature(h), T, epsilon);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio(), T/T0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperatureRatio(0.0), 1.0);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio(h), T/T0, epsilon);
+
+      double P = P0 + 1.0*h;
+      TS_ASSERT_EQUALS(atm.GetPressureSL(), P0);
+      TS_ASSERT_DELTA(atm.GetPressure(), P, epsilon);
+      TS_ASSERT_EQUALS(atm.GetPressure(0.0), P0);
+      TS_ASSERT_DELTA(atm.GetPressure(h), P, epsilon);
+      TS_ASSERT_DELTA(atm.GetPressureRatio(), P/P0, epsilon);
+
+      double rho = P/(R*T);
+      TS_ASSERT_DELTA(atm.GetDensity(), rho, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensity(0.0), rho0, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensity(h), rho, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensitySL(), rho0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetDensityRatio(), rho/rho0);
+
+      double a = sqrt(gamma*R*T);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(), a, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(0.0), a0, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(h), a, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedSL(), a0, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedRatio(), a/a0, epsilon);
+
+      TS_ASSERT_EQUALS(atm.GetDensityAltitude(), h);
+      TS_ASSERT_EQUALS(atm.GetPressureAltitude(), h);
+
+      double mu = beta*T*sqrt(T)/(k+T);
+      double nu = mu/rho;
+      TS_ASSERT_DELTA(atm.GetAbsoluteViscosity(), mu, epsilon);
+      TS_ASSERT_DELTA(atm.GetKinematicViscosity(), nu, epsilon);
+    }
+  }
+
+  void testTemperatureOverride() {
+    FGFDMExec fdmex;
+    auto pm = fdmex.GetPropertyManager();
+    auto atm = DummyAtmosphere(&fdmex, 0.1, 1.0);
+    TS_ASSERT(atm.InitModel());
+
+    const double R = atm.GetR();
+    const double gamma = atm.GetGamma();
+    const double T0 = FGAtmosphere::StdDaySLtemperature;
+    const double P0 = FGAtmosphere::StdDaySLpressure;
+    const double rho0 = P0/(R*T0);
+    const double a0 = sqrt(gamma*R*T0);
+    const double beta = atm.GetBeta();
+    const double k = atm.GetSutherlandConstant();
+
+    auto t_node = pm->GetNode("atmosphere/override/temperature", true);
+    const double T = 300.0;
+    t_node->setDoubleValue(T);
+
+    for(double h=-1000.0; h<10000; h+= 1000) {
+      atm.in.altitudeASL = h;
+      TS_ASSERT(atm.Run(false) == false);
+
+      double Tz = T0+0.1*h;
+      TS_ASSERT_EQUALS(atm.GetTemperatureSL(), T0);
+      TS_ASSERT_DELTA(atm.GetTemperature(), T, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperature(0.0), T0);
+      TS_ASSERT_DELTA(atm.GetTemperature(h), Tz, epsilon);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio(), T/T0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperatureRatio(0.0), 1.0);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio(h), 1.0+0.1*h/T0, epsilon);
+
+      double P = P0 + 1.0*h;
+      TS_ASSERT_EQUALS(atm.GetPressureSL(), P0);
+      TS_ASSERT_DELTA(atm.GetPressure(), P, epsilon);
+      TS_ASSERT_EQUALS(atm.GetPressure(0.0), P0);
+      TS_ASSERT_DELTA(atm.GetPressure(h), P, epsilon);
+      TS_ASSERT_DELTA(atm.GetPressureRatio(), P/P0, epsilon);
+
+      double rho = P/(R*T);
+      TS_ASSERT_DELTA(atm.GetDensity(), rho, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensity(0.0), rho0, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensity(h), P/(R*Tz), epsilon);
+      TS_ASSERT_DELTA(atm.GetDensitySL(), rho0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetDensityRatio(), rho/rho0);
+
+      double a = sqrt(gamma*R*T);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(), a, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(0.0), a0, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(h), sqrt(gamma*R*Tz), epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedSL(), a0, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedRatio(), a/a0, epsilon);
+
+      TS_ASSERT_EQUALS(atm.GetDensityAltitude(), h);
+      TS_ASSERT_EQUALS(atm.GetPressureAltitude(), h);
+
+      double mu = beta*T*sqrt(T)/(k+T);
+      double nu = mu/rho;
+      TS_ASSERT_DELTA(atm.GetAbsoluteViscosity(), mu, epsilon);
+      TS_ASSERT_DELTA(atm.GetKinematicViscosity(), nu, epsilon);
+    }
+  }
+
+  void testPressureOverride() {
+    FGFDMExec fdmex;
+    auto pm = fdmex.GetPropertyManager();
+    auto atm = DummyAtmosphere(&fdmex, 0.1, 1.0);
+    TS_ASSERT(atm.InitModel());
+
+    const double R = atm.GetR();
+    const double gamma = atm.GetGamma();
+    const double T0 = FGAtmosphere::StdDaySLtemperature;
+    const double P0 = FGAtmosphere::StdDaySLpressure;
+    const double rho0 = P0/(R*T0);
+    const double a0 = sqrt(gamma*R*T0);
+    const double beta = atm.GetBeta();
+    const double k = atm.GetSutherlandConstant();
+
+    auto p_node = pm->GetNode("atmosphere/override/pressure", true);
+    const double P = 3000.0;
+    p_node->setDoubleValue(P);
+
+    for(double h=-1000.0; h<10000; h+= 1000) {
+      atm.in.altitudeASL = h;
+      TS_ASSERT(atm.Run(false) == false);
+
+      double T = T0 + 0.1*h;
+      TS_ASSERT_EQUALS(atm.GetTemperatureSL(), T0);
+      TS_ASSERT_DELTA(atm.GetTemperature(), T, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperature(0.0), T0);
+      TS_ASSERT_DELTA(atm.GetTemperature(h), T, epsilon);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio(), T/T0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperatureRatio(0.0), 1.0);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio(h), T/T0, epsilon);
+
+      TS_ASSERT_EQUALS(atm.GetPressureSL(), P0);
+      TS_ASSERT_DELTA(atm.GetPressure(), P, epsilon);
+      TS_ASSERT_EQUALS(atm.GetPressure(0.0), P0);
+      TS_ASSERT_DELTA(atm.GetPressure(h), P0+h, epsilon);
+      TS_ASSERT_DELTA(atm.GetPressureRatio(), P/P0, epsilon);
+
+      double rho = P/(R*T);
+      TS_ASSERT_DELTA(atm.GetDensity(), rho, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensity(0.0), rho0, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensity(h), (P0+h)/(R*T), epsilon);
+      TS_ASSERT_DELTA(atm.GetDensitySL(), rho0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetDensityRatio(), rho/rho0);
+
+      double a = sqrt(gamma*R*T);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(), a, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(0.0), a0, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(h), a, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedSL(), a0, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedRatio(), a/a0, epsilon);
+
+      TS_ASSERT_EQUALS(atm.GetDensityAltitude(), h);
+      TS_ASSERT_EQUALS(atm.GetPressureAltitude(), h);
+
+      double mu = beta*T*sqrt(T)/(k+T);
+      double nu = mu/rho;
+      TS_ASSERT_DELTA(atm.GetAbsoluteViscosity(), mu, epsilon);
+      TS_ASSERT_DELTA(atm.GetKinematicViscosity(), nu, epsilon);
+    }
+  }
+
+  void testDensityOverride() {
+    FGFDMExec fdmex;
+    auto pm = fdmex.GetPropertyManager();
+    auto atm = DummyAtmosphere(&fdmex, 0.1, 1.0);
+    TS_ASSERT(atm.InitModel());
+
+    const double R = atm.GetR();
+    const double gamma = atm.GetGamma();
+    const double T0 = FGAtmosphere::StdDaySLtemperature;
+    const double P0 = FGAtmosphere::StdDaySLpressure;
+    const double rho0 = P0/(R*T0);
+    const double a0 = sqrt(gamma*R*T0);
+    const double beta = atm.GetBeta();
+    const double k = atm.GetSutherlandConstant();
+
+    auto rho_node = pm->GetNode("atmosphere/override/density", true);
+    const double rho = 3000.0;
+    rho_node->setDoubleValue(rho);
+
+    for(double h=-1000.0; h<10000; h+= 1000) {
+      atm.in.altitudeASL = h;
+      TS_ASSERT(atm.Run(false) == false);
+
+      double T = T0 + 0.1*h;
+      TS_ASSERT_EQUALS(atm.GetTemperatureSL(), T0);
+      TS_ASSERT_DELTA(atm.GetTemperature(), T, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperature(0.0), T0);
+      TS_ASSERT_DELTA(atm.GetTemperature(h), T, epsilon);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio(), T/T0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetTemperatureRatio(0.0), 1.0);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio(h), T/T0, epsilon);
+
+      double P = P0 + 1.0*h;
+      TS_ASSERT_EQUALS(atm.GetPressureSL(), P0);
+      TS_ASSERT_DELTA(atm.GetPressure(), P, epsilon);
+      TS_ASSERT_EQUALS(atm.GetPressure(0.0), P0);
+      TS_ASSERT_DELTA(atm.GetPressure(h), P, epsilon);
+      TS_ASSERT_DELTA(atm.GetPressureRatio(), P/P0, epsilon);
+
+      TS_ASSERT_DELTA(atm.GetDensity(), rho, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensity(0.0), rho0, epsilon);
+      TS_ASSERT_DELTA(atm.GetDensity(h), P/(R*T), epsilon);
+      TS_ASSERT_DELTA(atm.GetDensitySL(), rho0, epsilon);
+      TS_ASSERT_EQUALS(atm.GetDensityRatio(), rho/rho0);
+
+      double a = sqrt(gamma*R*T);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(), a, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(0.0), a0, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(h), a, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedSL(), a0, epsilon);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedRatio(), a/a0, epsilon);
+
+      TS_ASSERT_EQUALS(atm.GetDensityAltitude(), h);
+      TS_ASSERT_EQUALS(atm.GetPressureAltitude(), h);
+
+      double mu = beta*T*sqrt(T)/(k+T);
+      double nu = mu/rho;
+      TS_ASSERT_DELTA(atm.GetAbsoluteViscosity(), mu, epsilon);
+      TS_ASSERT_DELTA(atm.GetKinematicViscosity(), nu, epsilon);
+    }
+  }
+};


### PR DESCRIPTION
This PR adds a unit test for the `FGAtmosphere` class in preparation for further changes that will address the topics mentioned in https://github.com/JSBSim-Team/jsbsim/issues/666#issuecomment-1165808763 (static members & methods) and https://github.com/JSBSim-Team/jsbsim/issues/815#issuecomment-1407216771 (MSIS atmospheric model).

The unit test in this PR will provide a means to check that no regressions will be introduced by future changes to `FGAtmosphere`.

In the process of writing this unit test, the following bugs have been discovered and fixed:
* In `FGAtmosphere::InitModel()`, `Viscosity` and `KinematicViscosity` were computed *before* `SLTemperature` was initialized resulting in incorrect values of air viscosity.
* In `FGAtmosphere::Calculate()` the density was ignoring the values from the properties `atmosphere/override/temperature` or `atmosphere/override/pressure` if one or both of these features were used.
* In `FGAtmosphere::SetPressureSL()`, `SLdensity` was not updated despite the fact that `SLpressure` was modified.
* In `FGAtmosphere::SetTemperatureSL()`, `SLdensity` and `SLsoundspeed` were not updated despite the fact that `SLtemperature` was modified.
* Providing an erroneous unit enum value to conversion methods (`ConvertToRankine`, `ConvertFromPSF`, etc.) now always raise an exception. Previously, some conversion routines silently swallowed the error returning null temperatures or pressures in the process. And as has been discussed in issue #815, null temperature and pressure are evil !
* All the class members are now initialized (with meaningful values) when the constructor is called. Previously the constructor of `FGAtmosphere` did not initialize its members: that stage was defered to the call to `InitModel()`. This is evil because you never know what code might be executed between the construction and the call to `InitModel()`.