### PR TITLE
Unreal: Added an array of actors that are ignored by the GroundCheck callback.

### DIFF
--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
@@ -206,6 +206,9 @@ double UJSBSimMovementComponent::GetAGLevel(const FVector& StartECEFLocation, FV
   CollisionParams.bTraceComplex = true;
   CollisionParams.AddIgnoredActor(Parent);
 
+  if (GroundCheckIgnoredActors.Num() > 0)
+    CollisionParams.AddIgnoredActors(GroundCheckIgnoredActors);
+
   FCollisionObjectQueryParams ObjectParams = FCollisionObjectQueryParams(ECC_WorldStatic);
   ObjectParams.AddObjectTypesToQuery(ECC_WorldDynamic);
   ObjectParams.AddObjectTypesToQuery(ECC_Pawn);

--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/JSBSimMovementComponent.h
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/JSBSimMovementComponent.h
@@ -197,7 +197,9 @@ public:
 	UPROPERTY(Transient, BlueprintReadOnly, VisibleAnywhere, Category = "State")
 	FAircraftState AircraftState;
 
-
+  UPROPERTY(Transient, BlueprintReadOnly, VisibleAnywhere, Category = "State")
+  TArray<AActor*> GroundCheckIgnoredActors;
+  
     // Functions
 
 	/* Returns the full Aircraft name as set in the JSBSim definition file */ 


### PR DESCRIPTION
Hello,
This PR adds the possibility to specifiy actors to be ignored by the groundcheck function. It's usefull if the aircraft contains a Pawn with triggers, for instance SphereCollision on hands to grab the stick or push buttons.