### PR TITLE
Removed unused code that prevents Macos/Linux compilation of the Unreal Engine plugin.

### DIFF
--- a/src/simgear/props/props.hxx
+++ b/src/simgear/props/props.hxx
@@ -1878,30 +1878,6 @@ inline std::string getValue<std::string>(const SGPropertyNode* node)
     return node->getStringValue();
 }
 
-/** Extract enum from SGPropertyNode */
-template<typename T>
-#if PROPS_STANDALONE
-inline T
-#else
-inline typename boost::enable_if<boost::is_enum<T>, T>::type
-#endif
-getValue(const SGPropertyNode* node)
-{
-  typedef simgear::enum_traits<T> Traits;
-  int val = node->getIntValue();
-  if( !Traits::validate(val) )
-  {
-    SG_LOG
-    (
-      SG_GENERAL,
-      SG_WARN,
-      "Invalid value for enum (" << Traits::name() << ", val = " << val << ")"
-    );
-    return Traits::defVal();
-  }
-  return static_cast<T>(node->getIntValue());
-}
-
 inline bool setValue(SGPropertyNode* node, bool value)
 {
     return node->setBoolValue(value);

--- a/src/simgear/props/props.hxx
+++ b/src/simgear/props/props.hxx
@@ -1878,32 +1878,6 @@ inline std::string getValue<std::string>(const SGPropertyNode* node)
     return node->getStringValue();
 }
 
-namespace simgear
-{
-  /**
-   * Default trait for extracting enum values from SGPropertyNode. Create your
-   * own specialization for specific enum types to enable validation of values.
-   */
-  template<class T>
-  struct enum_traits
-  {
-    /**
-     * Typename of the enum
-     */
-    static const char* name() { return typeid(T).name(); }
-
-    /**
-     * @return Default value (will be used if validation fails)
-     */
-    static T defVal() { return T(); }
-
-    /**
-     * @return Whether the given integer value has an enum value defined
-     */
-    static bool validate(int) { return true; }
-  };
-} // namespace simgear
-
 /** Extract enum from SGPropertyNode */
 template<typename T>
 #if PROPS_STANDALONE


### PR DESCRIPTION
This PR removes the `enum_traits` in `props.hxx` because it's not used and break the compilation of the Unreal Engine plugin on Macos and Linux.

I've compiled the JSBSim and JSBSimUnreal solution without any issue.