### PR TITLE
Remove dead code from `FGSurface`

### DIFF
--- a/src/models/FGGroundReactions.cpp
+++ b/src/models/FGGroundReactions.cpp
@@ -239,7 +239,6 @@ string FGGroundReactions::GetGroundReactionValues(string delimeter) const
 
 void FGGroundReactions::bind(void)
 {
-  eSurfaceType = ctGROUND;
   FGSurface::bind(PropertyManager.get());
 
   PropertyManager->Tie("gear/num-units", this, &FGGroundReactions::GetNumGearUnits);

--- a/src/models/FGSurface.cpp
+++ b/src/models/FGSurface.cpp
@@ -49,17 +49,9 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGSurface::FGSurface(FGFDMExec* fdmex, int number) :
-   contactNumber(number)
+FGSurface::FGSurface(FGFDMExec* fdmex)
 {
-  eSurfaceType = ctBOGEY;
   resetValues();
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-FGSurface::~FGSurface()
-{
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -80,23 +72,9 @@ void FGSurface::resetValues(void)
 
 void FGSurface::bind(FGPropertyManager* PropertyManager)
 {
-  string base_property_name;
+  string base_property_name = "ground";
   string property_name;
 
-  switch(eSurfaceType) {
-  case ctBOGEY:
-    base_property_name = _CreateIndexedPropertyName("gear/unit", contactNumber);
-    break;
-  case ctSTRUCTURE:
-    base_property_name = _CreateIndexedPropertyName("contact/unit", contactNumber);
-    break;
-  case ctGROUND:
-    base_property_name = "ground";
-    break;
-  default:
-    return;
-  }
- 
   property_name = base_property_name + "/solid";
   PropertyManager->Tie( property_name.c_str(), &isSolid);
   property_name = base_property_name + "/bumpiness";
@@ -131,45 +109,6 @@ double FGSurface::GetBumpHeight()
   h += sin(2*y)+sin(5*y)+sin(9*y*x)+sin(17*y);
 
   return h*(1/8.)*bumpiness*maxGroundBumpAmplitude;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-string FGSurface::_CreateIndexedPropertyName(const string& Property, int index)
-{
-  std::ostringstream buf;
-  buf << Property << '[' << index << ']';
-  return buf.str();
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-string FGSurface::GetSurfaceStrings(string delimeter) const
-{
-  std::ostringstream buf;
-
-  buf << "staticFFactor" << delimeter
-      << "rollingFFactor" << delimeter
-      << "maximumForce" << delimeter
-      << "bumpiness" << delimeter
-      << "isSolid";
-  
-  return buf.str();
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-string FGSurface::GetSurfaceValues(string delimeter) const
-{
-  std::ostringstream buf;
- 
-  buf << staticFFactor << delimeter
-      << rollingFFactor << delimeter
-      << maximumForce << delimeter
-      << bumpiness << delimeter
-      << (isSolid ? "1" : "0");
-
-  return buf.str();
 }
 
 } // namespace JSBSim

--- a/src/models/FGSurface.h
+++ b/src/models/FGSurface.h
@@ -62,14 +62,8 @@ CLASS DECLARATION
 class FGSurface
 {
 public:
-
-  enum ContactType {ctBOGEY, ctSTRUCTURE, ctGROUND};
-
   /// Constructor
-  FGSurface(FGFDMExec* fdmex, int number = -1);
-
-  /// Destructor
-  ~FGSurface();
+  FGSurface(FGFDMExec* fdmex);
 
   void bind(FGPropertyManager* pm);
 
@@ -115,21 +109,14 @@ public:
   /// Returns the height of the bump at the provided offset
   double  GetBumpHeight();
 
-  std::string GetSurfaceStrings(std::string delimeter) const;
-  std::string GetSurfaceValues(std::string delimeter) const;
-
 protected:
-  ContactType eSurfaceType;
   double staticFFactor, rollingFFactor;
   double maximumForce;
   double bumpiness;
   bool isSolid;
 
 private:
-  int contactNumber;
   double pos[3];
-
-  static std::string _CreateIndexedPropertyName(const std::string& Property, int index);
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
As the title implies, this PR removes the dead code that results from the refactoring made by PR #884.

Some other PR will be submitted to remove the class `FGSurface` as was mentioned in https://github.com/JSBSim-Team/jsbsim/pull/884#issuecomment-1509586652.