### PR TITLE
Changed UE5 plugin to default as Release build and fixed Debug build

### DIFF
--- a/JSBSimForUnreal.sln
+++ b/JSBSimForUnreal.sln
@@ -7,14 +7,14 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JSBSimForUnreal", "JSBSimFo
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
+		1_Release|x64 = 1_Release|x64
+		2_Debug|x64 = 2_Debug|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AF971B4F-3D53-4655-8A03-97E8054DC58B}.Debug|x64.ActiveCfg = Debug|x64
-		{AF971B4F-3D53-4655-8A03-97E8054DC58B}.Debug|x64.Build.0 = Debug|x64
-		{AF971B4F-3D53-4655-8A03-97E8054DC58B}.Release|x64.ActiveCfg = Release|x64
-		{AF971B4F-3D53-4655-8A03-97E8054DC58B}.Release|x64.Build.0 = Release|x64
+		{AF971B4F-3D53-4655-8A03-97E8054DC58B}.1_Release|x64.ActiveCfg = Release|x64
+		{AF971B4F-3D53-4655-8A03-97E8054DC58B}.1_Release|x64.Build.0 = Release|x64
+		{AF971B4F-3D53-4655-8A03-97E8054DC58B}.2_Debug|x64.ActiveCfg = Debug|x64
+		{AF971B4F-3D53-4655-8A03-97E8054DC58B}.2_Debug|x64.Build.0 = Debug|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/JSBSimForUnreal.vcxproj
+++ b/JSBSimForUnreal.vcxproj
@@ -56,7 +56,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)src;$(ProjectDir)src\simgear\xml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>JSBSIM_EXPORT;JSBSIM_VERSION="1.2.0.dev1";WIN32;NOMINMAX;XML_STATIC;_NDEBUG;_CONSOLE;HAVE_EXPAT_CONFIG_H;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>JSBSIM_EXPORT;JSBSIM_VERSION="1.2.0.dev1";WIN32;NOMINMAX;XML_STATIC;NDEBUG;_CONSOLE;HAVE_EXPAT_CONFIG_H;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/JSBSimForUnreal.vcxproj
+++ b/JSBSimForUnreal.vcxproj
@@ -56,10 +56,10 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)src;$(ProjectDir)src\simgear\xml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>JSBSIM_EXPORT;JSBSIM_VERSION="1.2.0.dev1";WIN32;NOMINMAX;XML_STATIC;_DEBUG;_CONSOLE;HAVE_EXPAT_CONFIG_H;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>JSBSIM_EXPORT;JSBSIM_VERSION="1.2.0.dev1";WIN32;NOMINMAX;XML_STATIC;_NDEBUG;_CONSOLE;HAVE_EXPAT_CONFIG_H;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Precise</FloatingPointModel>
       <FloatingPointExceptions>true</FloatingPointExceptions>
@@ -70,7 +70,8 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DisableSpecificWarnings>4996;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <CompileAsManaged>false</CompileAsManaged>
+      <CompileAsManaged>
+      </CompileAsManaged>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>

--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/ThirdParty/JSBSim.Build.cs
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/ThirdParty/JSBSim.Build.cs
@@ -16,13 +16,13 @@ public class JSBSim : ModuleRules
 		{
 			string LibFolderName = "Lib";
 
-			// When working in debug mode, try to use the Debug version of JSBSim
-			if (Target.Configuration == UnrealTargetConfiguration.Debug)
-			{
+            // When working in debug mode, try to use the Debug version of JSBSim
+            if (Target.Configuration == UnrealTargetConfiguration.DebugGame)
+            {
 				// Source\ThirdParty\JSBSim\LibDebug
 				string DebugLibsPath = Path.Combine(ModuleDirectory, JSBSimLocalFolder, LibFolderName + "Debug");
-				if (Directory.Exists(DebugLibsPath))
-				{
+                if (Directory.Exists(DebugLibsPath))
+                {
 					System.Console.WriteLine(string.Format("Found Debug libraries for JSBSim in {0}", DebugLibsPath));
 					LibFolderName += "Debug";
 				}


### PR DESCRIPTION
New users experience trouble building UE5 plugin due to mismatching default build settings between Visual Studio and UE5. Which causes an error until the user selects the correct matching build options. Examples of user issues: https://github.com/JSBSim-Team/jsbsim/issues/808 https://github.com/JSBSim-Team/jsbsim/issues/740 https://github.com/JSBSim-Team/jsbsim/discussions/664

Visual Studio defaults to the build option that is alphabetically first. so a simple fix is to rename the build options as:  1_Release and 2_Debug. This way new users will always by default build JSBSimforUnreal as Release. And errors from UE5 users should be reduced.

Another issue is the UE5 plugin's Debug build is broken for unknown reasons. A simple change by using the non-debug dll but with all debug options still enabled, can allow successful debugging of UE5 & JSBSim library. Original discussion here: https://github.com/JSBSim-Team/jsbsim/discussions/761