### PR TITLE
Use standard day SL density for VEAS in `FGInitialCondition`.

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -464,7 +464,6 @@ void FGFDMExec::LoadInputs(unsigned int idx)
   case eAuxiliary:
     Auxiliary->in.Pressure     = Atmosphere->GetPressure();
     Auxiliary->in.Density      = Atmosphere->GetDensity();
-    Auxiliary->in.PressureSL   = Atmosphere->GetPressureSL();
     Auxiliary->in.Temperature  = Atmosphere->GetTemperature();
     Auxiliary->in.SoundSpeed   = Atmosphere->GetSoundSpeed();
     Auxiliary->in.KinematicViscosity = Atmosphere->GetKinematicViscosity();

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -156,8 +156,7 @@ void FGInitialCondition::SetVequivalentKtsIC(double ve)
 {
   double altitudeASL = GetAltitudeASLFtIC();
   double rho = Atmosphere->GetDensity(altitudeASL);
-  double rhoSL = Atmosphere->GetDensitySL();
-  SetVtrueFpsIC(ve*ktstofps*sqrt(rhoSL/rho));
+  SetVtrueFpsIC(ve*ktstofps*sqrt(FGAtmosphere::StdDaySLdensity/rho));
   lastSpeedSet = setve;
 }
 
@@ -682,11 +681,10 @@ void FGInitialCondition::SetAltitudeAGLFtIC(double agl)
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
   double rho = Atmosphere->GetDensity(altitudeASL);
-  double rhoSL = Atmosphere->GetDensitySL();
 
   double mach0 = vt / soundSpeed;
   double vc0 = Auxiliary->VcalibratedFromMach(mach0, pressure);
-  double ve0 = vt * sqrt(rho/rhoSL);
+  double ve0 = vt * sqrt(rho/FGAtmosphere::StdDaySLdensity);
 
   switch(lastLatitudeSet) {
   case setgeod:
@@ -734,7 +732,7 @@ void FGInitialCondition::SetAltitudeAGLFtIC(double agl)
       SetVtrueFpsIC(mach0 * soundSpeed);
       break;
     case setve:
-      SetVtrueFpsIC(ve0 * sqrt(rhoSL/rho));
+      SetVtrueFpsIC(ve0 * sqrt(FGAtmosphere::StdDaySLdensity/rho));
       break;
     default: // Make the compiler stop complaining about missing enums
       break;
@@ -754,11 +752,10 @@ void FGInitialCondition::SetAltitudeASLFtIC(double alt)
   double pressure = Atmosphere->GetPressure(altitudeASL);
   double soundSpeed = Atmosphere->GetSoundSpeed(altitudeASL);
   double rho = Atmosphere->GetDensity(altitudeASL);
-  double rhoSL = Atmosphere->GetDensitySL();
 
   double mach0 = vt / soundSpeed;
   double vc0 = Auxiliary->VcalibratedFromMach(mach0, pressure);
-  double ve0 = vt * sqrt(rho/rhoSL);
+  double ve0 = vt * sqrt(rho/FGAtmosphere::StdDaySLdensity);
 
   switch(lastLatitudeSet) {
   case setgeod:
@@ -838,7 +835,7 @@ void FGInitialCondition::SetAltitudeASLFtIC(double alt)
       SetVtrueFpsIC(mach0 * soundSpeed);
       break;
     case setve:
-      SetVtrueFpsIC(ve0 * sqrt(rhoSL/rho));
+      SetVtrueFpsIC(ve0 * sqrt(FGAtmosphere::StdDaySLdensity/rho));
       break;
     default: // Make the compiler stop complaining about missing enums
       break;
@@ -974,8 +971,7 @@ double FGInitialCondition::GetVequivalentKtsIC(void) const
 {
   double altitudeASL = GetAltitudeASLFtIC();
   double rho = Atmosphere->GetDensity(altitudeASL);
-  double rhoSL = Atmosphere->GetDensitySL();
-  return fpstokts * vt * sqrt(rho/rhoSL);
+  return fpstokts * vt * sqrt(rho/FGAtmosphere::StdDaySLdensity);
 }
 
 //******************************************************************************

--- a/src/models/FGAuxiliary.h
+++ b/src/models/FGAuxiliary.h
@@ -289,8 +289,6 @@ public:
   struct Inputs {
     double Pressure;
     double Density;
-    double DensitySL;
-    double PressureSL;
     double Temperature;
     double StdDaySLsoundspeed;
     double SoundSpeed;


### PR DESCRIPTION
Following the bug fix that has been released by @seanmcleod in PR #900, this PR applies the same fix to the `FGInitialCondition` class (it is not using the standard day SL density either for the computation of the [equivalent airspeed](https://en.wikipedia.org/wiki/Equivalent_airspeed)).

I took this opportunity to check that `FGAtmosphere::GetDensitySL()` was not called elsewhere and remove the member `FGAtmosphere::in.DensitySL` that is no longer needed. In the process I also removed the member `FGAtmosphere::in.PressureSL` which is not used anywhere.