### PR TITLE
Do not make direct calls to `FGAtmosphere`

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -451,7 +451,10 @@ void FGFDMExec::LoadInputs(unsigned int idx)
     Inertial->in.Position      = Propagate->GetLocation();
     break;
   case eAtmosphere:
-    Atmosphere->in.altitudeASL = Propagate->GetAltitudeASL();
+    Atmosphere->in.altitudeASL  = Propagate->GetAltitudeASL();
+    Atmosphere->in.vUVW         = Propagate->GetUVW();
+    Atmosphere->in.TotalWindNED = Winds->GetTotalWindNED();
+    Atmosphere->in.Tl2b         = Propagate->GetTl2b();
     break;
   case eWinds:
     Winds->in.AltitudeASL      = Propagate->GetAltitudeASL();
@@ -462,11 +465,8 @@ void FGFDMExec::LoadInputs(unsigned int idx)
     Winds->in.totalDeltaT      = dT * Winds->GetRate();
     break;
   case eAuxiliary:
-    Auxiliary->in.Pressure     = Atmosphere->GetPressure();
     Auxiliary->in.Density      = Atmosphere->GetDensity();
     Auxiliary->in.DensitySL    = Atmosphere->GetDensitySL();
-    Auxiliary->in.PressureSL   = Atmosphere->GetPressureSL();
-    Auxiliary->in.Temperature  = Atmosphere->GetTemperature();
     Auxiliary->in.SoundSpeed   = Atmosphere->GetSoundSpeed();
     Auxiliary->in.KinematicViscosity = Atmosphere->GetKinematicViscosity();
     Auxiliary->in.DistanceAGL  = Propagate->GetDistanceAGL();
@@ -503,11 +503,11 @@ void FGFDMExec::LoadInputs(unsigned int idx)
     Propulsion->in.DensityRatio     = Atmosphere->GetDensityRatio();
     Propulsion->in.Density          = Atmosphere->GetDensity();
     Propulsion->in.Soundspeed       = Atmosphere->GetSoundSpeed();
-    Propulsion->in.TotalPressure    = Auxiliary->GetTotalPressure();
-    Propulsion->in.Vc               = Auxiliary->GetVcalibratedKTS();
+    Propulsion->in.TotalPressure    = Atmosphere->GetTotalPressure();
+    Propulsion->in.TAT_c            = Atmosphere->GetTAT_C();
+    Propulsion->in.Vc               = Atmosphere->GetVcalibratedKTS();
     Propulsion->in.Vt               = Auxiliary->GetVt();
     Propulsion->in.qbar             = Auxiliary->Getqbar();
-    Propulsion->in.TAT_c            = Auxiliary->GetTAT_C();
     Propulsion->in.AeroUVW          = Auxiliary->GetAeroUVW();
     Propulsion->in.AeroPQR          = Auxiliary->GetAeroPQR();
     Propulsion->in.alpha            = Auxiliary->Getalpha();
@@ -535,7 +535,7 @@ void FGFDMExec::LoadInputs(unsigned int idx)
   case eGroundReactions:
     // There are no external inputs to this model.
     GroundReactions->in.Vground         = Auxiliary->GetVground();
-    GroundReactions->in.VcalibratedKts  = Auxiliary->GetVcalibratedKTS();
+    GroundReactions->in.VcalibratedKts  = Atmosphere->GetVcalibratedKTS();
     GroundReactions->in.Temperature     = Atmosphere->GetTemperature();
     GroundReactions->in.TakeoffThrottle = (FCS->GetThrottlePos().size() > 0) ? (FCS->GetThrottlePos(0) > 0.90) : false;
     GroundReactions->in.BrakePos        = FCS->GetBrakePos();

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -470,7 +470,6 @@ void FGFDMExec::LoadInputs(unsigned int idx)
     Auxiliary->in.SoundSpeed   = Atmosphere->GetSoundSpeed();
     Auxiliary->in.KinematicViscosity = Atmosphere->GetKinematicViscosity();
     Auxiliary->in.DistanceAGL  = Propagate->GetDistanceAGL();
-    Auxiliary->in.AltitudeASL  = Propagate->GetAltitudeASL();
     Auxiliary->in.Mass         = MassBalance->GetMass();
     Auxiliary->in.Tl2b         = Propagate->GetTl2b();
     Auxiliary->in.Tb2l         = Propagate->GetTb2l();

--- a/src/input_output/FGOutputFG.cpp
+++ b/src/input_output/FGOutputFG.cpp
@@ -44,6 +44,7 @@ INCLUDES
 #include "FGOutputFG.h"
 #include "FGXMLElement.h"
 #include "models/FGAuxiliary.h"
+#include "models/FGAtmosphere.h"
 #include "models/FGPropulsion.h"
 #include "models/FGFCS.h"
 #include "models/propulsion/FGPiston.h"
@@ -217,7 +218,7 @@ void FGOutputFG::SocketDataFill(void)
   net1->phidot = (float)(Auxiliary->GetEulerRates(ePhi));   // roll rate (radians/sec)
   net1->thetadot = (float)(Auxiliary->GetEulerRates(eTht)); // pitch rate (radians/sec)
   net1->psidot = (float)(Auxiliary->GetEulerRates(ePsi));   // yaw rate (radians/sec)
-  net1->vcas = (float)(Auxiliary->GetVcalibratedKTS());     // VCAS, knots
+  net1->vcas = (float)(Atmosphere->GetVcalibratedKTS());    // VCAS, knots
   net1->climb_rate = (float)(Propagate->Gethdot());         // altitude rate, ft/sec
   net1->v_north = (float)(Propagate->GetVel(eNorth));       // north vel in NED frame, fps
   net1->v_east = (float)(Propagate->GetVel(eEast));         // east vel in NED frame, fps

--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -57,6 +57,13 @@ FGAtmosphere::FGAtmosphere(FGFDMExec* fdmex)
 {
   Name = "FGAtmosphere";
 
+  in.altitudeASL = 0.0;
+  in.Tl2b = { 1.0, 0.0, 0.0,
+              0.0, 1.0, 0.0,
+              0.0, 0.0, 1.0};
+  in.vUVW.InitMatrix();
+  in.TotalWindNED.InitMatrix();
+
   bind();
   Debug(0);
 }

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -38,6 +38,7 @@ SENTRY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+#include "math/FGMatrix33.h"
 #include "models/FGModel.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -241,12 +242,41 @@ public:
   * */
   double MachFromVcalibrated(double vcas, double altitude) const;
 
+  /** Returns Calibrated airspeed in feet/second.*/
+  double GetVcalibratedFPS(void) const { return vcas; }
+
+  /** Returns Calibrated airspeed in knots.*/
+  double GetVcalibratedKTS(void) const { return vcas*fpstokts; }
+
+  /** Returns the total pressure in PSF.
+      Total pressure is freestream total pressure for subsonic only.
+      For supersonic it is the 1D total pressure behind a normal shock.
+    */
+  double GetTotalPressure(void) const { return TotalPressure; }
+
+  /** Returns the total temperature in Rankine.
+    The total temperature ("tat", isentropic flow) is calculated:
+    @code
+    tat = Temperature*(1 + 0.2*Mach*Mach)
+    @endcode
+    (where "Temperature" is the temperature calculated by the atmosphere model)
+  */
+  double GetTotalTemperature(void) const { return TotalTemperature; }
+
+  /** Return the total ambient temperature in degrees Celsius.
+      @see GetTotalTemperature
+  */
+  double GetTAT_C(void) const { return RankineToCelsius(TotalTemperature); }
+
   struct Inputs {
     double altitudeASL;
+    FGColumnVector3 vUVW;
+    FGMatrix33 Tl2b;
+    FGColumnVector3 TotalWindNED;
   } in;
 
-  static constexpr double StdDaySLtemperature = 518.67;
-  static constexpr double StdDaySLpressure = 2116.228;
+  static constexpr double StdDaySLtemperature = 518.67;  // deg Rankine
+  static constexpr double StdDaySLpressure = 2116.228;  // PSF
   const double StdDaySLsoundspeed;
 
 protected:
@@ -264,9 +294,13 @@ protected:
   double DensityAltitude = 0.0;
 
   static constexpr double SutherlandConstant = 198.72;  // deg Rankine
-  static constexpr double Beta = 2.269690E-08; // slug/(sec ft R^0.5)
+  static constexpr double Beta = 2.269690E-08;  // slug/(sec ft R^0.5)
   double Viscosity = 0.0;
   double KinematicViscosity = 0.0;
+
+  double vcas = 0.0;
+  double TotalPressure = 0.0;
+  double TotalTemperature = 1.8;
 
   /// Calculate the atmosphere for the given altitude.
   virtual void Calculate(double altitude);

--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -61,11 +61,8 @@ CLASS IMPLEMENTATION
 FGAuxiliary::FGAuxiliary(FGFDMExec* fdmex) : FGModel(fdmex)
 {
   Name = "FGAuxiliary";
-  pt = 2116.23; // ISA SL pressure
-  tatc = 15.0; // ISA SL temperature
-  tat = 518.67;
 
-  vcas = veas = 0.0;
+  veas = 0.0;
   qbar = qbarUW = qbarUV = 0.0;
   Mach = MachU = 0.0;
   alpha = beta = 0.0;
@@ -96,11 +93,7 @@ bool FGAuxiliary::InitModel(void)
 {
   if (!FGModel::InitModel()) return false;
 
-  pt = in.Pressure;
-  tat = in.Temperature;
-  tatc = RankineToCelsius(tat);
-
-  vcas = veas = 0.0;
+  veas = 0.0;
   qbar = qbarUW = qbarUV = 0.0;
   Mach = MachU = 0.0;
   alpha = beta = 0.0;
@@ -191,17 +184,7 @@ bool FGAuxiliary::Run(bool Holding)
   if (psigt < 0.0) psigt += 2*M_PI;
   gamma = atan2(-in.vVel(eDown), Vground);
 
-  tat = in.Temperature*(1 + 0.2*Mach*Mach); // Total Temperature, isentropic flow
-  tatc = RankineToCelsius(tat);
-
-  pt = FDMExec->GetAtmosphere()->PitotTotalPressure(Mach, in.Pressure);
-
-  if (abs(Mach) > 0.0) {
-    vcas = FDMExec->GetAtmosphere()->VcalibratedFromMach(Mach, in.AltitudeASL);
-    veas = sqrt(2 * qbar / in.DensitySL);
-  }
-  else
-    vcas = veas = 0.0;
+  veas = sqrt(2 * qbar / in.DensitySL);
 
   vPilotAccel.InitMatrix();
   vNcg = in.vBodyAccel/in.StandardGravity;
@@ -308,11 +291,6 @@ void FGAuxiliary::bind(void)
 {
   typedef double (FGAuxiliary::*PMF)(int) const;
   typedef double (FGAuxiliary::*PF)(void) const;
-  PropertyManager->Tie("propulsion/tat-r", this, &FGAuxiliary::GetTotalTemperature);
-  PropertyManager->Tie("propulsion/tat-c", this, &FGAuxiliary::GetTAT_C);
-  PropertyManager->Tie("propulsion/pt-lbs_sqft", this, &FGAuxiliary::GetTotalPressure);
-  PropertyManager->Tie("velocities/vc-fps", this, &FGAuxiliary::GetVcalibratedFPS);
-  PropertyManager->Tie("velocities/vc-kts", this, &FGAuxiliary::GetVcalibratedKTS);
   PropertyManager->Tie("velocities/ve-fps", this, &FGAuxiliary::GetVequivalentFPS);
   PropertyManager->Tie("velocities/ve-kts", this, &FGAuxiliary::GetVequivalentKTS);
   PropertyManager->Tie("velocities/vtrue-fps", this, &FGAuxiliary::GetVtrueFPS);

--- a/src/models/FGAuxiliary.h
+++ b/src/models/FGAuxiliary.h
@@ -121,10 +121,6 @@ public:
 // GET functions
 
   // Atmospheric parameters GET functions
-  /** Returns Calibrated airspeed in feet/second.*/
-  double GetVcalibratedFPS(void) const { return vcas; }
-  /** Returns Calibrated airspeed in knots.*/
-  double GetVcalibratedKTS(void) const { return vcas*fpstokts; }
   /** Returns equivalent airspeed in feet/second. */
   double GetVequivalentFPS(void) const { return veas; }
   /** Returns equivalent airspeed in knots. */
@@ -133,23 +129,6 @@ public:
   double GetVtrueFPS() const { return Vt; }
   /** Returns the true airspeed in knots. */
   double GetVtrueKTS() const { return Vt * fpstokts; }
-
-  /** Returns the total pressure.
-      Total pressure is freestream total pressure for
-      subsonic only. For supersonic it is the 1D total pressure
-      behind a normal shock. */
-  double GetTotalPressure(void) const { return pt; }
-
-  /** Returns the total temperature.
-    The total temperature ("tat", isentropic flow) is calculated:
-    @code
-    tat = in.Temperature*(1 + 0.2*Mach*Mach)
-    @endcode
-    (where "in.Temperature" is standard temperature calculated by the atmosphere
-    model) */
-
-  double GetTotalTemperature(void) const { return tat; }
-  double GetTAT_C(void) const { return tatc; }
 
   double GetPilotAccel(int idx)  const { return vPilotAccel(idx);  }
   double GetNpilot(int idx)      const { return vPilotAccelN(idx); }
@@ -252,11 +231,8 @@ public:
   void SetAeroPQR(const FGColumnVector3& tt) { vAeroPQR = tt; }
 
   struct Inputs {
-    double Pressure;
     double Density;
     double DensitySL;
-    double PressureSL;
-    double Temperature;
     double SoundSpeed;
     double KinematicViscosity;
     double DistanceAGL;
@@ -288,8 +264,7 @@ public:
   } in;
 
 private:
-  double vcas, veas;
-  double pt, tat, tatc; // Don't add a getter for pt!
+  double veas;
 
   FGMatrix33 mTw2b;
   FGMatrix33 mTb2w;

--- a/src/models/FGAuxiliary.h
+++ b/src/models/FGAuxiliary.h
@@ -236,7 +236,6 @@ public:
     double SoundSpeed;
     double KinematicViscosity;
     double DistanceAGL;
-    double AltitudeASL;
     double Wingspan;
     double Wingchord;
     double StandardGravity;


### PR DESCRIPTION
This PR is somewhat an opinionated one :smile:

Going back almost 12 years ago the [mediator programming pattern](https://en.wikipedia.org/wiki/Mediator_pattern) was introduced in JSBSim by @jonsberndt via the commit 3c05fee1b3a726a0b10c7584f0afa8f5c25be17c. In JSBSim the mediator object is the `FGFDMExec` class and the current architecture of JSBSim is that all communications between models (i.e. classes inheriting from `FGModel`) are made via `FGFDMExec` (more specifically by the method `FGFDMExec::LoadInputs`). Following the merge of the PR #881 this is no longer the case as `FGAuxiliary` makes direct calls to `FGAtmosphere`. The purpose of this PR is therefore to restore a "*pure*" mediator pattern.

In that purpose this PR moves the computation of the calibrated airspeed, total pressure and total temperature to `FGAtmosphere` where the routines required to perform these calculations are located. This change is absolutely not mandatory as JSBSim works perfectly well in its current state but the current state is a small breach in the overall architecture.

In order to compute calibrated airspeed and the total pressure and temperature `FGAtmosphere` need to get the aircraft aerodynamic velocity which includes getting access to the wind velocity. Currently `FGWinds` is evaluated **after** `FGAtmosphere` which means that `FGAtmosphere` uses a wind velocity that lags one time step behind. I have considered swapping the order in which `FGWinds` and `FGAtmosphere` were called but I have dropped this idea because I was finding it too intrusive[^1] while I don't see much problem in using the wind velocity from the previous time step. I don't expect the wind velocity changing much between 2 time steps (especially if the main loop runs at 120Hz).

The total temperature computation is also moved to `FGAtmosphere` as its formula actually depends on the specific heat ratio $\gamma$ (i.e. `FGAtmosphere::SHRatio`):
$$T_0=T\left(1+\frac{\gamma-1}{2}M^2\right)$$

This PR is a bit questionable in that computing a velocity in the class `FGAtmosphere` is not an obvious move. It is rather dictated by programming considerations (`vcas` uses methods from `FGAtmosphere`) rather than common sense. On the other hand, the calibrated airspeed is tightly linked to the atmospheric properties in which the aircraft flying, so... I'm submitting this PR and waiting for your comments/opinions.

[^1]: See commits 51f8b3eb3a14ecaef6d5671a1a7564a3a54c694e, 88b7def0a2f3eb1697a332350503d8a8513d4a31 and 9f775fecd8012b1fb8d1ccc5f0a52af4b7208b76 to convince yourself that changing the order in which models are evaluated is as much an art as a science.