### PR TITLE
Add a `LoadPlanet` method to `FGFDMExec`

### DIFF
--- a/python/JSBSim.py
+++ b/python/JSBSim.py
@@ -53,6 +53,8 @@ parser.add_argument("--suspend", default=False, action="store_true",
                     help="specifies to suspend the simulation after initialization")
 parser.add_argument("--initfile", metavar="<filename>",
                     help="specifies an initialization file")
+parser.add_argument("--planetfile", metavar="<filename>",
+                    help="specifies a planet definition file")
 parser.add_argument("--catalog", default=False, action="store_true",
                     help="specifies that all properties for this aircraft model should be printed")
 parser.add_argument("--property", action="append", metavar="<name=value>",
@@ -122,6 +124,9 @@ if args.simulation_rate:
         fdm.set_dt(1.0/args.simulation_rate)
 
 args.simulation_rate = fdm.get_delta_t()
+
+if args.planetfile:
+    fdm.load_planet(args.planetfile, False)
 
 if args.property:
     pm = fdm.get_property_manager()

--- a/python/jsbsim.pxd
+++ b/python/jsbsim.pxd
@@ -200,6 +200,8 @@ cdef extern from "FGFDMExec.h" namespace "JSBSim":
                        bool add_model_to_path) except +convertJSBSimToPyExc
         bool LoadScript(const c_SGPath& script, double delta_t,
                         const c_SGPath& initfile) except +convertJSBSimToPyExc
+        bool LoadPlanet(const c_SGPath& planet_path,
+                        bool useAircraftPath) except +convertJSBSimToPyExc
         bool SetEnginePath(const c_SGPath& path)
         bool SetAircraftPath(const c_SGPath& path)
         bool SetSystemsPath(const c_SGPath& path)

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -760,6 +760,17 @@ cdef class FGFDMExec(FGJSBBase):
         return self.thisptr.LoadScript(c_SGPath(script.encode(), NULL), delta_t,
                                        c_SGPath(initfile.encode(),NULL))
 
+    def load_planet(self, planet_path: str, useAircraftPath: bool) -> bool:
+        """@Dox(JSBSim::FGFDMExec::LoadPlanet)"""
+        planet_file = _append_xml(planet_path)
+        if useAircraftPath and not os.path.isabs(planet_file):
+            planet_file = os.path.join(self.get_full_aircraft_path(), planet_file)
+        if not os.path.exists(planet_file):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
+                                    planet_file)
+        return self.thisptr.LoadPlanet(c_SGPath(planet_file.encode(), NULL),
+                                       useAircraftPath)
+
     def set_engine_path(self, path: str) -> bool:
         """@Dox(JSBSim::FGFDMExec::SetEnginePath) """
         return self.thisptr.SetEnginePath(c_SGPath(path.encode(), NULL))

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -739,6 +739,60 @@ bool FGFDMExec::LoadScript(const SGPath& script, double deltaT,
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+bool FGFDMExec::LoadPlanet(const SGPath& PlanetPath, bool useAircraftPath)
+{
+  SGPath PlanetFileName;
+
+  if(useAircraftPath && PlanetPath.isRelative()) {
+    PlanetFileName = AircraftPath/PlanetPath.utf8Str();
+  } else {
+    PlanetFileName = PlanetPath;
+  }
+
+  FGXMLFileRead XMLFileRead;
+  Element* document = XMLFileRead.LoadXMLDocument(PlanetFileName);
+
+  // Make sure that the document is valid
+  if (!document) {
+    stringstream s;
+    s << "File: " << PlanetFileName << " could not be read.";
+    cerr << s.str() << endl;
+    throw BaseException(s.str());
+  }
+
+  if (document->GetName() != "planet") {
+    stringstream s;
+    s << "File: " << PlanetFileName << " is not a reset file.";
+    cerr << s.str() << endl;
+    throw BaseException(s.str());
+  }
+
+  bool result = LoadPlanet(document);
+
+  if (!result)
+    cerr << endl << "Planet element has problems in file " << PlanetFileName << endl;
+
+  return result;
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+bool FGFDMExec::LoadPlanet(Element* element)
+{
+  bool result = Models[eInertial]->Load(element);
+
+  if (result) {
+    // Reload the planet constants and re-initialize the models.
+    LoadPlanetConstants();
+    IC->InitializeIC();
+    InitializeModels();
+  }
+
+  return result;
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 bool FGFDMExec::LoadModel(const SGPath& AircraftPath, const SGPath& EnginePath,
                           const SGPath& SystemsPath, const string& model,
                           bool addModelToPath)
@@ -800,15 +854,11 @@ bool FGFDMExec::LoadModel(const string& model, bool addModelToPath)
     // Process the planet element. This element is OPTIONAL.
     element = document->FindElement("planet");
     if (element) {
-      result = Models[eInertial]->Load(element);
+      result = LoadPlanet(element);
       if (!result) {
         cerr << endl << "Planet element has problems in file " << aircraftCfgFileName << endl;
         return result;
       }
-      // Reload the planet constants and re-initialize the models.
-      LoadPlanetConstants();
-      IC->InitializeIC();
-      InitializeModels();
     }
 
     // Process the metrics element. This element is REQUIRED.

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -251,6 +251,14 @@ public:
       @return true if successful */
   bool RunIC(void);
 
+  /** Loads the planet.
+      Loads the definition of the planet on which the vehicle will evolve such as
+      its radius, gravity or its atmosphere characteristics.
+      @param PlanetPath The name of a planet definition file
+      @param useAircraftPath true if path is given relative to the aircraft path.
+      @return true if successful */
+  bool LoadPlanet(const SGPath& PlanetPath, bool useAircraftPath = true);
+
   /** Loads an aircraft model.
       @param AircraftPath path to the aircraft/ directory. For instance:
       "aircraft". Under aircraft, then, would be directories for various
@@ -687,6 +695,7 @@ private:
   int  SRand(void) const {return RandomSeed;}
   void LoadInputs(unsigned int idx);
   void LoadPlanetConstants(void);
+  bool LoadPlanet(Element* el);
   void LoadModelConstants(void);
   bool Allocate(void);
   bool DeAllocate(void);

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -83,6 +83,7 @@ SGPath RootDir;
 SGPath ScriptName;
 string AircraftName;
 SGPath ResetName;
+SGPath PlanetName;
 vector <string> LogOutputName;
 vector <SGPath> LogDirectiveName;
 vector <string> CommandLineProperties;
@@ -314,6 +315,7 @@ int real_main(int argc, char* argv[])
   ScriptName = "";
   AircraftName = "";
   ResetName = "";
+  PlanetName = "";
   LogOutputName.clear();
   LogDirectiveName.clear();
   bool result = false, success;
@@ -371,6 +373,16 @@ int real_main(int argc, char* argv[])
       if (FDMExec->GetPropertyManager()->GetNode(CommandLineProperties[i])) {
         FDMExec->SetPropertyValue(CommandLineProperties[i], CommandLinePropertyValues[i]);
       }
+    }
+  }
+
+  if (!PlanetName.isNull()) {
+    result = FDMExec->LoadPlanet(PlanetName, false);
+
+    if (!result) {
+      cerr << "Planet file " << PlanetName << " was not successfully loaded" << endl;
+      delete FDMExec;
+      exit(-1);
     }
   }
 
@@ -669,7 +681,13 @@ bool options(int count, char **arg)
         gripe;
         exit(1);
       }
-
+    } else if (keyword == "--planet") {
+      if (n != string::npos) {
+        PlanetName = SGPath::fromLocal8Bit(value.c_str());
+      } else {
+        gripe;
+        exit(1);
+      }
     } else if (keyword == "--property") {
       if (n != string::npos) {
          string propName = value.substr(0,value.find("="));
@@ -777,6 +795,7 @@ void PrintHelp(void)
     cout << "    --nohighlight  specifies that console output should be pure text only (no color)" << endl;
     cout << "    --suspend  specifies to suspend the simulation after initialization" << endl;
     cout << "    --initfile=<filename>  specifies an initilization file" << endl;
+    cout << "    --planetfile=<filename>  specifies a planet definition file" << endl;
     cout << "    --catalog specifies that all properties for this aircraft model should be printed" << endl;
     cout << "              (catalog=aircraftname is an optional format)" << endl;
     cout << "    --property=<name=value> e.g. --property=simulation/integrator/rate/rotational=1" << endl;

--- a/tests/TestPlanet.py
+++ b/tests/TestPlanet.py
@@ -43,6 +43,24 @@ class TestPlanet(JSBSimTestCase):
 
         self.assertAlmostEqual(self.fdm['metrics/terrain-radius']*0.3048/1736000, 1.0)
 
+    def test_load_planet(self):
+        tripod = FlightModel(self, 'tripod')
+        moon_file = self.sandbox.path_to_jsbsim_file('tests/moon.xml')
+        self.fdm = tripod.start()
+        self.fdm.load_planet(moon_file, False)
+        self.fdm['ic/h-agl-ft'] = 0.2
+        self.fdm['ic/long-gc-deg'] = 0.0
+        self.fdm['ic/lat-geod-deg'] = 0.0
+        self.fdm.run_ic()
+
+        self.assertAlmostEqual(self.fdm['metrics/terrain-radius']*0.3048/1738100, 1.0)
+        self.assertAlmostEqual(self.fdm['accelerations/gravity-ft_sec2']*0.3048, 1.62, delta=3e-3)
+
+        self.fdm['ic/lat-geod-deg'] = 90.0
+        self.fdm.run_ic()
+
+        self.assertAlmostEqual(self.fdm['metrics/terrain-radius']*0.3048/1736000, 1.0)
+
     def test_planet_geographic_error1(self):
         # Check that a negative equatorial radius raises an exception
         tripod = FlightModel(self, 'tripod')


### PR DESCRIPTION
Following an idea from @seanmcleod (see https://github.com/JSBSim-Team/jsbsim/pull/908#issuecomment-1546697685), this PR introduces a new method `FGFDMExec::LoadPlanet()` which can be used to load a planet definition such as `tests/moon.xml`:

https://github.com/JSBSim-Team/jsbsim/blob/8c13fd699ae3bc68e10e4ca8eaf52534aea28523/tests/moon.xml#L1-L7

As Sean explained, this feature allows to manage independently the aircraft model and the planet definition file on which the simulation should take place.

The programs `JSBSim.exe` and `JSBSim.py` have been updated accordingly. A script such as `ball_chute.xml` can therefore be run on the Moon using the following command line:
```bash
> JSBSim --script=scripts/ball_chute.xml --planet=tests/moon.xml
```
The ball needs 107.8 sec to fall from an height of 10000 ft on Earth and 329.6 sec to fall from the same height on the Moon. One might notice that the ratio of these 2 duration is not equal to $\sqrt{6}$ but the script deploys a parachute at an height of 5000 ft and we currently cannot force the Moon atmosphere to be the vacuum :wink:  