### PR TITLE
`FGLGear` doesn't need to inherit from `FGSurface`.

### DIFF
--- a/src/models/FGGroundReactions.cpp
+++ b/src/models/FGGroundReactions.cpp
@@ -100,7 +100,7 @@ bool FGGroundReactions::Run(bool Holding)
   // Perhaps there is some commonality for things which only need to be
   // calculated once.
   for (auto& gear:lGear) {
-    vForces  += gear->GetBodyForces(this);
+    vForces  += gear->GetBodyForces();
     vMoments += gear->GetMoments();
   }
 

--- a/src/models/FGLGear.cpp
+++ b/src/models/FGLGear.cpp
@@ -303,6 +303,10 @@ const FGColumnVector3& FGLGear::GetBodyForces(void)
     if (!fdmex->GetTrimStatus())
       height -= GroundReactions->GetBumpHeight();
     staticFFactor = GroundReactions->GetStaticFFactor();
+    rollingFFactor = GroundReactions->GetRollingFFactor();
+    maximumForce = GroundReactions->GetMaximumForce();
+    bumpiness = GroundReactions->GetBumpiness();
+    isSolid = GroundReactions->GetSolid();
 
     FGColumnVector3 vWhlDisplVec;
     double LGearProj = 1.0;
@@ -322,7 +326,7 @@ const FGColumnVector3& FGLGear::GetBodyForces(void)
       // including the strut compression.
       switch(eContactType) {
       case ctBOGEY:
-        if (GroundReactions->GetSolid()) {
+        if (isSolid) {
           compressLength = LGearProj > 0.0 ? height * normalZ / LGearProj : 0.0;
           vWhlDisplVec = mTGear * FGColumnVector3(0., 0., -compressLength);
         } else {
@@ -568,7 +572,7 @@ void FGLGear::CrashDetect(void)
 
 void FGLGear::ComputeBrakeForceCoefficient(void)
 {
-  BrakeFCoeff = GroundReactions->GetRollingFFactor() * rollingFCoeff;
+  BrakeFCoeff = rollingFFactor * rollingFCoeff;
 
   if (eBrakeGrp != bgNone)
     BrakeFCoeff += in.BrakePos[eBrakeGrp] * staticFFactor * (staticFCoeff - rollingFCoeff);
@@ -626,7 +630,6 @@ void FGLGear::ComputeVerticalStrutForce()
 
     }
 
-    double maximumForce = GroundReactions->GetMaximumForce();
     StrutForce = min(springForce + dampForce, (double)0.0);
     if (StrutForce > maximumForce) {
       StrutForce = maximumForce;
@@ -829,6 +832,17 @@ void FGLGear::bind(FGPropertyManager* PropertyManager)
     string tmp = CreateIndexedPropertyName("fcs/steer-pos-deg", GearNumber);
     PropertyManager->Tie(tmp.c_str(), this, &FGLGear::GetSteerAngleDeg, &FGLGear::SetSteerAngleDeg);
   }
+
+  property_name = base_property_name + "/solid";
+  PropertyManager->Tie( property_name.c_str(), &isSolid);
+  property_name = base_property_name + "/bumpiness";
+  PropertyManager->Tie( property_name.c_str(), &bumpiness);
+  property_name = base_property_name + "/maximum-force-lbs";
+  PropertyManager->Tie( property_name.c_str(), &maximumForce);
+  property_name = base_property_name + "/rolling_friction-factor";
+  PropertyManager->Tie( property_name.c_str(), &rollingFFactor);
+  property_name = base_property_name + "/static-friction-factor";
+  PropertyManager->Tie( property_name.c_str(), &staticFFactor);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGLGear.h
+++ b/src/models/FGLGear.h
@@ -43,7 +43,6 @@ INCLUDES
 #include "models/propulsion/FGForce.h"
 #include "math/FGLocation.h"
 #include "math/LagrangeMultiplier.h"
-#include "FGSurface.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 FORWARD DECLARATIONS
@@ -189,7 +188,7 @@ CLASS DOCUMENTATION
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class JSBSIM_API FGLGear : protected FGSurface, public FGForce
+class JSBSIM_API FGLGear : public FGForce
 {
 public:
   struct Inputs {
@@ -234,10 +233,8 @@ public:
   /// Destructor
   ~FGLGear();
 
-  /** The Force vector for this gear
-      @param surface another surface to interact with, set to NULL for none.
-   */
-  const FGColumnVector3& GetBodyForces(FGSurface *surface = NULL);
+  /// The Force vector for this gear
+  const FGColumnVector3& GetBodyForces(void) override;
 
   /// Gets the location of the gear in Body axes
   FGColumnVector3 GetBodyLocation(void) const {
@@ -339,7 +336,8 @@ private:
   double bDampRebound;
   double compressLength;
   double compressSpeed;
-  double rollingFCoeff;
+  double staticFCoeff, dynamicFCoeff, rollingFCoeff;
+  double staticFFactor;
   double Stiffness, Shape, Peak, Curvature; // Pacejka factors
   double BrakeFCoeff;
   double maxCompLen;

--- a/src/models/FGLGear.h
+++ b/src/models/FGLGear.h
@@ -337,7 +337,6 @@ private:
   double compressLength;
   double compressSpeed;
   double staticFCoeff, dynamicFCoeff, rollingFCoeff;
-  double staticFFactor = 1.0;
   double Stiffness, Shape, Peak, Curvature; // Pacejka factors
   double BrakeFCoeff;
   double maxCompLen;
@@ -351,6 +350,11 @@ private:
   double FCoeff;
   double WheelSlip;
   double GearPos;
+  double staticFFactor = 1.0;
+  double rollingFFactor = 1.0;
+  double maximumForce = DBL_MAX;
+  double bumpiness = 0.0;
+  bool isSolid = true;
   bool WOW;
   bool lastWOW;
   bool FirstContact;

--- a/src/models/FGLGear.h
+++ b/src/models/FGLGear.h
@@ -337,7 +337,7 @@ private:
   double compressLength;
   double compressSpeed;
   double staticFCoeff, dynamicFCoeff, rollingFCoeff;
-  double staticFFactor;
+  double staticFFactor = 1.0;
   double Stiffness, Shape, Peak, Curvature; // Pacejka factors
   double BrakeFCoeff;
   double maxCompLen;

--- a/src/models/FGSurface.h
+++ b/src/models/FGSurface.h
@@ -125,8 +125,6 @@ protected:
   double bumpiness;
   bool isSolid;
 
-  double staticFCoeff, dynamicFCoeff;
-
 private:
   int contactNumber;
   double pos[3];


### PR DESCRIPTION
As I exposed in https://github.com/JSBSim-Team/jsbsim/pull/883#issuecomment-1501728281, `FGLGear` does not need to inherit from `FGSurface`. This PR introduces a few modifications to remove this inheritance without impacting the features provided by `FGSurface`.

The PR shows that:
* `FGLGear` does not use any methods that it inherits from `FGSurface`. Nor any code is using these inherited methods from anywhere else in JSBSim code.
* ~~`isSolid`, `maximumForce` and `rollingFFactor` need not being members. In 2 cases, they do not even need being variable as they are used at a single location.~~
* ~~`bumpiness` is not used anywhere.~~
* ~~The only member that needs to be moved from `FGSurface` is `staticFFactor`. But it merely contains the value read from `FGGroundReactions`.~~
* The members `staticFCoeff` and `dynamicFCoeff` need not being in `FGSurface` as `FGLGear` is the only class that accesses them.

*EDIT: The arguments above that are stroke out happened to be irrelevant as has been shown in the discussion below. The other arguments, including those exposed in https://github.com/JSBSim-Team/jsbsim/pull/883#issuecomment-1501728281, are still applicable.*