### PR TITLE
Avoid misleading messages about properties being already defined

### DIFF
--- a/src/input_output/FGPropertyReader.cpp
+++ b/src/input_output/FGPropertyReader.cpp
@@ -64,12 +64,12 @@ bool FGPropertyReader::ResetToIC(void)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropertyReader::Load(Element* el, FGPropertyManager* PM, bool override)
+void FGPropertyReader::Load(Element* el, FGPropertyManager* PM, bool override_props)
 {
   Element *property_element = el->FindElement("property");
   if (property_element && FGJSBBase::debug_lvl > 0) {
     cout << endl << "    ";
-    if (override)
+    if (override_props)
       cout << "Overriding";
     else
       cout << "Declared";
@@ -79,13 +79,13 @@ void FGPropertyReader::Load(Element* el, FGPropertyManager* PM, bool override)
   while (property_element) {
     SGPropertyNode* node = nullptr;
     double value=0.0;
-    if ( ! property_element->GetAttributeValue("value").empty())
+    if (!property_element->GetAttributeValue("value").empty())
       value = property_element->GetAttributeValueAsNumber("value");
 
     string interface_property_string = property_element->GetDataLine();
     if (PM->HasNode(interface_property_string)) {
-      if (override) {
-        node = PM->GetNode(interface_property_string);
+      node = PM->GetNode(interface_property_string);
+      if (override_props) {
 
         if (FGJSBBase::debug_lvl > 0) {
           if (interface_prop_initial_value.find(node) == interface_prop_initial_value.end()) {
@@ -102,11 +102,15 @@ void FGPropertyReader::Load(Element* el, FGPropertyManager* PM, bool override)
         node->setDoubleValue(value);
       }
       else {
-        cerr << property_element->ReadFrom()
-             << "      Property " << interface_property_string 
-             << " is already defined." << endl;
-	property_element = el->FindNextElement("property");
-	continue;
+        if (!property_element->GetAttributeValue("value").empty()) {
+          cerr << property_element->ReadFrom()
+              << "      Property " << interface_property_string
+              << " is already defined." << endl
+              << "      Its value (" << node->getDoubleValue() << ") will not"
+              << " be overridden." << endl;
+        }
+        property_element = el->FindNextElement("property");
+        continue;
       }
     } else {
       node = PM->GetNode(interface_property_string, true);
@@ -114,7 +118,7 @@ void FGPropertyReader::Load(Element* el, FGPropertyManager* PM, bool override)
         node->setDoubleValue(value);
 
         if (FGJSBBase::debug_lvl > 0)
-          cout << "      " << interface_property_string << " (initial value: " 
+          cout << "      " << interface_property_string << " (initial value: "
                << value << ")" << endl << endl;
       }
       else {
@@ -130,7 +134,7 @@ void FGPropertyReader::Load(Element* el, FGPropertyManager* PM, bool override)
 
     property_element = el->FindNextElement("property");
   }
-  
+
   // End of interface property loading logic
 }
 }

--- a/src/input_output/FGPropertyReader.h
+++ b/src/input_output/FGPropertyReader.h
@@ -62,7 +62,7 @@ CLASS DECLARATION
 class FGPropertyReader
 {
 public:
-  void Load(Element* el, FGPropertyManager* PropertyManager, bool override);
+  void Load(Element* el, FGPropertyManager* PropertyManager, bool override_props);
   bool ResetToIC(void);
 
   class const_iterator


### PR DESCRIPTION
JSBSim issues warning messages `"Property x/y/z is already defined"` when encountering a property definition in an definition XML file while the property exists.

This warning message puzzles users as it is not obvious to understand what this message exactly means. This has been reported several times:
* Discussion #854
* Issue #140 
* Issue https://github.com/JSBSim-Team/jsbsim/issues/108#issuecomment-412089961

The code that issues this warning message is located in
https://github.com/JSBSim-Team/jsbsim/blob/e1af7cea6ce6dfc35cad99a005df6cce66a0b328/src/input_output/FGPropertyReader.cpp#L86-L110

It is a feature that allows to specify the initial value of a property:
```xml
<property value="1.0"> system/variable </property>
```
This statement is very similar to a variable declaration in C++ such as `double x=1.0;`.

When JSBSim meets this statement, it creates the property `system/variable` and sets its value to `1.0`.

However if the property `system/variable` already exists then JSBSim considers that the property has already been defined (and possibly initialized) elsewhere. So JSBSim ignores this XML statement and issues a warning message `Property system/variable is already defined` to avoid **overriding** the property initialization (possibly with an inconsistent value).

Alternatively, JSBSim allows declaring a property without the `value` attribute:
```xml
<property> system/variable </property>
```
This variant of the statement is similar to a C++ variable declaration without an initialization such as `double x;`. It is meant to tell JSBSim to create a property if it does not already exist. This is useful because some XML statements might need a property to exist at the moment of their creation while the property is actually defined at some other place in the XML aircraft definition files. Once again, this is very similar to the declaration of a C++ global variable or function.

If the property `system/variable` already exists then JSBSim issues the warning message `Property system/variable is already defined.`

The point of this PR is that it is useless to issue this warning message when the XML statement does not specify the `value`. As nothing wrong can derive from ignoring the XML statement `<property> system/variable </property>` when the property `system/variable` already exists.

This would save a number of warning messages that are issued when loading some FDM, including some of the example models that are distributed with JSBSim.

---

I also took opportunity of this PR to rename the variable `override` to `override_props` since, as @ermarch mentioned in the discussion #854, `override` is a C++ identifier since C++11. [Strictly speaking `override` is not a reserved keyword](https://en.cppreference.com/w/cpp/language/override) and compilers do not issue warning messages when using `override` as a variable name (neither gcc, nor MSVC or clang). However it is most likely not good practice to do so as it might bring confusion. What about
```c++
void override(bool override) override;
```
(which is legal in C++) :wink: ?