### PR TITLE
Correct VEAS to use standard day SL density

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -464,7 +464,6 @@ void FGFDMExec::LoadInputs(unsigned int idx)
   case eAuxiliary:
     Auxiliary->in.Pressure     = Atmosphere->GetPressure();
     Auxiliary->in.Density      = Atmosphere->GetDensity();
-    Auxiliary->in.DensitySL    = Atmosphere->GetDensitySL();
     Auxiliary->in.PressureSL   = Atmosphere->GetPressureSL();
     Auxiliary->in.Temperature  = Atmosphere->GetTemperature();
     Auxiliary->in.SoundSpeed   = Atmosphere->GetSoundSpeed();

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -293,6 +293,9 @@ protected:
 
   virtual void bind(void);
   void Debug(int from) override;
+
+public:
+  static constexpr double StdDaySLdensity = StdDaySLpressure / (Reng0 * StdDaySLtemperature);
 };
 
 } // namespace JSBSim

--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -198,7 +198,7 @@ bool FGAuxiliary::Run(bool Holding)
 
   if (abs(Mach) > 0.0) {
     vcas = VcalibratedFromMach(Mach, in.Pressure);
-    veas = sqrt(2 * qbar / in.DensitySL);
+    veas = sqrt(2 * qbar / FGAtmosphere::StdDaySLdensity);
   }
   else
     vcas = veas = 0.0;


### PR DESCRIPTION
Slightly messy layout in FGAtmosphere.h in terms of ideally wanting to add `StdDaySLdensity` to the existing group of public constants.

```c++
  static constexpr double StdDaySLtemperature = 518.67;
  static constexpr double StdDaySLpressure = 2116.228;
  const double StdDaySLsoundspeed;
  static constexpr double SHRatio = 1.4;
```

But require `Reng0` to be defined first, but it's currently lower down in a `protected` section.

So couple of options in terms, not sure if the one I've chosen is the best.