### PR TITLE
Do not store the result of `FGFDMExec::GetAtmosphere()`.

### DIFF
--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -64,7 +64,6 @@ FGInitialCondition::FGInitialCondition(FGFDMExec *FDMExec) : fdmex(FDMExec)
   InitializeIC();
 
   if(FDMExec) {
-    Atmosphere=fdmex->GetAtmosphere();
     Aircraft=fdmex->GetAircraft();
     Auxiliary=fdmex->GetAuxiliary();
   } else {
@@ -154,6 +153,7 @@ void FGInitialCondition::InitializeIC(void)
 
 void FGInitialCondition::SetVequivalentKtsIC(double ve)
 {
+  auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double rho = Atmosphere->GetDensity(altitudeASL);
   double rhoSL = Atmosphere->GetDensitySL();
@@ -165,6 +165,7 @@ void FGInitialCondition::SetVequivalentKtsIC(double ve)
 
 void FGInitialCondition::SetMachIC(double mach)
 {
+  auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
   SetVtrueFpsIC(mach*soundSpeed);
@@ -175,6 +176,7 @@ void FGInitialCondition::SetMachIC(double mach)
 
 void FGInitialCondition::SetVcalibratedKtsIC(double vcas)
 {
+  auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double mach = Auxiliary->MachFromVcalibrated(fabs(vcas)*ktstofps, pressure);
@@ -678,6 +680,7 @@ double FGInitialCondition::GetTerrainElevationFtIC(void) const
 
 void FGInitialCondition::SetAltitudeAGLFtIC(double agl)
 {
+  auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
@@ -750,6 +753,7 @@ void FGInitialCondition::SetAltitudeAGLFtIC(double agl)
 
 void FGInitialCondition::SetAltitudeASLFtIC(double alt)
 {
+  auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
@@ -960,6 +964,7 @@ double FGInitialCondition::GetBodyWindFpsIC(int idx) const
 
 double FGInitialCondition::GetVcalibratedKtsIC(void) const
 {
+  auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
@@ -972,6 +977,7 @@ double FGInitialCondition::GetVcalibratedKtsIC(void) const
 
 double FGInitialCondition::GetVequivalentKtsIC(void) const
 {
+  auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double rho = Atmosphere->GetDensity(altitudeASL);
   double rhoSL = Atmosphere->GetDensitySL();
@@ -982,6 +988,7 @@ double FGInitialCondition::GetVequivalentKtsIC(void) const
 
 double FGInitialCondition::GetMachIC(void) const
 {
+  auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
   return vt / soundSpeed;

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -153,7 +153,7 @@ void FGInitialCondition::InitializeIC(void)
 
 void FGInitialCondition::SetVequivalentKtsIC(double ve)
 {
-  auto Atmosphere = fdmex->GetAtmosphere();
+  const auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double rho = Atmosphere->GetDensity(altitudeASL);
   double rhoSL = Atmosphere->GetDensitySL();
@@ -165,7 +165,7 @@ void FGInitialCondition::SetVequivalentKtsIC(double ve)
 
 void FGInitialCondition::SetMachIC(double mach)
 {
-  auto Atmosphere = fdmex->GetAtmosphere();
+  const auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
   SetVtrueFpsIC(mach*soundSpeed);
@@ -176,7 +176,7 @@ void FGInitialCondition::SetMachIC(double mach)
 
 void FGInitialCondition::SetVcalibratedKtsIC(double vcas)
 {
-  auto Atmosphere = fdmex->GetAtmosphere();
+  const auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double mach = Auxiliary->MachFromVcalibrated(fabs(vcas)*ktstofps, pressure);
@@ -680,7 +680,7 @@ double FGInitialCondition::GetTerrainElevationFtIC(void) const
 
 void FGInitialCondition::SetAltitudeAGLFtIC(double agl)
 {
-  auto Atmosphere = fdmex->GetAtmosphere();
+  const auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
@@ -753,7 +753,7 @@ void FGInitialCondition::SetAltitudeAGLFtIC(double agl)
 
 void FGInitialCondition::SetAltitudeASLFtIC(double alt)
 {
-  auto Atmosphere = fdmex->GetAtmosphere();
+  const auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
@@ -964,7 +964,7 @@ double FGInitialCondition::GetBodyWindFpsIC(int idx) const
 
 double FGInitialCondition::GetVcalibratedKtsIC(void) const
 {
-  auto Atmosphere = fdmex->GetAtmosphere();
+  const auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
@@ -977,7 +977,7 @@ double FGInitialCondition::GetVcalibratedKtsIC(void) const
 
 double FGInitialCondition::GetVequivalentKtsIC(void) const
 {
-  auto Atmosphere = fdmex->GetAtmosphere();
+  const auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double rho = Atmosphere->GetDensity(altitudeASL);
   double rhoSL = Atmosphere->GetDensitySL();
@@ -988,7 +988,7 @@ double FGInitialCondition::GetVequivalentKtsIC(void) const
 
 double FGInitialCondition::GetMachIC(void) const
 {
-  auto Atmosphere = fdmex->GetAtmosphere();
+  const auto Atmosphere = fdmex->GetAtmosphere();
   double altitudeASL = GetAltitudeASLFtIC();
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
   return vt / soundSpeed;

--- a/src/initialization/FGInitialCondition.h
+++ b/src/initialization/FGInitialCondition.h
@@ -62,7 +62,6 @@ namespace JSBSim {
 class FGFDMExec;
 class FGMatrix33;
 class FGColumnVector3;
-class FGAtmosphere;
 class FGAircraft;
 class FGAuxiliary;
 class FGPropertyManager;
@@ -706,7 +705,6 @@ private:
   int trimRequested;
 
   FGFDMExec *fdmex;
-  std::shared_ptr<FGAtmosphere> Atmosphere;
   std::shared_ptr<FGAircraft> Aircraft;
   std::shared_ptr<FGAuxiliary> Auxiliary;
 

--- a/src/input_output/FGOutputSocket.cpp
+++ b/src/input_output/FGOutputSocket.cpp
@@ -333,6 +333,7 @@ void FGOutputSocket::Print(void)
     socket->Append(Aircraft->GetMoments(eN));
   }
   if (SubSystems & ssAtmosphere) {
+    auto Atmosphere = FDMExec->GetAtmosphere();
     socket->Append(Atmosphere->GetDensity());
     socket->Append(Atmosphere->GetPressureSL());
     socket->Append(Atmosphere->GetPressure());

--- a/src/input_output/FGOutputSocket.cpp
+++ b/src/input_output/FGOutputSocket.cpp
@@ -333,7 +333,7 @@ void FGOutputSocket::Print(void)
     socket->Append(Aircraft->GetMoments(eN));
   }
   if (SubSystems & ssAtmosphere) {
-    auto Atmosphere = FDMExec->GetAtmosphere();
+    const auto Atmosphere = FDMExec->GetAtmosphere();
     socket->Append(Atmosphere->GetDensity());
     socket->Append(Atmosphere->GetPressureSL());
     socket->Append(Atmosphere->GetPressure());

--- a/src/input_output/FGOutputTextFile.cpp
+++ b/src/input_output/FGOutputTextFile.cpp
@@ -319,6 +319,7 @@ void FGOutputTextFile::Print(void)
     outstream << Accelerations->GetMoments().Dump(delimeter);
   }
   if (SubSystems & ssAtmosphere) {
+    auto Atmosphere = FDMExec->GetAtmosphere();
     outstream << delimeter;
     outstream << Atmosphere->GetDensity() << delimeter;
     outstream << Atmosphere->GetAbsoluteViscosity() << delimeter;

--- a/src/input_output/FGOutputTextFile.cpp
+++ b/src/input_output/FGOutputTextFile.cpp
@@ -319,7 +319,7 @@ void FGOutputTextFile::Print(void)
     outstream << Accelerations->GetMoments().Dump(delimeter);
   }
   if (SubSystems & ssAtmosphere) {
-    auto Atmosphere = FDMExec->GetAtmosphere();
+    const auto Atmosphere = FDMExec->GetAtmosphere();
     outstream << delimeter;
     outstream << Atmosphere->GetDensity() << delimeter;
     outstream << Atmosphere->GetAbsoluteViscosity() << delimeter;

--- a/src/input_output/FGOutputType.cpp
+++ b/src/input_output/FGOutputType.cpp
@@ -62,7 +62,6 @@ FGOutputType::FGOutputType(FGFDMExec* fdmex) :
   Aerodynamics = FDMExec->GetAerodynamics();
   Auxiliary = FDMExec->GetAuxiliary();
   Aircraft = FDMExec->GetAircraft();
-  Atmosphere = FDMExec->GetAtmosphere();
   Winds = FDMExec->GetWinds();
   Propulsion = FDMExec->GetPropulsion();
   MassBalance = FDMExec->GetMassBalance();

--- a/src/input_output/FGOutputType.h
+++ b/src/input_output/FGOutputType.h
@@ -53,7 +53,6 @@ class Element;
 class FGAerodynamics;
 class FGAuxiliary;
 class FGAircraft;
-class FGAtmosphere;
 class FGWinds;
 class FGPropulsion;
 class FGMassBalance;
@@ -200,7 +199,6 @@ protected:
   std::shared_ptr<FGAerodynamics> Aerodynamics;
   std::shared_ptr<FGAuxiliary> Auxiliary;
   std::shared_ptr<FGAircraft> Aircraft;
-  std::shared_ptr<FGAtmosphere> Atmosphere;
   std::shared_ptr<FGWinds> Winds;
   std::shared_ptr<FGPropulsion> Propulsion;
   std::shared_ptr<FGMassBalance> MassBalance;


### PR DESCRIPTION
This PR is a followup of the PR #902.

As was exposed in #902, we might need to modify the atmosphere model when `FGFDMExec::LoadModel()` is executed and that would result in `Model[eAtmosphere]` being modified. As a result if a class stores the pointer returned by `FGFDMExec::GetAtmosphere()` before the atmosphere model could be modified then this pointer could be invalidated.

This sequence of events exists when the constructor of the class `FGInitialCondition` is called and stores a copy of `FGFDMExec::GetAtmosphere()` in its member `Atmosphere`:

https://github.com/JSBSim-Team/jsbsim/blob/db830c68c77d9b56e86bbe5811f40e22cb0d0acf/src/initialization/FGInitialCondition.cpp#L62-L67

And the constructor of `FGInitialCondition` is called from the constructor of `FGFDMExec` i.e. before `FGFDMExec::LoadModel()` is executed:

https://github.com/JSBSim-Team/jsbsim/blob/db830c68c77d9b56e86bbe5811f40e22cb0d0acf/src/FGFDMExec.cpp#L267

This PR addresses this issue by removing the storage of a copy of the result of `FGFDMExec::GetAtmosphere()`. After the PR will be merged, `FGInitialCondition` will call `FGFDMExec::GetAtmosphere()` each time it needs to get data from the atmosphere model. As `FGInitialCondition` is only used during initialization, the performance impact (if any) is negligible.

The classes `FGOutputType`, `FGOutputTextFile` and `FGOutputSocket` also store a copy of `FGFDMExec::GetAtmosphere()` but strictly speaking they are not concerned by this issue as they are created  by `FGOutput::Load()` after the atmosphere model would be modified:

https://github.com/JSBSim-Team/jsbsim/blob/db830c68c77d9b56e86bbe5811f40e22cb0d0acf/src/models/FGOutput.cpp#L202-L220

Indeed `FGOutput` is the last `FGModel` instance that parses the XML files:

https://github.com/JSBSim-Team/jsbsim/blob/db830c68c77d9b56e86bbe5811f40e22cb0d0acf/src/FGFDMExec.cpp#L940-L948

However this PR extends the requirement of not storing a copy of `FGFDMExec::GetAtmosphere()` to all classes because this fortunate call sequence might be (accidentally ?) broken in the future for the classes `FGOutputType`, `FGOutputTextFile` and `FGOutputSocket`. In addition the performance impact is low as well for output classes as outputs are generally not requested at every time step and furthermore the call to `FGFDMExec::GetAtmosphere()` will be inlined by compilers.