### PR TITLE
Unbind `FGAtmosphere` properties

### DIFF
--- a/src/input_output/FGPropertyManager.cpp
+++ b/src/input_output/FGPropertyManager.cpp
@@ -53,10 +53,25 @@ namespace JSBSim {
 
 void FGPropertyManager::Unbind(void)
 {
-  for(auto& prop: tied_properties)
-    prop->untie();
+  for(auto& property: tied_properties)
+    property.untie();
 
   tied_properties.clear();
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+void FGPropertyManager::Unbind(void* instance)
+{
+  auto it = tied_properties.begin();
+
+  while(it != tied_properties.end()) {
+    auto property = it++;
+    if (property->BindingInstance == instance) {
+      property->untie();
+      tied_properties.erase(property);
+    }
+  }
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -305,8 +320,8 @@ void FGPropertyManager::Untie(SGPropertyNode *property)
   assert(property->isTied());
 
   for (auto it = tied_properties.begin(); it != tied_properties.end(); ++it) {
-    if (*it == property) {
-      property->untie();
+    if (it->node.ptr() == property) {
+      it->untie();
       tied_properties.erase(it);
       if (FGJSBBase::debug_lvl & 0x20) cout << "Untied " << name << endl;
       return;

--- a/src/simgear/props/props.cxx
+++ b/src/simgear/props/props.cxx
@@ -2475,6 +2475,7 @@ SGPropertyNode_ptr
 SGPropertyNode::eraseChild(simgear::PropertyList::iterator child)
 {
   SGPropertyNode_ptr node = *child;
+  node->_parent = nullptr;
   node->setAttribute(REMOVED, true);
   node->clearValue();
   fireChildRemoved(node);

--- a/tests/unit_tests/FGAtmosphereTest.h
+++ b/tests/unit_tests/FGAtmosphereTest.h
@@ -186,6 +186,21 @@ public:
   void testRun()
   {
     FGFDMExec fdmex;
+    auto pm = fdmex.GetPropertyManager();
+    pm->Untie("atmosphere/T-R");
+    pm->Untie("atmosphere/rho-slugs_ft3");
+    pm->Untie("atmosphere/P-psf");
+    pm->Untie("atmosphere/a-fps");
+    pm->Untie("atmosphere/T-sl-R");
+    pm->Untie("atmosphere/rho-sl-slugs_ft3");
+    pm->Untie("atmosphere/a-sl-fps");
+    pm->Untie("atmosphere/theta");
+    pm->Untie("atmosphere/sigma");
+    pm->Untie("atmosphere/delta");
+    pm->Untie("atmosphere/a-ratio");
+    pm->Untie("atmosphere/density-altitude");
+    pm->Untie("atmosphere/pressure-altitude");
+
     auto atm = DummyAtmosphere(&fdmex, 0.1, 1.0);
     TS_ASSERT(atm.InitModel());
 
@@ -194,48 +209,77 @@ public:
     constexpr double rho0 = P0/(R*T0);
     const double a0 = sqrt(gama*R*T0);
 
+    auto T_node = pm->GetNode("atmosphere/T-R");
+    auto rho_node = pm->GetNode("atmosphere/rho-slugs_ft3");
+    auto P_node = pm->GetNode("atmosphere/P-psf");
+    auto a_node = pm->GetNode("atmosphere/a-fps");
+    auto T0_node = pm->GetNode("atmosphere/T-sl-R");
+    auto rho0_node = pm->GetNode("atmosphere/rho-sl-slugs_ft3");
+    auto a0_node = pm->GetNode("atmosphere/a-sl-fps");
+    auto theta_node = pm->GetNode("atmosphere/theta");
+    auto sigma_node = pm->GetNode("atmosphere/sigma");
+    auto delta_node = pm->GetNode("atmosphere/delta");
+    auto a_ratio_node = pm->GetNode("atmosphere/a-ratio");
+    auto density_altitude_node = pm->GetNode("atmosphere/density-altitude");
+    auto pressure_altitude_node = pm->GetNode("atmosphere/pressure-altitude");
+
     for(double h=-1000.0; h<10000; h+= 1000) {
       atm.in.altitudeASL = h;
       TS_ASSERT(atm.Run(false) == false);
 
       double T = T0 + 0.1*h;
       TS_ASSERT_EQUALS(atm.GetTemperatureSL(), T0);
+      TS_ASSERT_DELTA(T0_node->getDoubleValue(), T0, epsilon);
       TS_ASSERT_DELTA(atm.GetTemperature(), T, epsilon);
+      TS_ASSERT_DELTA(T_node->getDoubleValue(), T, epsilon);
       TS_ASSERT_EQUALS(atm.GetTemperature(0.0), T0);
       TS_ASSERT_DELTA(atm.GetTemperature(h), T, epsilon);
       TS_ASSERT_DELTA(atm.GetTemperatureRatio(), T/T0, epsilon);
       TS_ASSERT_EQUALS(atm.GetTemperatureRatio(0.0), 1.0);
       TS_ASSERT_DELTA(atm.GetTemperatureRatio(h), T/T0, epsilon);
+      TS_ASSERT_DELTA(theta_node->getDoubleValue(), T/T0, epsilon);
 
       double P = P0 + 1.0*h;
       TS_ASSERT_EQUALS(atm.GetPressureSL(), P0);
       TS_ASSERT_DELTA(atm.GetPressure(), P, epsilon);
+      TS_ASSERT_DELTA(P_node->getDoubleValue(), P, epsilon);
       TS_ASSERT_EQUALS(atm.GetPressure(0.0), P0);
       TS_ASSERT_DELTA(atm.GetPressure(h), P, epsilon);
       TS_ASSERT_DELTA(atm.GetPressureRatio(), P/P0, epsilon);
+      TS_ASSERT_DELTA(delta_node->getDoubleValue(), P/P0, epsilon);
 
       double rho = P/(R*T);
       TS_ASSERT_DELTA(atm.GetDensity(), rho, epsilon);
+      TS_ASSERT_DELTA(rho_node->getDoubleValue(), rho, epsilon);
       TS_ASSERT_DELTA(atm.GetDensity(0.0), rho0, epsilon);
       TS_ASSERT_DELTA(atm.GetDensity(h), rho, epsilon);
       TS_ASSERT_DELTA(atm.GetDensitySL(), rho0, epsilon);
+      TS_ASSERT_DELTA(rho0_node->getDoubleValue(), rho0, epsilon);
       TS_ASSERT_EQUALS(atm.GetDensityRatio(), rho/rho0);
+      TS_ASSERT_DELTA(sigma_node->getDoubleValue(), rho/rho0, epsilon);
 
       double a = sqrt(gama*R*T);
       TS_ASSERT_DELTA(atm.GetSoundSpeed(), a, epsilon);
+      TS_ASSERT_DELTA(a_node->getDoubleValue(), a, epsilon);
       TS_ASSERT_DELTA(atm.GetSoundSpeed(0.0), a0, epsilon);
       TS_ASSERT_DELTA(atm.GetSoundSpeed(h), a, epsilon);
       TS_ASSERT_DELTA(atm.GetSoundSpeedSL(), a0, epsilon);
+      TS_ASSERT_DELTA(a0_node->getDoubleValue(), a0, epsilon);
       TS_ASSERT_DELTA(atm.GetSoundSpeedRatio(), a/a0, epsilon);
+      TS_ASSERT_DELTA(a_ratio_node->getDoubleValue(), a/a0, epsilon);
 
       TS_ASSERT_EQUALS(atm.GetDensityAltitude(), h);
+      TS_ASSERT_EQUALS(density_altitude_node->getDoubleValue(), h);
       TS_ASSERT_EQUALS(atm.GetPressureAltitude(), h);
+      TS_ASSERT_EQUALS(pressure_altitude_node->getDoubleValue(), h);
 
       double mu = beta*T*sqrt(T)/(k+T);
       double nu = mu/rho;
       TS_ASSERT_DELTA(atm.GetAbsoluteViscosity(), mu, epsilon);
       TS_ASSERT_DELTA(atm.GetKinematicViscosity(), nu, epsilon);
     }
+
+    pm->Unbind();
   }
 
   void testTemperatureOverride()


### PR DESCRIPTION
As I mentioned previously in https://github.com/JSBSim-Team/jsbsim/pull/885#issuecomment-1513821802, I'm currently working on adding the [NRLMSIS2.0 atmospheric model](https://ccmc.gsfc.nasa.gov/models/NRLMSIS~v2.0/) to JSBSim which is kind of a revival of the existing `src/models/atmosphere/FGMSIS.cpp` code (which was based on the previous version 1.0 of NRLMSIS)[^1].

In order for this feature to work, we will need to modify the atmosphere model that is currently created by default in `FGFDMExec`:
https://github.com/JSBSim-Team/jsbsim/blob/39e70585021752fe9a68061b556d496e3587b22f/src/FGFDMExec.cpp#L229

Basically, the idea is to call at some point the following code:
```c++
if (some_XML_instructions_are_found) {
  // Delete the FGStandardAtmosphere instance and replace it by an FGMSIS instance
  Models[eAtmosphere] = std::make_shared<FGMSIS>(this);
  // ERROR messages : Failed to tie property XXX to object methods.
}
```
The trick is that if no special care is taken, the properties `atmosphere/T-R`, `atmosphere/P-Psf`, etc. will still be bound to the old instance of `FGStandardAtmosphere` even after the above code has been executed. With the current code, `FGMSIS` would fail to bind itself to the aforementioned properties as they would already be tied to `FGStandardAtmosphere` and JSBSim would complain with the infamous error message `Failed to tie property atmosphere/T-R to object methods`. Even worse, if one would try to access `atmosphere/T-R` and the likes, it would cause a SEGFAULT as the property would try to call the method `FGAtmosphere::GetTemperature()` on a deleted `FGStandardAtmopshere` instance.

To avoid this issue, we need to tell JSBSim to unbind `FGStandardAtmosphere` before an instance of `FGMSIS` is created. Currently there is no generic code in JSBSim that allows to unbind a single `FGModel` instance (you'd need to untie the properties one by one which is less than ideal from a maintenance standpoint).

To address this issue the current PR adds a new method `FGPropertyManager::Unbind(void* instance)` to unbind the properties of a given class instance. With this new method, the code above will become something like:
```c++
if (some_XML_instructions_are_found) {
  PropertyManager->Unbind(Models[eAtmosphere]);
  Models[eAtmosphere] = std::make_shared<FGMSIS>(this);
  // SUCCESS! No "Failed to tie..." error messages.
}
```

The new `Unbind` method also restores the read/write attributes of each properties as the newly bound instance might want to set them differently.

Finally, the unit test `FGAtmosphereTest` is amended by the PR to test the new feature and checks that the properties such `atmosphere/T-R` are tied to the correct instance (see the method `testRun()` in `FGAmosphereTest`).

[^1]: For the record the code in `FGMSIS.cpp` is dead code as there is currently no means to execute this code from JSBSim.