### PR TITLE
Update the `FGMSIS` class

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -37,9 +37,34 @@ jobs:
               xmllint --noout --schema JSBSimSystem.xsd $filename
           done
 
+  MSIS-validation:
+    name: MSIS code validation
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout JSBSim
+        uses: actions/checkout@v3
+      - name: Configure the MSIS test program
+        run: |
+          mkdir build && cd build
+          cmake ../src/models/atmosphere/MSIS
+      - name: Build the JSBSim test program
+        working-directory: build
+        run: make -j2
+      - name: Run the NRLMSIS-00 C package
+        working-directory: src/models/atmosphere/MSIS
+        run: |
+          if [[ $(head -261 DOCUMENTATION | tail -104 | diff -urN <(../../../../build/nrlmsise-test) - | wc -c) -ne 0 ]]; then
+            echo "Failed."
+            exit 1
+          fi
+
   Linux:
     name: C/C++ build (Linux)
-    needs: XML-validation
+    needs: [XML-validation, MSIS-validation]
     strategy:
       fail-fast: false
       matrix:
@@ -404,7 +429,7 @@ jobs:
 
   MacOSX:
     name: C/C++ build (MacOSX)
-    needs: XML-validation
+    needs: [XML-validation, MSIS-validation]
     runs-on: macos-latest
     strategy:
       fail-fast: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ if (CXXTEST_FOUND)
   list(APPEND LCOV_REMOVE_PATTERNS "'*/GeographicLib/*'")
   list(APPEND LCOV_REMOVE_PATTERNS "'*/simgear/*'")
   list(APPEND LCOV_REMOVE_PATTERNS "'*/unit_tests/*'")
+  list(APPEND LCOV_REMOVE_PATTERNS "'*/models/atmosphere/MSIS/*'")
   coverage_evaluate()
 endif(CXXTEST_FOUND)
 

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -208,6 +208,8 @@ public:
 
   struct Inputs {
     double altitudeASL;
+    double GeodLatitudeDeg;
+    double LongitudeDeg;
   } in;
 
   static constexpr double StdDaySLtemperature = 518.67;

--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -72,8 +72,6 @@ FGAuxiliary::FGAuxiliary(FGFDMExec* fdmex) : FGModel(fdmex)
   adot = bdot = 0.0;
   gamma = Vt = Vground = 0.0;
   psigt = 0.0;
-  day_of_year = 1;
-  seconds_in_day = 0.0;
   hoverbmac = hoverbcg = 0.0;
   Re = 0.0;
   Nx = Ny = Nz = 0.0;
@@ -107,8 +105,6 @@ bool FGAuxiliary::InitModel(void)
   adot = bdot = 0.0;
   gamma = Vt = Vground = 0.0;
   psigt = 0.0;
-  day_of_year = 1;
-  seconds_in_day = 0.0;
   hoverbmac = hoverbcg = 0.0;
   Re = 0.0;
   Nz = Ny = 0.0;

--- a/src/models/FGAuxiliary.h
+++ b/src/models/FGAuxiliary.h
@@ -272,14 +272,6 @@ public:
     else return BadUnits();
   }
 
-// Time routines, SET and GET functions, used by FGMSIS atmosphere
-
-  void SetDayOfYear    (int doy)    { day_of_year = doy;    }
-  void SetSecondsInDay (double sid) { seconds_in_day = sid; }
-
-  int    GetDayOfYear    (void) const { return day_of_year;    }
-  double GetSecondsInDay (void) const { return seconds_in_day; }
-
   double GetLongitudeRelativePosition (void) const;
   double GetLatitudeRelativePosition  (void) const;
   double GetDistanceRelativePosition  (void) const;
@@ -345,8 +337,6 @@ private:
   double adot,bdot;
   double psigt, gamma;
   double Nx, Ny, Nz;
-  double seconds_in_day;  // seconds since current GMT day began
-  int    day_of_year;     // GMT day, 1 .. 366
 
   double hoverbcg, hoverbmac;
 

--- a/src/models/atmosphere/CMakeLists.txt
+++ b/src/models/atmosphere/CMakeLists.txt
@@ -1,13 +1,15 @@
 set(SOURCES FGMSIS.cpp
-            FGMSISData.cpp
             FGMars.cpp
             FGStandardAtmosphere.cpp
-            FGWinds.cpp)
+            FGWinds.cpp
+            MSIS/nrlmsise-00.c
+            MSIS/nrlmsise-00_data.c)
 
 set(HEADERS FGMSIS.h
             FGMars.h
             FGStandardAtmosphere.h
-            FGWinds.h)
+            FGWinds.h
+            MSIS/nrlmsise-00.h)
 
 add_library(Atmosphere OBJECT ${HEADERS} ${SOURCES})
 set_target_properties(Atmosphere PROPERTIES TARGET_DIRECTORY

--- a/src/models/atmosphere/FGMSIS.cpp
+++ b/src/models/atmosphere/FGMSIS.cpp
@@ -34,6 +34,7 @@ HISTORY
 --------------------------------------------------------------------------------
 12/14/03   DPC   Created
 01/11/04   DPC   Derived from FGAtmosphere
+03/18/23   BC    Refactored
 
  --------------------------------------------------------------------
  ---------  N R L M S I S E - 0 0    M O D E L    2 0 0 1  ----------
@@ -57,1531 +58,151 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+#include "FGFDMExec.h"
 #include "FGMSIS.h"
-#include "models/FGAuxiliary.h"
-#include <cmath>          /* maths functions */
-#include <iostream>        // for cout, endl
 
 using namespace std;
 
 namespace JSBSim {
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-EXTERNAL GLOBAL DATA
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
-
-  /* POWER7 */
-  extern double pt[150];
-  extern double pd[9][150];
-  extern double ps[150];
-  extern double pdl[2][25];
-  extern double ptl[4][100];
-  extern double pma[10][100];
-  extern double sam[100];
-
-  /* LOWER7 */
-  extern double ptm[10];
-  extern double pdm[8][10];
-  extern double pavgm[10];
-
-/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 
-MSIS::MSIS(FGFDMExec* fdmex) : FGAtmosphere(fdmex)
+FGMSIS::FGMSIS(FGFDMExec* fdmex) : FGStandardAtmosphere(fdmex)
 {
   Name = "MSIS";
 
-  for (int i=0; i<9; i++) output.d[i] = 0.0;
-  for (int i=0; i<2; i++) output.t[i] = 0.0;
-
-  dm04 = dm16 = dm28 = dm32 = dm40 = dm01 = dm14 = dfa = 0.0;
-
-  for (int i=0; i<5; i++) meso_tn1[i] = 0.0;
-  for (int i=0; i<4; i++) meso_tn2[i] = 0.0;
-  for (int i=0; i<5; i++) meso_tn3[i] = 0.0;
-  for (int i=0; i<2; i++) meso_tgn1[i] = 0.0;
-  for (int i=0; i<2; i++) meso_tgn2[i] = 0.0;
-  for (int i=0; i<2; i++) meso_tgn3[i] = 0.0;
+  for(unsigned int i=0; i<24; ++i)
+    flags.switches[i] = 1;
+  input.year = 0;  // Ignored by NRLMSIS
+  input.f107A = 150.;
+  input.f107 = 150.;
+  input.ap = 4.;
+  input.ap_a = nullptr;
 
   Debug(0);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-MSIS::~MSIS()
+FGMSIS::~FGMSIS()
 {
   Debug(1);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-bool MSIS::InitModel(void)
+bool FGMSIS::InitModel(void)
 {
-  unsigned int i;
+  FGStandardAtmosphere::InitModel();
 
-  flags.switches[0] = 0;
-  flags.sw[0] = 0;
-  flags.swc[0] = 0;
-  for (i=1;i<24;i++) {
-    flags.switches[i] = 1;
-    flags.sw[i] = 1;
-    flags.swc[i] = 1;
-  }
-
-  for (i=0;i<7;i++) aph.a[i] = 100.0;
-
-  // set some common magnetic flux values
-  input.f107A = 150.0;
-  input.f107 = 150.0;
-  input.ap = 4.0;
-
-//  UseInternal();
-
-//  SLtemperature = intTemperature = 518.0;
-//  SLpressure    = intPressure = 2116.7;
-//  SLdensity     = intDensity = 0.002378;
-//  SLsoundspeed  = sqrt(2403.0832 * SLtemperature);
+  Calculate(0.0);
 
   return true;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-bool MSIS::Run(bool Holding)
+bool FGMSIS::Load(Element* el)
 {
-  if (FGModel::Run(Holding)) return true;
-  if (Holding) return false;
+  if (!Upload(el, true)) return false;
 
-  double h = FDMExec->GetPropagate()->GetAltitudeASL();
+  if (el->FindElement("day"))
+    day_of_year = el->FindElementValueAsNumber("day");
+  if (el->FindElement("utc"))
+    seconds_in_day = el->FindElementValueAsNumber("utc");
 
-  //do temp, pressure, and density first
-  //if (!useExternal) {
-    // get sea-level values
-    Calculate(FDMExec->GetAuxiliary()->GetDayOfYear(),
-              FDMExec->GetAuxiliary()->GetSecondsInDay(),
-              0.0,
-              FDMExec->GetPropagate()->GetLocation().GetLatitudeDeg(),
-              FDMExec->GetPropagate()->GetLocation().GetLongitudeDeg());
-    SLtemperature = output.t[1] * 1.8;
-    SLdensity     = output.d[5] * 1.940321;
-    SLpressure    = 1716.488 * SLdensity * SLtemperature;
-    SLsoundspeed  = sqrt(2403.0832 * SLtemperature);
+  Debug(3);
 
-    // get at-altitude values
-    Calculate(FDMExec->GetAuxiliary()->GetDayOfYear(),
-              FDMExec->GetAuxiliary()->GetSecondsInDay(),
-              h,
-              FDMExec->GetPropagate()->GetLocation().GetLatitudeDeg(),
-              FDMExec->GetPropagate()->GetLocation().GetLongitudeDeg());
-    //intTemperature = output.t[1] * 1.8;
-    //intDensity     = output.d[5] * 1.940321;
-    //intPressure    = 1716.488 * intDensity * intTemperature;
-    //cout << "T=" << intTemperature << " D=" << intDensity << " P=";
-    //cout << intPressure << " a=" << soundspeed << endl;
-  //}
-
-  Debug(2);
-
-  return false;
+  return true;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void MSIS::Calculate(int day, double sec, double alt, double lat, double lon)
+void FGMSIS::Calculate(double altitude)
 {
-  input.year = 2000;
-  input.doy = day;
-  input.sec = sec;
-  input.alt = alt / 3281;  //feet to kilometers
+  double SLRair = 0.0;
+
+  Compute(0.0, SLpressure, SLtemperature, SLdensity, SLRair);
+  Compute(altitude, Pressure, Temperature, Density, Reng);
+
+  SLsoundspeed  = sqrt(SHRatio*SLRair*SLtemperature);
+  Soundspeed  = sqrt(SHRatio*Reng*Temperature);
+  PressureAltitude = CalculatePressureAltitude(Pressure, altitude);
+  DensityAltitude = CalculateDensityAltitude(Density, altitude);
+
+  Viscosity = Beta * pow(Temperature, 1.5) / (SutherlandConstant + Temperature);
+  KinematicViscosity = Viscosity / Density;
+  // SaturatedVaporPressure = CalculateVaporPressure(Temperature);
+  // ValidateVaporMassFraction(altitude);
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+void FGMSIS::Compute(double altitude, double& pressure, double& temperature,
+                    double& density, double &Rair) const
+{
+  constexpr double fttokm = fttom / 1000.;
+  constexpr double kgm3_to_slugft3 = kgtoslug / m3toft3;
+  constexpr double gtoslug = kgtoslug / 1000.;
+  // Molecular weight (g/mol)
+  // N2 O2 O He H Ar N OA
+  const double species_mmol[8] {28.0134, 31.9988, 31.9988/2.0, 4.0, 1.0, 39.948,
+                                28.0134/2.0, 31.9988/2.0};
+
+  double dn[10] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  double h = altitude*fttokm;
+  double lat = in.GeodLatitudeDeg;
+  double lon = in.LongitudeDeg;
+
+  // Compute epoch
+  double utc_seconds = seconds_in_day + FDMExec->GetSimTime();
+  unsigned int days = utc_seconds / 86400.;
+  utc_seconds -= days * 86400.;
+  double today = day_of_year + days;
+  unsigned int year = today / 365.;
+  today -= year * 365.;
+
+  struct nrlmsise_output output;
+
+  input.doy = today;
+  input.sec = utc_seconds;
+  input.alt = h;
   input.g_lat = lat;
   input.g_long = lon;
+  input.lst = utc_seconds/3600 + lon/15;  // Local Solar Time (hours)
+  assert(flags.switches[9] != -1);        // Make sure that input.ap is used.
 
-  input.lst = (sec/3600) + (lon/15);
-  if (input.lst > 24.0) input.lst -= 24.0;
-  if (input.lst < 0.0) input.lst = 24 - input.lst;
+  gtd7(&input, &flags, &output);
 
-  gtd7d(&input, &flags, &output);
+  temperature = KelvinToRankine(output.t[1]);
+  density = output.d[5] * kgm3_to_slugft3;
+  dn[1] = output.d[2];  // N2
+  dn[2] = output.d[3];  // O2
+  dn[3] = output.d[1];  // O
+  dn[4] = output.d[0];  // He
+  dn[5] = output.d[6];  // H
+  dn[6] = output.d[4];  // Ar
+  dn[7] = output.d[7];  // N
+  // SUBROUTINE GTD7 does NOT include anomalous oxygen so we drop it from
+  // the molar mass computation as well for consistency.
+  dn[8] = 0.0;          // OA
+
+  // Compute specific gas constant for air
+  double mmol = 0.0;
+  double qty_mol = 0.0;
+
+  for (unsigned int i=1; i<9; ++i) {
+    mmol += dn[i]*species_mmol[i-1];
+    qty_mol += dn[i];
+  }
+  double mair = mmol * gtoslug / qty_mol;
+  Rair = Rstar / mair;
+
+  pressure = density * Rair * temperature;
 }
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-void MSIS::UseExternal(void){
-  // do nothing, external control not allowed
-}
-
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-void MSIS::tselec(struct nrlmsise_flags *flags)
-{
-  int i;
-  for (i=0;i<24;i++) {
-    if (i!=9) {
-      if (flags->switches[i]==1)
-        flags->sw[i]=1;
-      else
-        flags->sw[i]=0;
-      if (flags->switches[i]>0)
-        flags->swc[i]=1;
-      else
-        flags->swc[i]=0;
-    } else {
-      flags->sw[i]=flags->switches[i];
-      flags->swc[i]=flags->switches[i];
-    }
-  }
-}
-
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void MSIS::glatf(double lat, double *gv, double *reff)
-{
-  double dgtr = 1.74533E-2;
-  double c2;
-  c2 = cos(2.0*dgtr*lat);
-  *gv = 980.616 * (1.0 - 0.0026373 * c2);
-  *reff = 2.0 * (*gv) / (3.085462E-6 + 2.27E-9 * c2) * 1.0E-5;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double MSIS::ccor(double alt, double r, double h1, double zh)
-{
-/*        CHEMISTRY/DISSOCIATION CORRECTION FOR MSIS MODELS
- *         ALT - altitude
- *         R - target ratio
- *         H1 - transition scale length
- *         ZH - altitude of 1/2 R
- */
-  double e;
-  double ex;
-  e = (alt - zh) / h1;
-  if (e>70)
-    return exp(0.0);
-  if (e<-70)
-    return exp(r);
-  ex = exp(e);
-  e = r / (1.0 + ex);
-  return exp(e);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double MSIS::ccor2(double alt, double r, double h1, double zh, double h2)
-{
-/*        CHEMISTRY/DISSOCIATION CORRECTION FOR MSIS MODELS
- *         ALT - altitude
- *         R - target ratio
- *         H1 - transition scale length
- *         ZH - altitude of 1/2 R
- *         H2 - transition scale length #2 ?
- */
-  double e1, e2;
-  double ex1, ex2;
-  double ccor2v;
-  e1 = (alt - zh) / h1;
-  e2 = (alt - zh) / h2;
-  if ((e1 > 70) || (e2 > 70))
-    return exp(0.0);
-  if ((e1 < -70) && (e2 < -70))
-    return exp(r);
-  ex1 = exp(e1);
-  ex2 = exp(e2);
-  ccor2v = r / (1.0 + 0.5 * (ex1 + ex2));
-  return exp(ccor2v);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double MSIS::scalh(double alt, double xm, double temp)
-{
-  double g;
-  double rgas=831.4;
-  g = gsurf / (pow((1.0 + alt/re),2.0));
-  g = rgas * temp / (g * xm);
-  return g;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double MSIS::dnet (double dd, double dm, double zhm, double xmm, double xm)
-{
-/*       TURBOPAUSE CORRECTION FOR MSIS MODELS
- *        Root mean density
- *         DD - diffusive density
- *         DM - full mixed density
- *         ZHM - transition scale length
- *         XMM - full mixed molecular weight
- *         XM  - species molecular weight
- *         DNET - combined density
- */
-  double a;
-  double ylog;
-  a  = zhm / (xmm-xm);
-  if (!((dm>0) && (dd>0))) {
-    cerr << "dnet log error " << dm << ' ' << dd << ' ' << xm << ' ' << endl;
-    if ((dd==0) && (dm==0))
-      dd=1;
-    if (dm==0)
-      return dd;
-    if (dd==0)
-      return dm;
-  }
-  ylog = a * log(dm/dd);
-  if (ylog<-10)
-    return dd;
-  if (ylog>10)
-    return dm;
-  a = dd*pow((1.0 + exp(ylog)),(1.0/a));
-  return a;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void MSIS::splini (double *xa, double *ya, double *y2a, int n, double x, double *y)
-{
-/*      INTEGRATE CUBIC SPLINE FUNCTION FROM XA(1) TO X
- *       XA,YA: ARRAYS OF TABULATED FUNCTION IN ASCENDING ORDER BY X
- *       Y2A: ARRAY OF SECOND DERIVATIVES
- *       N: SIZE OF ARRAYS XA,YA,Y2A
- *       X: ABSCISSA ENDPOINT FOR INTEGRATION
- *       Y: OUTPUT VALUE
- */
-  double yi=0;
-  int klo=0;
-  int khi=1;
-  double xx=0.0, h=0.0, a=0.0, b=0.0, a2=0.0, b2=0.0;
-  while ((x>xa[klo]) && (khi<n)) {
-    xx=x;
-    if (khi<(n-1)) {
-      if (x<xa[khi])
-        xx=x;
-      else
-        xx=xa[khi];
-    }
-    h = xa[khi] - xa[klo];
-    a = (xa[khi] - xx)/h;
-    b = (xx - xa[klo])/h;
-    a2 = a*a;
-    b2 = b*b;
-    yi += ((1.0 - a2) * ya[klo] / 2.0 + b2 * ya[khi] / 2.0 + ((-(1.0+a2*a2)/4.0 + a2/2.0) * y2a[klo] + (b2*b2/4.0 - b2/2.0) * y2a[khi]) * h * h / 6.0) * h;
-    klo++;
-    khi++;
-  }
-  *y = yi;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void MSIS::splint (double *xa, double *ya, double *y2a, int n, double x, double *y)
-{
-/*      CALCULATE CUBIC SPLINE INTERP VALUE
- *       ADAPTED FROM NUMERICAL RECIPES BY PRESS ET AL.
- *       XA,YA: ARRAYS OF TABULATED FUNCTION IN ASCENDING ORDER BY X
- *       Y2A: ARRAY OF SECOND DERIVATIVES
- *       N: SIZE OF ARRAYS XA,YA,Y2A
- *       X: ABSCISSA FOR INTERPOLATION
- *       Y: OUTPUT VALUE
- */
-  int klo=0;
-  int khi=n-1;
-  int k;
-  double h;
-  double a, b, yi;
-  while ((khi-klo)>1) {
-    k=(khi+klo)/2;
-    if (xa[k]>x)
-      khi=k;
-    else
-      klo=k;
-  }
-  h = xa[khi] - xa[klo];
-  if (h==0.0)
-    cerr << "bad XA input to splint" << endl;
-  a = (xa[khi] - x)/h;
-  b = (x - xa[klo])/h;
-  yi = a * ya[klo] + b * ya[khi] + ((a*a*a - a) * y2a[klo] + (b*b*b - b) * y2a[khi]) * h * h/6.0;
-  *y = yi;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void MSIS::spline (double *x, double *y, int n, double yp1, double ypn, double *y2)
-{
-/*       CALCULATE 2ND DERIVATIVES OF CUBIC SPLINE INTERP FUNCTION
- *       ADAPTED FROM NUMERICAL RECIPES BY PRESS ET AL
- *       X,Y: ARRAYS OF TABULATED FUNCTION IN ASCENDING ORDER BY X
- *       N: SIZE OF ARRAYS X,Y
- *       YP1,YPN: SPECIFIED DERIVATIVES AT X[0] AND X[N-1]; VALUES
- *                >= 1E30 SIGNAL SIGNAL SECOND DERIVATIVE ZERO
- *       Y2: OUTPUT ARRAY OF SECOND DERIVATIVES
- */
-  double *u;
-  double sig, p, qn, un;
-  int i, k;
-  u=new double[n];
-  if (u==NULL) {
-    cerr << "Out Of Memory in spline - ERROR" << endl;
-    return;
-  }
-  if (yp1>0.99E30) {
-    y2[0]=0;
-    u[0]=0;
-  } else {
-    y2[0]=-0.5;
-    u[0]=(3.0/(x[1]-x[0]))*((y[1]-y[0])/(x[1]-x[0])-yp1);
-  }
-  for (i=1;i<(n-1);i++) {
-    sig = (x[i]-x[i-1])/(x[i+1] - x[i-1]);
-    p = sig * y2[i-1] + 2.0;
-    y2[i] = (sig - 1.0) / p;
-    u[i] = (6.0 * ((y[i+1] - y[i])/(x[i+1] - x[i]) -(y[i] - y[i-1]) / (x[i] - x[i-1]))/(x[i+1] - x[i-1]) - sig * u[i-1])/p;
-  }
-  if (ypn>0.99E30) {
-    qn = 0;
-    un = 0;
-  } else {
-    qn = 0.5;
-    un = (3.0 / (x[n-1] - x[n-2])) * (ypn - (y[n-1] - y[n-2])/(x[n-1] - x[n-2]));
-  }
-  y2[n-1] = (un - qn * u[n-2]) / (qn * y2[n-2] + 1.0);
-  for (k=n-2;k>=0;k--)
-    y2[k] = y2[k] * y2[k+1] + u[k];
-
-  delete[] u;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double MSIS::zeta(double zz, double zl)
-{
-  return ((zz-zl)*(re+zl)/(re+zz));
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double MSIS::densm(double alt, double d0, double xm, double *tz, int mn3,
-                     double *zn3, double *tn3, double *tgn3, int mn2, double *zn2,
-                     double *tn2, double *tgn2)
-{
-/*      Calculate Temperature and Density Profiles for lower atmos.  */
-  double xs[10] = {0,0,0,0,0,0,0,0,0,0};
-  double ys[10] = {0,0,0,0,0,0,0,0,0,0};
-  double y2out[10] = {0,0,0,0,0,0,0,0,0,0};
-  double rgas = 831.4;
-  double z=0, z1=0, z2=0, t1=0, t2=0, zg=0, zgdif=0;
-  double yd1=0, yd2=0;
-  double x=0, y=0, yi=0;
-  double expl=0, gamm=0, glb=0;
-  double densm_tmp=0;
-  int mn=0;
-  int k=0;
-  densm_tmp=d0;
-  if (alt>zn2[0]) {
-    if (xm==0.0)
-      return *tz;
-    else
-      return d0;
-  }
-
-  /* STRATOSPHERE/MESOSPHERE TEMPERATURE */
-  if (alt>zn2[mn2-1])
-    z=alt;
-  else
-    z=zn2[mn2-1];
-  mn=mn2;
-  z1=zn2[0];
-  z2=zn2[mn-1];
-  t1=tn2[0];
-  t2=tn2[mn-1];
-  zg = zeta(z, z1);
-  zgdif = zeta(z2, z1);
-
-  /* set up spline nodes */
-  for (k=0;k<mn;k++) {
-    xs[k]=zeta(zn2[k],z1)/zgdif;
-    ys[k]=1.0 / tn2[k];
-  }
-  yd1=-tgn2[0] / (t1*t1) * zgdif;
-  yd2=-tgn2[1] / (t2*t2) * zgdif * (pow(((re+z2)/(re+z1)),2.0));
-
-  /* calculate spline coefficients */
-  spline (xs, ys, mn, yd1, yd2, y2out);
-  x = zg/zgdif;
-  splint (xs, ys, y2out, mn, x, &y);
-
-  /* temperature at altitude */
-  *tz = 1.0 / y;
-  if (xm!=0.0) {
-    /* calaculate stratosphere / mesospehere density */
-    glb = gsurf / (pow((1.0 + z1/re),2.0));
-    gamm = xm * glb * zgdif / rgas;
-
-    /* Integrate temperature profile */
-    splini(xs, ys, y2out, mn, x, &yi);
-    expl=gamm*yi;
-    if (expl>50.0)
-      expl=50.0;
-
-    /* Density at altitude */
-    densm_tmp = densm_tmp * (t1 / *tz) * exp(-expl);
-  }
-
-  if (alt>zn3[0]) {
-    if (xm==0.0)
-      return *tz;
-    else
-      return densm_tmp;
-  }
-
-  /* troposhere / stratosphere temperature */
-  z = alt;
-  mn = mn3;
-  z1=zn3[0];
-  z2=zn3[mn-1];
-  t1=tn3[0];
-  t2=tn3[mn-1];
-  zg=zeta(z,z1);
-  zgdif=zeta(z2,z1);
-
-  /* set up spline nodes */
-  for (k=0;k<mn;k++) {
-    xs[k] = zeta(zn3[k],z1) / zgdif;
-    ys[k] = 1.0 / tn3[k];
-  }
-  yd1=-tgn3[0] / (t1*t1) * zgdif;
-  yd2=-tgn3[1] / (t2*t2) * zgdif * (pow(((re+z2)/(re+z1)),2.0));
-
-  /* calculate spline coefficients */
-  spline (xs, ys, mn, yd1, yd2, y2out);
-  x = zg/zgdif;
-  splint (xs, ys, y2out, mn, x, &y);
-
-  /* temperature at altitude */
-  *tz = 1.0 / y;
-  if (xm!=0.0) {
-    /* calaculate tropospheric / stratosphere density */
-    glb = gsurf / (pow((1.0 + z1/re),2.0));
-    gamm = xm * glb * zgdif / rgas;
-
-    /* Integrate temperature profile */
-    splini(xs, ys, y2out, mn, x, &yi);
-    expl=gamm*yi;
-    if (expl>50.0)
-      expl=50.0;
-
-    /* Density at altitude */
-    densm_tmp = densm_tmp * (t1 / *tz) * exp(-expl);
-  }
-  if (xm==0.0)
-    return *tz;
-  else
-    return densm_tmp;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double MSIS::densu(double alt, double dlb, double tinf, double tlb, double xm,
-                     double alpha, double *tz, double zlb, double s2, int mn1,
-                     double *zn1, double *tn1, double *tgn1)
-{
-/*      Calculate Temperature and Density Profiles for MSIS models
- *      New lower thermo polynomial
- */
-  double yd2=0.0, yd1=0.0, x=0.0, y=0.0;
-  double rgas=831.4;
-  double densu_temp=1.0;
-  double za=0.0, z=0.0, zg2=0.0, tt=0.0, ta=0.0;
-  double dta=0.0, z1=0.0, z2=0.0, t1=0.0, t2=0.0, zg=0.0, zgdif=0.0;
-  int mn=0;
-  int k=0;
-  double glb=0.0;
-  double expl=0.0;
-  double yi=0.0;
-  double densa=0.0;
-  double gamma=0.0, gamm=0.0;
-  double xs[5]={0.0,0.0,0.0,0.0,0.0}, ys[5]={0.0,0.0,0.0,0.0,0.0}, y2out[5]={0.0,0.0,0.0,0.0,0.0};
-  /* joining altitudes of Bates and spline */
-  za=zn1[0];
-  if (alt>za)
-    z=alt;
-  else
-    z=za;
-
-  /* geopotential altitude difference from ZLB */
-  zg2 = zeta(z, zlb);
-
-  /* Bates temperature */
-  tt = tinf - (tinf - tlb) * exp(-s2*zg2);
-  ta = tt;
-  *tz = tt;
-  densu_temp = *tz;
-
-  if (alt<za) {
-    /* calculate temperature below ZA
-     * temperature gradient at ZA from Bates profile */
-    dta = (tinf - ta) * s2 * pow(((re+zlb)/(re+za)),2.0);
-    tgn1[0]=dta;
-    tn1[0]=ta;
-    if (alt>zn1[mn1-1])
-      z=alt;
-    else
-      z=zn1[mn1-1];
-    mn=mn1;
-    z1=zn1[0];
-    z2=zn1[mn-1];
-    t1=tn1[0];
-    t2=tn1[mn-1];
-    /* geopotental difference from z1 */
-    zg = zeta (z, z1);
-    zgdif = zeta(z2, z1);
-    /* set up spline nodes */
-    for (k=0;k<mn;k++) {
-      xs[k] = zeta(zn1[k], z1) / zgdif;
-      ys[k] = 1.0 / tn1[k];
-    }
-    /* end node derivatives */
-    yd1 = -tgn1[0] / (t1*t1) * zgdif;
-    yd2 = -tgn1[1] / (t2*t2) * zgdif * pow(((re+z2)/(re+z1)),2.0);
-    /* calculate spline coefficients */
-    spline (xs, ys, mn, yd1, yd2, y2out);
-    x = zg / zgdif;
-    splint (xs, ys, y2out, mn, x, &y);
-    /* temperature at altitude */
-    *tz = 1.0 / y;
-    densu_temp = *tz;
-  }
-  if (xm==0)
-    return densu_temp;
-
-  /* calculate density above za */
-  glb = gsurf / pow((1.0 + zlb/re),2.0);
-  gamma = xm * glb / (s2 * rgas * tinf);
-  expl = exp(-s2 * gamma * zg2);
-  if (expl>50.0)
-      expl=50.0;
-  if (tt<=0)
-    expl=50.0;
-
-  /* density at altitude */
-  densa = dlb * pow((tlb/tt),((1.0+alpha+gamma))) * expl;
-  densu_temp=densa;
-  if (alt>=za)
-    return densu_temp;
-
-  /* calculate density below za */
-  glb = gsurf / pow((1.0 + z1/re),2.0);
-  gamm = xm * glb * zgdif / rgas;
-
-  /* integrate spline temperatures */
-  splini (xs, ys, y2out, mn, x, &yi);
-  expl = gamm * yi;
-  if (expl>50.0)
-    expl=50.0;
-  if (*tz<=0)
-    expl=50.0;
-
-  /* density at altitude */
-  densu_temp = densu_temp * pow ((t1 / *tz),(1.0 + alpha)) * exp(-expl);
-  return densu_temp;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-/*    3hr Magnetic activity functions */
-/*    Eq. A24d */
-double MSIS::g0(double a, double *p)
-{
-  return (a - 4.0 + (p[25] - 1.0) * (a - 4.0 + (exp(-sqrt(p[24]*p[24]) *
-                (a - 4.0)) - 1.0) / sqrt(p[24]*p[24])));
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-/*    Eq. A24c */
-double MSIS::sumex(double ex)
-{
-  return (1.0 + (1.0 - pow(ex,19.0)) / (1.0 - ex) * pow(ex,0.5));
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-/*    Eq. A24a */
-double MSIS::sg0(double ex, double *p, double *ap)
-{
-  return (g0(ap[1],p) + (g0(ap[2],p)*ex + g0(ap[3],p)*ex*ex +
-                g0(ap[4],p)*pow(ex,3.0)  + (g0(ap[5],p)*pow(ex,4.0) +
-                g0(ap[6],p)*pow(ex,12.0))*(1.0-pow(ex,8.0))/(1.0-ex)))/sumex(ex);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double MSIS::globe7(double *p, struct nrlmsise_input *input,
-                      struct nrlmsise_flags *flags)
-{
-/*       CALCULATE G(L) FUNCTION
- *       Upper Thermosphere Parameters */
-  double t[15];
-  int i,j;
-  double apd;
-  double tloc;
-  double c, s, c2, c4, s2;
-  double sr = 7.2722E-5;
-  double dgtr = 1.74533E-2;
-  double dr = 1.72142E-2;
-  double hr = 0.2618;
-  double cd32, cd18, cd14, cd39;
-  double df;
-  double f1, f2;
-  double tinf;
-  struct ap_array *ap;
-
-  tloc=input->lst;
-  for (j=0;j<14;j++)
-    t[j]=0;
-
-  /* calculate legendre polynomials */
-  c = sin(input->g_lat * dgtr);
-  s = cos(input->g_lat * dgtr);
-  c2 = c*c;
-  c4 = c2*c2;
-  s2 = s*s;
-
-  plg[0][1] = c;
-  plg[0][2] = 0.5*(3.0*c2 -1.0);
-  plg[0][3] = 0.5*(5.0*c*c2-3.0*c);
-  plg[0][4] = (35.0*c4 - 30.0*c2 + 3.0)/8.0;
-  plg[0][5] = (63.0*c2*c2*c - 70.0*c2*c + 15.0*c)/8.0;
-  plg[0][6] = (11.0*c*plg[0][5] - 5.0*plg[0][4])/6.0;
-/*      plg[0][7] = (13.0*c*plg[0][6] - 6.0*plg[0][5])/7.0; */
-  plg[1][1] = s;
-  plg[1][2] = 3.0*c*s;
-  plg[1][3] = 1.5*(5.0*c2-1.0)*s;
-  plg[1][4] = 2.5*(7.0*c2*c-3.0*c)*s;
-  plg[1][5] = 1.875*(21.0*c4 - 14.0*c2 +1.0)*s;
-  plg[1][6] = (11.0*c*plg[1][5]-6.0*plg[1][4])/5.0;
-/*      plg[1][7] = (13.0*c*plg[1][6]-7.0*plg[1][5])/6.0; */
-/*      plg[1][8] = (15.0*c*plg[1][7]-8.0*plg[1][6])/7.0; */
-  plg[2][2] = 3.0*s2;
-  plg[2][3] = 15.0*s2*c;
-  plg[2][4] = 7.5*(7.0*c2 -1.0)*s2;
-  plg[2][5] = 3.0*c*plg[2][4]-2.0*plg[2][3];
-  plg[2][6] =(11.0*c*plg[2][5]-7.0*plg[2][4])/4.0;
-  plg[2][7] =(13.0*c*plg[2][6]-8.0*plg[2][5])/5.0;
-  plg[3][3] = 15.0*s2*s;
-  plg[3][4] = 105.0*s2*s*c;
-  plg[3][5] =(9.0*c*plg[3][4]-7.*plg[3][3])/2.0;
-  plg[3][6] =(11.0*c*plg[3][5]-8.*plg[3][4])/3.0;
-
-  if (!(((flags->sw[7]==0)&&(flags->sw[8]==0))&&(flags->sw[14]==0))) {
-    stloc = sin(hr*tloc);
-    ctloc = cos(hr*tloc);
-    s2tloc = sin(2.0*hr*tloc);
-    c2tloc = cos(2.0*hr*tloc);
-    s3tloc = sin(3.0*hr*tloc);
-    c3tloc = cos(3.0*hr*tloc);
-  }
-
-  cd32 = cos(dr*(input->doy-p[31]));
-  cd18 = cos(2.0*dr*(input->doy-p[17]));
-  cd14 = cos(dr*(input->doy-p[13]));
-  cd39 = cos(2.0*dr*(input->doy-p[38]));
-
-  /* F10.7 EFFECT */
-  df = input->f107 - input->f107A;
-  dfa = input->f107A - 150.0;
-  t[0] =  p[19]*df*(1.0+p[59]*dfa) + p[20]*df*df + p[21]*dfa + p[29]*pow(dfa,2.0);
-  f1 = 1.0 + (p[47]*dfa +p[19]*df+p[20]*df*df)*flags->swc[1];
-  f2 = 1.0 + (p[49]*dfa+p[19]*df+p[20]*df*df)*flags->swc[1];
-
-  /*  TIME INDEPENDENT */
-  t[1] = (p[1]*plg[0][2]+ p[2]*plg[0][4]+p[22]*plg[0][6]) +
-        (p[14]*plg[0][2])*dfa*flags->swc[1] +p[26]*plg[0][1];
-
-  /*  SYMMETRICAL ANNUAL */
-  t[2] = p[18]*cd32;
-
-  /*  SYMMETRICAL SEMIANNUAL */
-  t[3] = (p[15]+p[16]*plg[0][2])*cd18;
-
-  /*  ASYMMETRICAL ANNUAL */
-  t[4] =  f1*(p[9]*plg[0][1]+p[10]*plg[0][3])*cd14;
-
-  /*  ASYMMETRICAL SEMIANNUAL */
-  t[5] =    p[37]*plg[0][1]*cd39;
-
-        /* DIURNAL */
-  if (flags->sw[7]) {
-    double t71, t72;
-    t71 = (p[11]*plg[1][2])*cd14*flags->swc[5];
-    t72 = (p[12]*plg[1][2])*cd14*flags->swc[5];
-    t[6] = f2*((p[3]*plg[1][1] + p[4]*plg[1][3] + p[27]*plg[1][5] + t71) * \
-         ctloc + (p[6]*plg[1][1] + p[7]*plg[1][3] + p[28]*plg[1][5] \
-            + t72)*stloc);
-}
-
-  /* SEMIDIURNAL */
-  if (flags->sw[8]) {
-    double t81, t82;
-    t81 = (p[23]*plg[2][3]+p[35]*plg[2][5])*cd14*flags->swc[5];
-    t82 = (p[33]*plg[2][3]+p[36]*plg[2][5])*cd14*flags->swc[5];
-    t[7] = f2*((p[5]*plg[2][2]+ p[41]*plg[2][4] + t81)*c2tloc +(p[8]*plg[2][2] + p[42]*plg[2][4] + t82)*s2tloc);
-  }
-
-  /* TERDIURNAL */
-  if (flags->sw[14]) {
-    t[13] = f2 * ((p[39]*plg[3][3]+(p[93]*plg[3][4]+p[46]*plg[3][6])*cd14*flags->swc[5])* s3tloc +(p[40]*plg[3][3]+(p[94]*plg[3][4]+p[48]*plg[3][6])*cd14*flags->swc[5])* c3tloc);
-}
-
-  /* magnetic activity based on daily ap */
-  if (flags->sw[9]==-1) {
-    ap = input->ap_a;
-    if (p[51]!=0) {
-      double exp1;
-      exp1 = exp(-10800.0*sqrt(p[51]*p[51])/(1.0+p[138]*(45.0-sqrt(input->g_lat*input->g_lat))));
-      if (exp1>0.99999)
-        exp1=0.99999;
-      if (p[24]<1.0E-4)
-        p[24]=1.0E-4;
-      apt[0]=sg0(exp1,p,ap->a);
-      /* apt[1]=sg2(exp1,p,ap->a);
-         apt[2]=sg0(exp2,p,ap->a);
-         apt[3]=sg2(exp2,p,ap->a);
-      */
-      if (flags->sw[9]) {
-        t[8] = apt[0]*(p[50]+p[96]*plg[0][2]+p[54]*plg[0][4]+ \
-     (p[125]*plg[0][1]+p[126]*plg[0][3]+p[127]*plg[0][5])*cd14*flags->swc[5]+ \
-     (p[128]*plg[1][1]+p[129]*plg[1][3]+p[130]*plg[1][5])*flags->swc[7]* \
-                 cos(hr*(tloc-p[131])));
-      }
-    }
-  } else {
-    double p44, p45;
-    apd=input->ap-4.0;
-    p44=p[43];
-    p45=p[44];
-    if (p44<0)
-      p44 = 1.0E-5;
-    apdf = apd + (p45-1.0)*(apd + (exp(-p44 * apd) - 1.0)/p44);
-    if (flags->sw[9]) {
-      t[8]=apdf*(p[32]+p[45]*plg[0][2]+p[34]*plg[0][4]+ \
-     (p[100]*plg[0][1]+p[101]*plg[0][3]+p[102]*plg[0][5])*cd14*flags->swc[5]+
-     (p[121]*plg[1][1]+p[122]*plg[1][3]+p[123]*plg[1][5])*flags->swc[7]*
-            cos(hr*(tloc-p[124])));
-    }
-  }
-
-  if ((flags->sw[10])&&(input->g_long>-1000.0)) {
-
-    /* longitudinal */
-    if (flags->sw[11]) {
-      t[10] = (1.0 + p[80]*dfa*flags->swc[1])* \
-     ((p[64]*plg[1][2]+p[65]*plg[1][4]+p[66]*plg[1][6]\
-      +p[103]*plg[1][1]+p[104]*plg[1][3]+p[105]*plg[1][5]\
-      +flags->swc[5]*(p[109]*plg[1][1]+p[110]*plg[1][3]+p[111]*plg[1][5])*cd14)* \
-          cos(dgtr*input->g_long) \
-      +(p[90]*plg[1][2]+p[91]*plg[1][4]+p[92]*plg[1][6]\
-      +p[106]*plg[1][1]+p[107]*plg[1][3]+p[108]*plg[1][5]\
-      +flags->swc[5]*(p[112]*plg[1][1]+p[113]*plg[1][3]+p[114]*plg[1][5])*cd14)* \
-      sin(dgtr*input->g_long));
-    }
-
-    /* ut and mixed ut, longitude */
-    if (flags->sw[12]){
-      t[11]=(1.0+p[95]*plg[0][1])*(1.0+p[81]*dfa*flags->swc[1])*\
-        (1.0+p[119]*plg[0][1]*flags->swc[5]*cd14)*\
-        ((p[68]*plg[0][1]+p[69]*plg[0][3]+p[70]*plg[0][5])*\
-        cos(sr*(input->sec-p[71])));
-      t[11]+=flags->swc[11]*\
-        (p[76]*plg[2][3]+p[77]*plg[2][5]+p[78]*plg[2][7])*\
-        cos(sr*(input->sec-p[79])+2.0*dgtr*input->g_long)*(1.0+p[137]*dfa*flags->swc[1]);
-    }
-
-    /* ut, longitude magnetic activity */
-    if (flags->sw[13]) {
-      if (flags->sw[9]==-1) {
-        if (p[51]) {
-          t[12]=apt[0]*flags->swc[11]*(1.+p[132]*plg[0][1])*\
-            ((p[52]*plg[1][2]+p[98]*plg[1][4]+p[67]*plg[1][6])*\
-             cos(dgtr*(input->g_long-p[97])))\
-            +apt[0]*flags->swc[11]*flags->swc[5]*\
-            (p[133]*plg[1][1]+p[134]*plg[1][3]+p[135]*plg[1][5])*\
-            cd14*cos(dgtr*(input->g_long-p[136])) \
-            +apt[0]*flags->swc[12]* \
-            (p[55]*plg[0][1]+p[56]*plg[0][3]+p[57]*plg[0][5])*\
-            cos(sr*(input->sec-p[58]));
-        }
-      } else {
-        t[12] = apdf*flags->swc[11]*(1.0+p[120]*plg[0][1])*\
-          ((p[60]*plg[1][2]+p[61]*plg[1][4]+p[62]*plg[1][6])*\
-          cos(dgtr*(input->g_long-p[63])))\
-          +apdf*flags->swc[11]*flags->swc[5]* \
-          (p[115]*plg[1][1]+p[116]*plg[1][3]+p[117]*plg[1][5])* \
-          cd14*cos(dgtr*(input->g_long-p[118])) \
-          + apdf*flags->swc[12]* \
-          (p[83]*plg[0][1]+p[84]*plg[0][3]+p[85]*plg[0][5])* \
-          cos(sr*(input->sec-p[75]));
-      }
-    }
-  }
-
-  /* parms not used: 82, 89, 99, 139-149 */
-  tinf = p[30];
-  for (i=0;i<14;i++)
-    tinf = tinf + fabs(flags->sw[i+1])*t[i];
-  return tinf;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double MSIS::glob7s(double *p, struct nrlmsise_input *input,
-                      struct nrlmsise_flags *flags)
-{
-/*    VERSION OF GLOBE FOR LOWER ATMOSPHERE 10/26/99
- */
-  double pset=2.0;
-  double t[14] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,};
-  double tt=0.0;
-  double cd32=0.0, cd18=0.0, cd14=0.0, cd39=0.0;
-  int i=0,j=0;
-  double dr=1.72142E-2;
-  double dgtr=1.74533E-2;
-  /* confirm parameter set */
-  if (p[99]==0)
-    p[99]=pset;
-  if (p[99]!=pset) {
-    cerr << "Wrong parameter set for glob7s" << endl;
-    return -1;
-  }
-  for (j=0;j<14;j++)
-    t[j]=0.0;
-  cd32 = cos(dr*(input->doy-p[31]));
-  cd18 = cos(2.0*dr*(input->doy-p[17]));
-  cd14 = cos(dr*(input->doy-p[13]));
-  cd39 = cos(2.0*dr*(input->doy-p[38]));
-
-  /* F10.7 */
-  t[0] = p[21]*dfa;
-
-  /* time independent */
-  t[1]=p[1]*plg[0][2] + p[2]*plg[0][4] + p[22]*plg[0][6] + p[26]*plg[0][1] + p[14]*plg[0][3] + p[59]*plg[0][5];
-
-        /* SYMMETRICAL ANNUAL */
-  t[2]=(p[18]+p[47]*plg[0][2]+p[29]*plg[0][4])*cd32;
-
-        /* SYMMETRICAL SEMIANNUAL */
-  t[3]=(p[15]+p[16]*plg[0][2]+p[30]*plg[0][4])*cd18;
-
-        /* ASYMMETRICAL ANNUAL */
-  t[4]=(p[9]*plg[0][1]+p[10]*plg[0][3]+p[20]*plg[0][5])*cd14;
-
-  /* ASYMMETRICAL SEMIANNUAL */
-  t[5]=(p[37]*plg[0][1])*cd39;
-
-        /* DIURNAL */
-  if (flags->sw[7]) {
-    double t71, t72;
-    t71 = p[11]*plg[1][2]*cd14*flags->swc[5];
-    t72 = p[12]*plg[1][2]*cd14*flags->swc[5];
-    t[6] = ((p[3]*plg[1][1] + p[4]*plg[1][3] + t71) * ctloc + (p[6]*plg[1][1] + p[7]*plg[1][3] + t72) * stloc) ;
-  }
-
-  /* SEMIDIURNAL */
-  if (flags->sw[8]) {
-    double t81, t82;
-    t81 = (p[23]*plg[2][3]+p[35]*plg[2][5])*cd14*flags->swc[5];
-    t82 = (p[33]*plg[2][3]+p[36]*plg[2][5])*cd14*flags->swc[5];
-    t[7] = ((p[5]*plg[2][2] + p[41]*plg[2][4] + t81) * c2tloc + (p[8]*plg[2][2] + p[42]*plg[2][4] + t82) * s2tloc);
-  }
-
-  /* TERDIURNAL */
-  if (flags->sw[14]) {
-    t[13] = p[39] * plg[3][3] * s3tloc + p[40] * plg[3][3] * c3tloc;
-  }
-
-  /* MAGNETIC ACTIVITY */
-  if (flags->sw[9]) {
-    if (flags->sw[9]==1)
-      t[8] = apdf * (p[32] + p[45] * plg[0][2] * flags->swc[2]);
-    if (flags->sw[9]==-1)
-      t[8]=(p[50]*apt[0] + p[96]*plg[0][2] * apt[0]*flags->swc[2]);
-  }
-
-  /* LONGITUDINAL */
-  if (!((flags->sw[10]==0) || (flags->sw[11]==0) || (input->g_long<=-1000.0))) {
-    t[10] = (1.0 + plg[0][1]*(p[80]*flags->swc[5]*cos(dr*(input->doy-p[81]))\
-            +p[85]*flags->swc[6]*cos(2.0*dr*(input->doy-p[86])))\
-      +p[83]*flags->swc[3]*cos(dr*(input->doy-p[84]))\
-      +p[87]*flags->swc[4]*cos(2.0*dr*(input->doy-p[88])))\
-      *((p[64]*plg[1][2]+p[65]*plg[1][4]+p[66]*plg[1][6]\
-      +p[74]*plg[1][1]+p[75]*plg[1][3]+p[76]*plg[1][5]\
-      )*cos(dgtr*input->g_long)\
-      +(p[90]*plg[1][2]+p[91]*plg[1][4]+p[92]*plg[1][6]\
-      +p[77]*plg[1][1]+p[78]*plg[1][3]+p[79]*plg[1][5]\
-      )*sin(dgtr*input->g_long));
-  }
-  tt=0;
-  for (i=0;i<14;i++)
-    tt+=fabs(flags->sw[i+1])*t[i];
-  return tt;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void MSIS::gtd7(struct nrlmsise_input *input, struct nrlmsise_flags *flags,
-                  struct nrlmsise_output *output)
-{
-  double xlat=0.0;
-  double xmm=0.0;
-  int mn3 = 5;
-  double zn3[5]={32.5,20.0,15.0,10.0,0.0};
-  int mn2 = 4;
-  double zn2[4]={72.5,55.0,45.0,32.5};
-  double altt=0.0;
-  double zmix=62.5;
-  double tmp=0.0;
-  double dm28m=0.0;
-  double tz=0.0;
-  double dmc=0.0;
-  double dmr=0.0;
-  double dz28=0.0;
-  struct nrlmsise_output soutput;
-  int i;
-
-  for (int i=0; i<9; i++) soutput.d[i] = 0.0;
-  for (int i=0; i<2; i++) soutput.t[i] = 0.0;
-
-  tselec(flags);
-
-  /* Latitude variation of gravity (none for sw[2]=0) */
-  xlat=input->g_lat;
-  if (flags->sw[2]==0)
-    xlat=45.0;
-  glatf(xlat, &gsurf, &re);
-
-  xmm = pdm[2][4];
-
-  /* THERMOSPHERE / MESOSPHERE (above zn2[0]) */
-  if (input->alt>zn2[0])
-    altt=input->alt;
-  else
-    altt=zn2[0];
-
-  tmp=input->alt;
-  input->alt=altt;
-  gts7(input, flags, &soutput);
-  altt=input->alt;
-  input->alt=tmp;
-  if (flags->sw[0])   /* metric adjustment */
-    dm28m=dm28*1.0E6;
-  else
-    dm28m=dm28;
-  output->t[0]=soutput.t[0];
-  output->t[1]=soutput.t[1];
-  if (input->alt>=zn2[0]) {
-    for (i=0;i<9;i++)
-      output->d[i]=soutput.d[i];
-    return;
-  }
-
-/*       LOWER MESOSPHERE/UPPER STRATOSPHERE (between zn3[0] and zn2[0])
- *         Temperature at nodes and gradients at end nodes
- *         Inverse temperature a linear function of spherical harmonics
- */
-  meso_tgn2[0]=meso_tgn1[1];
-  meso_tn2[0]=meso_tn1[4];
-        meso_tn2[1]=pma[0][0]*pavgm[0]/(1.0-flags->sw[20]*glob7s(pma[0], input, flags));
-        meso_tn2[2]=pma[1][0]*pavgm[1]/(1.0-flags->sw[20]*glob7s(pma[1], input, flags));
-        meso_tn2[3]=pma[2][0]*pavgm[2]/(1.0-flags->sw[20]*flags->sw[22]*glob7s(pma[2], input, flags));
-  meso_tgn2[1]=pavgm[8]*pma[9][0]*(1.0+flags->sw[20]*flags->sw[22]*glob7s(pma[9], input, flags))*meso_tn2[3]*meso_tn2[3]/(pow((pma[2][0]*pavgm[2]),2.0));
-  meso_tn3[0]=meso_tn2[3];
-
-  if (input->alt<zn3[0]) {
-/*       LOWER STRATOSPHERE AND TROPOSPHERE (below zn3[0])
- *         Temperature at nodes and gradients at end nodes
- *         Inverse temperature a linear function of spherical harmonics
- */
-    meso_tgn3[0]=meso_tgn2[1];
-    meso_tn3[1]=pma[3][0]*pavgm[3]/(1.0-flags->sw[22]*glob7s(pma[3], input, flags));
-    meso_tn3[2]=pma[4][0]*pavgm[4]/(1.0-flags->sw[22]*glob7s(pma[4], input, flags));
-    meso_tn3[3]=pma[5][0]*pavgm[5]/(1.0-flags->sw[22]*glob7s(pma[5], input, flags));
-    meso_tn3[4]=pma[6][0]*pavgm[6]/(1.0-flags->sw[22]*glob7s(pma[6], input, flags));
-    meso_tgn3[1]=pma[7][0]*pavgm[7]*(1.0+flags->sw[22]*glob7s(pma[7], input, flags)) *meso_tn3[4]*meso_tn3[4]/(pow((pma[6][0]*pavgm[6]),2.0));
-  }
-
-        /* LINEAR TRANSITION TO FULL MIXING BELOW zn2[0] */
-
-  dmc=0;
-  if (input->alt>zmix)
-    dmc = 1.0 - (zn2[0]-input->alt)/(zn2[0] - zmix);
-  dz28=soutput.d[2];
-
-  /**** N2 density ****/
-  dmr=soutput.d[2] / dm28m - 1.0;
-  output->d[2]=densm(input->alt,dm28m,xmm, &tz, mn3, zn3, meso_tn3, meso_tgn3, mn2, zn2, meso_tn2, meso_tgn2);
-  output->d[2]=output->d[2] * (1.0 + dmr*dmc);
-
-  /**** HE density ****/
-  dmr = soutput.d[0] / (dz28 * pdm[0][1]) - 1.0;
-  output->d[0] = output->d[2] * pdm[0][1] * (1.0 + dmr*dmc);
-
-  /**** O density ****/
-  output->d[1] = 0;
-  output->d[8] = 0;
-
-  /**** O2 density ****/
-  dmr = soutput.d[3] / (dz28 * pdm[3][1]) - 1.0;
-  output->d[3] = output->d[2] * pdm[3][1] * (1.0 + dmr*dmc);
-
-  /**** AR density ***/
-  dmr = soutput.d[4] / (dz28 * pdm[4][1]) - 1.0;
-  output->d[4] = output->d[2] * pdm[4][1] * (1.0 + dmr*dmc);
-
-  /**** Hydrogen density ****/
-  output->d[6] = 0;
-
-  /**** Atomic nitrogen density ****/
-  output->d[7] = 0;
-
-  /**** Total mass density */
-  output->d[5] = 1.66E-24 * (4.0 * output->d[0] + 16.0 * output->d[1] +
-                     28.0 * output->d[2] + 32.0 * output->d[3] + 40.0 * output->d[4]
-                     + output->d[6] + 14.0 * output->d[7]);
-
-  if (flags->sw[0])
-    output->d[5]=output->d[5]/1000;
-
-  /**** temperature at altitude ****/
-  dd = densm(input->alt, 1.0, 0, &tz, mn3, zn3, meso_tn3, meso_tgn3,
-                   mn2, zn2, meso_tn2, meso_tgn2);
-  output->t[1]=tz;
-
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void MSIS::gtd7d(struct nrlmsise_input *input, struct nrlmsise_flags *flags,
-                   struct nrlmsise_output *output)
-{
-  gtd7(input, flags, output);
-  output->d[5] = 1.66E-24 * (4.0 * output->d[0] + 16.0 * output->d[1] +
-                   28.0 * output->d[2] + 32.0 * output->d[3] + 40.0 * output->d[4]
-                   + output->d[6] + 14.0 * output->d[7] + 16.0 * output->d[8]);
-  if (flags->sw[0])
-    output->d[5]=output->d[5]/1000;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void MSIS::ghp7(struct nrlmsise_input *input, struct nrlmsise_flags *flags,
-                  struct nrlmsise_output *output, double press)
-{
-  double bm = 1.3806E-19;
-  double rgas = 831.4;
-  double test = 0.00043;
-  double ltest = 12;
-  double pl, p;
-  double zi = 0.0;
-  double z;
-  double cl, cl2;
-  double ca, cd;
-  double xn, xm, diff;
-  double g, sh;
-  int l;
-  pl = log10(press);
-  if (pl >= -5.0) {
-    if (pl>2.5)
-      zi = 18.06 * (3.00 - pl);
-    else if ((pl>0.075) && (pl<=2.5))
-      zi = 14.98 * (3.08 - pl);
-    else if ((pl>-1) && (pl<=0.075))
-      zi = 17.80 * (2.72 - pl);
-    else if ((pl>-2) && (pl<=-1))
-      zi = 14.28 * (3.64 - pl);
-    else if ((pl>-4) && (pl<=-2))
-      zi = 12.72 * (4.32 -pl);
-    else if (pl<=-4)
-      zi = 25.3 * (0.11 - pl);
-    cl = input->g_lat/90.0;
-    cl2 = cl*cl;
-    if (input->doy<182)
-      cd = (1.0 - (double) input->doy) / 91.25;
-    else
-      cd = ((double) input->doy) / 91.25 - 3.0;
-    ca = 0;
-    if ((pl > -1.11) && (pl<=-0.23))
-      ca = 1.0;
-    if (pl > -0.23)
-      ca = (2.79 - pl) / (2.79 + 0.23);
-    if ((pl <= -1.11) && (pl>-3))
-      ca = (-2.93 - pl)/(-2.93 + 1.11);
-    z = zi - 4.87 * cl * cd * ca - 1.64 * cl2 * ca + 0.31 * ca * cl;
-  } else
-    z = 22.0 * pow((pl + 4.0),2.0) + 110.0;
-
-  /* iteration  loop */
-  l = 0;
-  do {
-    l++;
-    input->alt = z;
-    gtd7(input, flags, output);
-    z = input->alt;
-    xn = output->d[0] + output->d[1] + output->d[2] + output->d[3] + output->d[4] + output->d[6] + output->d[7];
-    p = bm * xn * output->t[1];
-    if (flags->sw[0])
-      p = p*1.0E-6;
-    diff = pl - log10(p);
-    if (sqrt(diff*diff)<test)
-      return;
-    if (l==ltest) {
-      cerr << "ERROR: ghp7 not converging for press " << press << ", diff " << diff << endl;
-      return;
-    }
-    xm = output->d[5] / xn / 1.66E-24;
-    if (flags->sw[0])
-      xm = xm * 1.0E3;
-    g = gsurf / (pow((1.0 + z/re),2.0));
-    sh = rgas * output->t[1] / (xm * g);
-
-    /* new altitude estimate using scale height */
-    if (l <  6)
-      z = z - sh * diff * 2.302;
-    else
-      z = z - sh * diff;
-  } while (1==1);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void MSIS::gts7(struct nrlmsise_input *input, struct nrlmsise_flags *flags,
-                  struct nrlmsise_output *output)
-{
-/*     Thermospheric portion of NRLMSISE-00
- *     See GTD7 for more extensive comments
- *     alt > 72.5 km!
- */
-  double za=0.0;
-  int i, j;
-  double z=0.0;
-  double zn1[5] = {120.0, 110.0, 100.0, 90.0, 72.5};
-  double tinf=0.0;
-  int mn1 = 5;
-  double g0=0.0;
-  double tlb=0.0;
-  double s=0.0;
-  double db01=0.0, db04=0.0, db14=0.0, db16=0.0, db28=0.0, db32=0.0, db40=0.0;
-  double zh28=0.0, zh04=0.0, zh16=0.0, zh32=0.0, zh40=0.0, zh01=0.0, zh14=0.0;
-  double zhm28=0.0, zhm04=0.0, zhm16=0.0, zhm32=0.0, zhm40=0.0, zhm01=0.0, zhm14=0.0;
-  double xmd=0.0;
-  double b28=0.0, b04=0.0, b16=0.0, b32=0.0, b40=0.0, b01=0.0, b14=0.0;
-  double tz=0.0;
-  double g28=0.0, g4=0.0, g16=0.0, g32=0.0, g40=0.0, g1=0.0, g14=0.0;
-  double zhf=0.0, xmm=0.0;
-  double zc04=0.0, zc16=0.0, zc32=0.0, zc40=0.0, zc01=0.0, zc14=0.0;
-  double hc04=0.0, hc16=0.0, hc32=0.0, hc40=0.0, hc01=0.0, hc14=0.0;
-  double hcc16=0.0, hcc32=0.0, hcc01=0.0, hcc14=0.0;
-  double zcc16=0.0, zcc32=0.0, zcc01=0.0, zcc14=0.0;
-  double rc16=0.0, rc32=0.0, rc01=0.0, rc14=0.0;
-  double rl=0.0;
-  double g16h=0.0, db16h=0.0, tho=0.0, zsht=0.0, zmho=0.0, zsho=0.0;
-  double dgtr=1.74533E-2;
-  double dr=1.72142E-2;
-  double alpha[9]={-0.38, 0.0, 0.0, 0.0, 0.17, 0.0, -0.38, 0.0, 0.0};
-  double altl[8]={200.0, 300.0, 160.0, 250.0, 240.0, 450.0, 320.0, 450.0};
-  double dd=0.0;
-  double hc216=0.0, hcc232=0.0;
-  za = pdl[1][15];
-  zn1[0] = za;
-  for (j=0;j<9;j++)
-    output->d[j]=0;
-
-  /* TINF VARIATIONS NOT IMPORTANT BELOW ZA OR ZN1(1) */
-  if (input->alt>zn1[0])
-    tinf = ptm[0]*pt[0] * \
-      (1.0+flags->sw[16]*globe7(pt,input,flags));
-  else
-    tinf = ptm[0]*pt[0];
-  output->t[0]=tinf;
-
-  /*  GRADIENT VARIATIONS NOT IMPORTANT BELOW ZN1(5) */
-  if (input->alt>zn1[4])
-    g0 = ptm[3]*ps[0] * \
-      (1.0+flags->sw[19]*globe7(ps,input,flags));
-  else
-    g0 = ptm[3]*ps[0];
-  tlb = ptm[1] * (1.0 + flags->sw[17]*globe7(pd[3],input,flags))*pd[3][0];
-  s = g0 / (tinf - tlb);
-
-/*      Lower thermosphere temp variations not significant for
- *       density above 300 km */
-  if (input->alt<300.0) {
-    meso_tn1[1]=ptm[6]*ptl[0][0]/(1.0-flags->sw[18]*glob7s(ptl[0], input, flags));
-    meso_tn1[2]=ptm[2]*ptl[1][0]/(1.0-flags->sw[18]*glob7s(ptl[1], input, flags));
-    meso_tn1[3]=ptm[7]*ptl[2][0]/(1.0-flags->sw[18]*glob7s(ptl[2], input, flags));
-    meso_tn1[4]=ptm[4]*ptl[3][0]/(1.0-flags->sw[18]*flags->sw[20]*glob7s(ptl[3], input, flags));
-    meso_tgn1[1]=ptm[8]*pma[8][0]*(1.0+flags->sw[18]*flags->sw[20]*glob7s(pma[8], input, flags))*meso_tn1[4]*meso_tn1[4]/(pow((ptm[4]*ptl[3][0]),2.0));
-  } else {
-    meso_tn1[1]=ptm[6]*ptl[0][0];
-    meso_tn1[2]=ptm[2]*ptl[1][0];
-    meso_tn1[3]=ptm[7]*ptl[2][0];
-    meso_tn1[4]=ptm[4]*ptl[3][0];
-    meso_tgn1[1]=ptm[8]*pma[8][0]*meso_tn1[4]*meso_tn1[4]/(pow((ptm[4]*ptl[3][0]),2.0));
-  }
-
-  /* N2 variation factor at Zlb */
-  g28=flags->sw[21]*globe7(pd[2], input, flags);
-
-  /* VARIATION OF TURBOPAUSE HEIGHT */
-  zhf=pdl[1][24]*(1.0+flags->sw[5]*pdl[0][24]*sin(dgtr*input->g_lat)*cos(dr*(input->doy-pt[13])));
-  output->t[0]=tinf;
-  xmm = pdm[2][4];
-  z = input->alt;
-
-
-        /**** N2 DENSITY ****/
-
-  /* Diffusive density at Zlb */
-  db28 = pdm[2][0]*exp(g28)*pd[2][0];
-  /* Diffusive density at Alt */
-  output->d[2]=densu(z,db28,tinf,tlb,28.0,alpha[2],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-  dd=output->d[2];
-  /* Turbopause */
-  zh28=pdm[2][2]*zhf;
-  zhm28=pdm[2][3]*pdl[1][5];
-  xmd=28.0-xmm;
-  /* Mixed density at Zlb */
-  b28=densu(zh28,db28,tinf,tlb,xmd,(alpha[2]-1.0),&tz,ptm[5],s,mn1, zn1,meso_tn1,meso_tgn1);
-  if ((flags->sw[15])&&(z<=altl[2])) {
-    /*  Mixed density at Alt */
-    dm28=densu(z,b28,tinf,tlb,xmm,alpha[2],&tz,ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    /*  Net density at Alt */
-    output->d[2]=dnet(output->d[2],dm28,zhm28,xmm,28.0);
-  }
-
-
-        /**** HE DENSITY ****/
-
-  /*   Density variation factor at Zlb */
-  g4 = flags->sw[21]*globe7(pd[0], input, flags);
-  /*  Diffusive density at Zlb */
-  db04 = pdm[0][0]*exp(g4)*pd[0][0];
-        /*  Diffusive density at Alt */
-  output->d[0]=densu(z,db04,tinf,tlb, 4.,alpha[0],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-  dd=output->d[0];
-  if ((flags->sw[15]) && (z<altl[0])) {
-    /*  Turbopause */
-    zh04=pdm[0][2];
-    /*  Mixed density at Zlb */
-    b04=densu(zh04,db04,tinf,tlb,4.-xmm,alpha[0]-1.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    /*  Mixed density at Alt */
-    dm04=densu(z,b04,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    zhm04=zhm28;
-    /*  Net density at Alt */
-    output->d[0]=dnet(output->d[0],dm04,zhm04,xmm,4.);
-    /*  Correction to specified mixing ratio at ground */
-    rl=log(b28*pdm[0][1]/b04);
-    zc04=pdm[0][4]*pdl[1][0];
-    hc04=pdm[0][5]*pdl[1][1];
-    /*  Net density corrected at Alt */
-    output->d[0]=output->d[0]*ccor(z,rl,hc04,zc04);
-  }
-
-
-        /**** O DENSITY ****/
-
-  /*  Density variation factor at Zlb */
-  g16= flags->sw[21]*globe7(pd[1],input,flags);
-  /*  Diffusive density at Zlb */
-  db16 =  pdm[1][0]*exp(g16)*pd[1][0];
-        /*   Diffusive density at Alt */
-  output->d[1]=densu(z,db16,tinf,tlb, 16.,alpha[1],&output->t[1],ptm[5],s,mn1, zn1,meso_tn1,meso_tgn1);
-  dd=output->d[1];
-  if ((flags->sw[15]) && (z<=altl[1])) {
-    /*   Turbopause */
-    zh16=pdm[1][2];
-    /*  Mixed density at Zlb */
-    b16=densu(zh16,db16,tinf,tlb,16.0-xmm,(alpha[1]-1.0), &output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    /*  Mixed density at Alt */
-    dm16=densu(z,b16,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    zhm16=zhm28;
-    /*  Net density at Alt */
-    output->d[1]=dnet(output->d[1],dm16,zhm16,xmm,16.);
-    rl=pdm[1][1]*pdl[1][16]*(1.0+flags->sw[1]*pdl[0][23]*(input->f107A-150.0));
-    hc16=pdm[1][5]*pdl[1][3];
-    zc16=pdm[1][4]*pdl[1][2];
-    hc216=pdm[1][5]*pdl[1][4];
-    output->d[1]=output->d[1]*ccor2(z,rl,hc16,zc16,hc216);
-    /*   Chemistry correction */
-    hcc16=pdm[1][7]*pdl[1][13];
-    zcc16=pdm[1][6]*pdl[1][12];
-    rc16=pdm[1][3]*pdl[1][14];
-    /*  Net density corrected at Alt */
-    output->d[1]=output->d[1]*ccor(z,rc16,hcc16,zcc16);
-  }
-
-
-        /**** O2 DENSITY ****/
-
-        /*   Density variation factor at Zlb */
-  g32= flags->sw[21]*globe7(pd[4], input, flags);
-        /*  Diffusive density at Zlb */
-  db32 = pdm[3][0]*exp(g32)*pd[4][0];
-        /*   Diffusive density at Alt */
-  output->d[3]=densu(z,db32,tinf,tlb, 32.,alpha[3],&output->t[1],ptm[5],s,mn1, zn1,meso_tn1,meso_tgn1);
-  dd=output->d[3];
-  if (flags->sw[15]) {
-    if (z<=altl[3]) {
-      /*   Turbopause */
-      zh32=pdm[3][2];
-      /*  Mixed density at Zlb */
-      b32=densu(zh32,db32,tinf,tlb,32.-xmm,alpha[3]-1., &output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-      /*  Mixed density at Alt */
-      dm32=densu(z,b32,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-      zhm32=zhm28;
-      /*  Net density at Alt */
-      output->d[3]=dnet(output->d[3],dm32,zhm32,xmm,32.);
-      /*   Correction to specified mixing ratio at ground */
-      rl=log(b28*pdm[3][1]/b32);
-      hc32=pdm[3][5]*pdl[1][7];
-      zc32=pdm[3][4]*pdl[1][6];
-      output->d[3]=output->d[3]*ccor(z,rl,hc32,zc32);
-    }
-    /*  Correction for general departure from diffusive equilibrium above Zlb */
-    hcc32=pdm[3][7]*pdl[1][22];
-    hcc232=pdm[3][7]*pdl[0][22];
-    zcc32=pdm[3][6]*pdl[1][21];
-    rc32=pdm[3][3]*pdl[1][23]*(1.+flags->sw[1]*pdl[0][23]*(input->f107A-150.));
-    /*  Net density corrected at Alt */
-    output->d[3]=output->d[3]*ccor2(z,rc32,hcc32,zcc32,hcc232);
-  }
-
-
-        /**** AR DENSITY ****/
-
-        /*   Density variation factor at Zlb */
-  g40= flags->sw[21]*globe7(pd[5],input,flags);
-        /*  Diffusive density at Zlb */
-  db40 = pdm[4][0]*exp(g40)*pd[5][0];
-  /*   Diffusive density at Alt */
-  output->d[4]=densu(z,db40,tinf,tlb, 40.,alpha[4],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-  dd=output->d[4];
-  if ((flags->sw[15]) && (z<=altl[4])) {
-    /*   Turbopause */
-    zh40=pdm[4][2];
-    /*  Mixed density at Zlb */
-    b40=densu(zh40,db40,tinf,tlb,40.-xmm,alpha[4]-1.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    /*  Mixed density at Alt */
-    dm40=densu(z,b40,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    zhm40=zhm28;
-    /*  Net density at Alt */
-    output->d[4]=dnet(output->d[4],dm40,zhm40,xmm,40.);
-    /*   Correction to specified mixing ratio at ground */
-    rl=log(b28*pdm[4][1]/b40);
-    hc40=pdm[4][5]*pdl[1][9];
-    zc40=pdm[4][4]*pdl[1][8];
-    /*  Net density corrected at Alt */
-    output->d[4]=output->d[4]*ccor(z,rl,hc40,zc40);
-    }
-
-
-        /**** HYDROGEN DENSITY ****/
-
-        /*   Density variation factor at Zlb */
-  g1 = flags->sw[21]*globe7(pd[6], input, flags);
-        /*  Diffusive density at Zlb */
-  db01 = pdm[5][0]*exp(g1)*pd[6][0];
-        /*   Diffusive density at Alt */
-  output->d[6]=densu(z,db01,tinf,tlb,1.,alpha[6],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-  dd=output->d[6];
-  if ((flags->sw[15]) && (z<=altl[6])) {
-    /*   Turbopause */
-    zh01=pdm[5][2];
-    /*  Mixed density at Zlb */
-    b01=densu(zh01,db01,tinf,tlb,1.-xmm,alpha[6]-1., &output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    /*  Mixed density at Alt */
-    dm01=densu(z,b01,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    zhm01=zhm28;
-    /*  Net density at Alt */
-    output->d[6]=dnet(output->d[6],dm01,zhm01,xmm,1.);
-    /*   Correction to specified mixing ratio at ground */
-    rl=log(b28*pdm[5][1]*sqrt(pdl[1][17]*pdl[1][17])/b01);
-    hc01=pdm[5][5]*pdl[1][11];
-    zc01=pdm[5][4]*pdl[1][10];
-    output->d[6]=output->d[6]*ccor(z,rl,hc01,zc01);
-    /*   Chemistry correction */
-    hcc01=pdm[5][7]*pdl[1][19];
-    zcc01=pdm[5][6]*pdl[1][18];
-    rc01=pdm[5][3]*pdl[1][20];
-    /*  Net density corrected at Alt */
-    output->d[6]=output->d[6]*ccor(z,rc01,hcc01,zcc01);
-}
-
-
-        /**** ATOMIC NITROGEN DENSITY ****/
-
-  /*   Density variation factor at Zlb */
-  g14 = flags->sw[21]*globe7(pd[7],input,flags);
-        /*  Diffusive density at Zlb */
-  db14 = pdm[6][0]*exp(g14)*pd[7][0];
-        /*   Diffusive density at Alt */
-  output->d[7]=densu(z,db14,tinf,tlb,14.,alpha[7],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-  dd=output->d[7];
-  if ((flags->sw[15]) && (z<=altl[7])) {
-    /*   Turbopause */
-    zh14=pdm[6][2];
-    /*  Mixed density at Zlb */
-    b14=densu(zh14,db14,tinf,tlb,14.-xmm,alpha[7]-1., &output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    /*  Mixed density at Alt */
-    dm14=densu(z,b14,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
-    zhm14=zhm28;
-    /*  Net density at Alt */
-    output->d[7]=dnet(output->d[7],dm14,zhm14,xmm,14.);
-    /*   Correction to specified mixing ratio at ground */
-    rl=log(b28*pdm[6][1]*sqrt(pdl[0][2]*pdl[0][2])/b14);
-    hc14=pdm[6][5]*pdl[0][1];
-    zc14=pdm[6][4]*pdl[0][0];
-    output->d[7]=output->d[7]*ccor(z,rl,hc14,zc14);
-    /*   Chemistry correction */
-    hcc14=pdm[6][7]*pdl[0][4];
-    zcc14=pdm[6][6]*pdl[0][3];
-    rc14=pdm[6][3]*pdl[0][5];
-    /*  Net density corrected at Alt */
-    output->d[7]=output->d[7]*ccor(z,rc14,hcc14,zcc14);
-  }
-
-
-        /**** Anomalous OXYGEN DENSITY ****/
-
-  g16h = flags->sw[21]*globe7(pd[8],input,flags);
-  db16h = pdm[7][0]*exp(g16h)*pd[8][0];
-  tho = pdm[7][9]*pdl[0][6];
-  dd=densu(z,db16h,tho,tho,16.,alpha[8],&output->t[1],ptm[5],s,mn1, zn1,meso_tn1,meso_tgn1);
-  zsht=pdm[7][5];
-  zmho=pdm[7][4];
-  zsho=scalh(zmho,16.0,tho);
-  output->d[8]=dd*exp(-zsht/zsho*(exp(-(z-zmho)/zsht)-1.));
-
-
-  /* total mass density */
-  output->d[5] = 1.66E-24*(4.0*output->d[0]+16.0*output->d[1]+28.0*output->d[2]+32.0*output->d[3]+40.0*output->d[4]+ output->d[6]+14.0*output->d[7]);
-
-
-
-  /* temperature */
-  z = sqrt(input->alt*input->alt);
-  densu(z,1.0, tinf, tlb, 0.0, 0.0, &output->t[1], ptm[5], s, mn1, zn1, meso_tn1, meso_tgn1);
-  if (flags->sw[0]) {
-    for(i=0;i<9;i++)
-      output->d[i]=output->d[i]*1.0E6;
-    output->d[5]=output->d[5]/1000;
-  }
-}
-
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 //    The bitmasked value choices are as follows:
@@ -1602,17 +223,21 @@ void MSIS::gts7(struct nrlmsise_input *input, struct nrlmsise_flags *flags,
 //    16: When set various parameters are sanity checked and
 //       a message is printed out when they go out of bounds
 
-void MSIS::Debug(int from)
+void FGMSIS::Debug(int from)
 {
   if (debug_lvl <= 0) return;
 
   if (debug_lvl & 1) { // Standard console startup message output
-    if (from == 0) { // Constructor
+    if (from == 0) {} // Constructor
+    if (from == 3) { // Loading
+      cout << "    NRLMSIS atmosphere model" << endl;
+      cout << "      day: " << day_of_year << endl;
+      cout << "      UTC: " << seconds_in_day << endl << endl;
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: MSIS" << endl;
-    if (from == 1) cout << "Destroyed:    MSIS" << endl;
+    if (from == 0) std::cout << "Instantiated: MSIS" << std::endl;
+    if (from == 1) std::cout << "Destroyed:    MSIS" << std::endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }
@@ -1620,7 +245,7 @@ void MSIS::Debug(int from)
   }
   if (debug_lvl & 16) { // Sanity checking
   }
-  if (debug_lvl & 32) { // Turbulence
+  if (debug_lvl & 128) { //
   }
   if (debug_lvl & 64) {
     if (from == 0) { // Constructor
@@ -1628,7 +253,4 @@ void MSIS::Debug(int from)
   }
 }
 
-
-
 } // namespace JSBSim
-

--- a/src/models/atmosphere/FGMSIS.h
+++ b/src/models/atmosphere/FGMSIS.h
@@ -28,7 +28,8 @@ HISTORY
 --------------------------------------------------------------------------------
 12/14/03   DPC   Created
 01/11/04   DPC   Derive from FGAtmosphere
- 
+03/18/23   BC    Refactored
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 SENTRY
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
@@ -40,12 +41,15 @@ SENTRY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include "models/FGAtmosphere.h"
-#include "FGFDMExec.h"
+#include "models/atmosphere/FGStandardAtmosphere.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 FORWARD DECLARATIONS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+extern "C" {
+#include "MSIS/nrlmsise-00.h"
+}
 
 namespace JSBSim {
 
@@ -56,7 +60,7 @@ CLASS DOCUMENTATION
 /** Models the MSIS-00 atmosphere.
     This is a wrapper for the NRL-MSIS-00 model 2001:
 
-    This C++ format model wraps the NRLMSISE-00 C source code package - release
+    This C++ format model uses the NRLMSISE-00 C source code package - release
     20020503
  
     The NRLMSISE-00 model was developed by Mike Picone, Alan Hedin, and
@@ -71,162 +75,19 @@ CLASS DOCUMENTATION
     @author David Culp
 */
 
-/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-STRUCT DECLARATIONS
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
-
-struct nrlmsise_flags {
-  int switches[24];
-  double sw[24];
-  double swc[24];
-};
-/*   
- *   Switches: to turn on and off particular variations use these switches.
- *   0 is off, 1 is on, and 2 is main effects off but cross terms on.
- *
- *   Standard values are 0 for switch 0 and 1 for switches 1 to 23. The 
- *   array "switches" needs to be set accordingly by the calling program. 
- *   The arrays sw and swc are set internally.
- *
- *   switches[i]:
- *    i - explanation
- *   -----------------
- *    0 - output in centimeters instead of meters
- *    1 - F10.7 effect on mean
- *    2 - time independent
- *    3 - symmetrical annual
- *    4 - symmetrical semiannual
- *    5 - asymmetrical annual
- *    6 - asymmetrical semiannual
- *    7 - diurnal
- *    8 - semidiurnal
- *    9 - daily ap [when this is set to -1 (!) the pointer
- *                  ap_a in struct nrlmsise_input must
- *                  point to a struct ap_array]
- *   10 - all UT/long effects
- *   11 - longitudinal
- *   12 - UT and mixed UT/long
- *   13 - mixed AP/UT/LONG
- *   14 - terdiurnal
- *   15 - departures from diffusive equilibrium
- *   16 - all TINF var
- *   17 - all TLB var
- *   18 - all TN1 var
- *   19 - all S var
- *   20 - all TN2 var
- *   21 - all NLB var
- *   22 - all TN3 var
- *   23 - turbo scale height var
- */
-
-struct ap_array {
-  double a[7];   
-};
-/* Array containing the following magnetic values:
- *   0 : daily AP
- *   1 : 3 hr AP index for current time
- *   2 : 3 hr AP index for 3 hrs before current time
- *   3 : 3 hr AP index for 6 hrs before current time
- *   4 : 3 hr AP index for 9 hrs before current time
- *   5 : Average of eight 3 hr AP indicies from 12 to 33 hrs 
- *           prior to current time
- *   6 : Average of eight 3 hr AP indicies from 36 to 57 hrs 
- *           prior to current time 
- */
-
-
-struct nrlmsise_input {
-  int year;      /* year, currently ignored                           */
-  int doy;       /* day of year                                       */
-  double sec;    /* seconds in day (UT)                               */
-  double alt;    /* altitude in kilometers                            */
-  double g_lat;  /* geodetic latitude                                 */
-  double g_long; /* geodetic longitude                                */
-  double lst;    /* local apparent solar time (hours), see note below */
-  double f107A;  /* 81 day average of F10.7 flux (centered on DOY)    */
-  double f107;   /* daily F10.7 flux for previous day                 */
-  double ap;     /* magnetic index(daily)                             */
-  struct ap_array *ap_a; /* see above */
-};
-/*
- *   NOTES ON INPUT VARIABLES: 
- *      UT, Local Time, and Longitude are used independently in the
- *      model and are not of equal importance for every situation.  
- *      For the most physically realistic calculation these three
- *      variables should be consistent (lst=sec/3600 + g_long/15).
- *      The Equation of Time departures from the above formula
- *      for apparent local time can be included if available but
- *      are of minor importance.
- *
- *      f107 and f107A values used to generate the model correspond
- *      to the 10.7 cm radio flux at the actual distance of the Earth
- *      from the Sun rather than the radio flux at 1 AU. The following
- *      site provides both classes of values:
- *      ftp://ftp.ngdc.noaa.gov/STP/SOLAR_DATA/SOLAR_RADIO/FLUX/
- *
- *      f107, f107A, and ap effects are neither large nor well
- *      established below 80 km and these parameters should be set to
- *      150., 150., and 4. respectively.
- */
-
-
-
-/* ------------------------------------------------------------------- */
-/* ------------------------------ OUTPUT ----------------------------- */
-/* ------------------------------------------------------------------- */
-
-struct nrlmsise_output {
-  double d[9];   /* densities    */
-  double t[2];   /* temperatures */
-};
-/* 
- *   OUTPUT VARIABLES:
- *      d[0] - HE NUMBER DENSITY(CM-3)
- *      d[1] - O NUMBER DENSITY(CM-3)
- *      d[2] - N2 NUMBER DENSITY(CM-3)
- *      d[3] - O2 NUMBER DENSITY(CM-3)
- *      d[4] - AR NUMBER DENSITY(CM-3)                       
- *      d[5] - TOTAL MASS DENSITY(GM/CM3) [includes d[8] in td7d]
- *      d[6] - H NUMBER DENSITY(CM-3)
- *      d[7] - N NUMBER DENSITY(CM-3)
- *      d[8] - Anomalous oxygen NUMBER DENSITY(CM-3)
- *      t[0] - EXOSPHERIC TEMPERATURE
- *      t[1] - TEMPERATURE AT ALT
- * 
- *
- *      O, H, and N are set to zero below 72.5 km
- *
- *      t[0], Exospheric temperature, is set to global average for
- *      altitudes below 120 km. The 120 km gradient is left at global
- *      average value for altitudes below 72 km.
- *
- *      d[5], TOTAL MASS DENSITY, is NOT the same for subroutines GTD7 
- *      and GTD7D
- *
- *        SUBROUTINE GTD7 -- d[5] is the sum of the mass densities of the
- *        species labeled by indices 0-4 and 6-7 in output variable d.
- *        This includes He, O, N2, O2, Ar, H, and N but does NOT include
- *        anomalous oxygen (species index 8).
- *
- *        SUBROUTINE GTD7D -- d[5] is the "effective total mass density
- *        for drag" and is the sum of the mass densities of all species
- *        in this model, INCLUDING anomalous oxygen.
- */
-
-
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class MSIS : public FGAtmosphere
+class JSBSIM_API FGMSIS : public FGStandardAtmosphere
 {
 public:
 
   /// Constructor
-  MSIS(FGFDMExec*);
+  FGMSIS(FGFDMExec*);
   /// Destructor
-  ~MSIS();
+  ~FGMSIS();
   /** Runs the MSIS-00 atmosphere model; called by the Executive
       Can pass in a value indicating if the executive is directing the simulation to Hold.
       @param Holding if true, the executive has been directed to hold the sim from 
@@ -234,101 +95,58 @@ public:
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
       @return false if no error */
-  bool Run(bool Holding);
 
-  bool InitModel(void);
+  bool InitModel(void) override;
+  bool Load(Element* el) override;
 
-  /// Does nothing. External control is not allowed.
-  void UseExternal(void);
+  using FGAtmosphere::GetTemperature;  // Prevent C++ from hiding GetTemperature(void)
+  double GetTemperature(double altitude) const override {
+    double t, p, rho, R;
+    Compute(altitude, p, t, rho, R);
+    return t;
+  }
+
+  using FGAtmosphere::GetPressure;  // Prevent C++ from hiding GetPressure(void)
+  double GetPressure(double altitude) const override {
+    double t, p, rho, R;
+    Compute(altitude, p, t, rho, R);
+    return p;
+  }
+
+  using FGAtmosphere::GetDensity;  // Prevent C++ from hiding GetDensity(void)
+  double GetDensity(double altitude) const override {
+    double t, p, rho, R;
+    Compute(altitude, p, t, rho, R);
+    return rho;
+  }
+
+  using FGAtmosphere::GetSoundSpeed;  // Prevent C++ from hiding GetSoundSpeed(void)
+  double GetSoundSpeed(double altitude) const override {
+    double t, p, rho, R;
+    Compute(altitude, p, t, rho, R);
+    return sqrt(FGAtmosphere::SHRatio*R*t);
+  }
+
+protected:
+  void Calculate(double altitude) override;
+  void Compute(double altitude, double& pression, double& temperature,
+                double& density, double &Rair) const;
+
+  double day_of_year = 1.0;
+  double seconds_in_day = 0.0;
+
+  mutable struct nrlmsise_flags flags;
+  mutable struct nrlmsise_input input;
 
 private:
-
-  void Calculate(int day,      // day of year (1 to 366) 
-                 double sec,   // seconds in day (0.0 to 86400.0)
-                 double alt,   // altitude, feet
-                 double lat,   // geodetic latitude, degrees
-                 double lon    // geodetic longitude, degrees
-                );
-
-  void Debug(int from);
-
-  nrlmsise_flags flags;
-  nrlmsise_input input;
-  nrlmsise_output output;
-  ap_array aph;
-
-  /* PARMB */
-  double gsurf;
-  double re;
-
-  /* GTS3C */
-  double dd;
-
-  /* DMIX */
-  double dm04, dm16, dm28, dm32, dm40, dm01, dm14;
-
-  /* MESO7 */
-  double meso_tn1[5];
-  double meso_tn2[4];
-  double meso_tn3[5];
-  double meso_tgn1[2];
-  double meso_tgn2[2];
-  double meso_tgn3[2];
-
-  /* LPOLY */
-  double dfa;
-  double plg[4][9];
-  double ctloc, stloc;
-  double c2tloc, s2tloc;
-  double s3tloc, c3tloc;
-  double apdf, apt[4];
-
-  void tselec(struct nrlmsise_flags *flags);
-  void glatf(double lat, double *gv, double *reff);
-  double ccor(double alt, double r, double h1, double zh);
-  double ccor2(double alt, double r, double h1, double zh, double h2);
-  double scalh(double alt, double xm, double temp);
-  double dnet(double dd, double dm, double zhm, double xmm, double xm);
-  void splini(double *xa, double *ya, double *y2a, int n, double x, double *y);
-  void splint(double *xa, double *ya, double *y2a, int n, double x, double *y);
-  void spline(double *x, double *y, int n, double yp1, double ypn, double *y2);
-  double zeta(double zz, double zl);
-  double densm(double alt, double d0, double xm, double *tz, int mn3, double *zn3,
-               double *tn3, double *tgn3, int mn2, double *zn2, double *tn2,
-               double *tgn2);
-  double densu(double alt, double dlb, double tinf, double tlb, double xm, 
-               double alpha, double *tz, double zlb, double s2, int mn1, 
-               double *zn1, double *tn1, double *tgn1);
-  double g0(double a, double *p);
-  double sumex(double ex);
-  double sg0(double ex, double *p, double *ap);
-  double globe7(double *p, nrlmsise_input *input, nrlmsise_flags *flags);
-  double glob7s(double *p, nrlmsise_input *input, nrlmsise_flags *flags);
-
-// GTD7
-// Neutral Atmosphere Empirical Model from the surface to lower exosphere.
-  void gtd7(nrlmsise_input *input, nrlmsise_flags *flags, nrlmsise_output *output);
-
-// GTD7D 
-// This subroutine provides Effective Total Mass Density for output
-// d[5] which includes contributions from "anomalous oxygen" which can
-// affect satellite drag above 500 km. See the section "output" for
-// additional details.
-  void gtd7d(nrlmsise_input *input, nrlmsise_flags *flags, nrlmsise_output *output); 
-
-// GHP7
-// To specify outputs at a pressure level (press) rather than at
-// an altitude.
-  void ghp7(nrlmsise_input *input, nrlmsise_flags *flags, nrlmsise_output *output, double press);
-
-// GTS7
-// Thermospheric portion of NRLMSISE-00
-  void gts7(nrlmsise_input *input, nrlmsise_flags *flags, nrlmsise_output *output); 
-
+  // Setting temperature & pressure is not allowed in this model.
+  void SetTemperature(double t, double h, eTemperature unit) override {};
+  void SetTemperatureSL(double t, eTemperature unit) override {};
+  void SetPressureSL(ePressure unit, double pressure) override {};
+  void Debug(int from) override;
 };
 
 } // namespace JSBSim
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 #endif
-

--- a/src/models/atmosphere/FGStandardAtmosphere.cpp
+++ b/src/models/atmosphere/FGStandardAtmosphere.cpp
@@ -59,7 +59,7 @@ CLASS IMPLEMENTATION
 FGStandardAtmosphere::FGStandardAtmosphere(FGFDMExec* fdmex)
   : FGAtmosphere(fdmex), StdSLpressure(StdDaySLpressure), TemperatureBias(0.0),
     TemperatureDeltaGradient(0.0), VaporMassFraction(0.0),
-    SaturatedVaporPressure(0.0), StdAtmosTemperatureTable(9),
+    SaturatedVaporPressure(StdDaySLpressure), StdAtmosTemperatureTable(9),
     MaxVaporMassFraction(10)
 {
   Name = "FGStandardAtmosphere";

--- a/src/models/atmosphere/FGStandardAtmosphere.h
+++ b/src/models/atmosphere/FGStandardAtmosphere.h
@@ -95,7 +95,7 @@ will be consistently and accurately calculated.
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class FGStandardAtmosphere : public FGAtmosphere {
+class JSBSIM_API FGStandardAtmosphere : public FGAtmosphere {
 public:
   /// Constructor
   FGStandardAtmosphere(FGFDMExec*);

--- a/src/models/atmosphere/MSIS/CMakeLists.txt
+++ b/src/models/atmosphere/MSIS/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required (VERSION 3.1)
+
+project(NRLMSIS)
+
+# NRLMSIS-00 C package
+add_executable(nrlmsise-test nrlmsise-00.c nrlmsise-00_data.c nrlmsise-00_test.c)
+target_link_libraries(nrlmsise-test m)

--- a/src/models/atmosphere/MSIS/DOCUMENTATION
+++ b/src/models/atmosphere/MSIS/DOCUMENTATION
@@ -1,0 +1,275 @@
+--------------------------------------------------------------------
+---------  N R L M S I S E - 0 0    M O D E L    2 0 0 1  ----------
+--------------------------------------------------------------------
+
+
+Table of Contents
+-----------------
+
+1. Legal Information
+2. Brief Description
+3. Source Code Availability
+4. This C Release
+    4.1  Files
+    4.2  Differences between FORTRAN and C version
+5. Interface
+6. Release Notes
+7. Testing Output
+
+
+
+1. LEGAL INFORMATION
+====================
+
+This package is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Please inform the
+maintainer of the C release (Dominik Brodowski - mail@brodo.de) of
+any patches and bug-fixes you implement for NRLMSISE-00 so that this C
+package can be updated with these improvements.
+
+
+
+2. BRIEF DESCRIPTION
+====================
+
+The NRLMSIS-00 empirical atmosphere model was developed by Mike
+Picone, Alan Hedin, and Doug Drob based on the MSISE90 model.
+
+The MSISE90 model describes the neutral temperature and densities in
+Earth's atmosphere from ground to thermospheric heights. Below 72.5 km
+the model is primarily based on the MAP Handbook (Labitzke et al.,
+1985) tabulation of zonal average temperature and pressure by Barnett
+and Corney, which was also used for the CIRA-86. Below 20 km these
+data were supplemented with averages from the National Meteorological
+Center (NMC). In addition, pitot tube, falling sphere, and grenade
+sounder rocket measurements from 1947 to 1972 were taken into
+consideration. Above 72.5 km MSISE-90 is essentially a revised MSIS-86
+model taking into account data derived from space shuttle flights and
+newer incoherent scatter results. For someone interested only in the
+thermosphere (above 120 km), the author recommends the MSIS-86
+model. MSISE is also not the model of preference for specialized
+tropospheric work. It is rather for studies that reach across several
+atmospheric boundaries.
+(quoted from http://nssdc.gsfc.nasa.gov/space/model/atmos/nrlmsise00.html)
+
+
+
+3. SOURCE CODE AVAILABILITY
+===========================
+
+The authors of the NRLMSISE-00 model have released a FORTRAN version
+which is available at
+http://uap-www.nrl.navy.mil/models_web/msis/msis_home.htm
+
+Based on the Official Beta Release 1.0 (NRLMSISE-00.DIST12.TXT)
+Dominik Brodowski wrote an implementation in C which is available on
+http://www.brodo.de/english/pub/nrlmsise/
+This release is based on the Official Beta Release 2.0 
+(NRLMSISE-00.DIST17.TXT).
+
+
+
+4. THIS C RELEASE
+=================
+
+When "INLINE" is not externally defined the source code should be
+clean, plain ANSI which any C compiler should be able to work with. If
+you find any problems, please report them to the maintainer Dominik
+Brodowski at mail@brodo.de. Thank you!
+
+
+4.1 Files
+---------
+
+DOCUMENTATION      - this Documentation
+nrlmsise-00.h      - header file for nrlmsise-00
+nrlmsise-00.c      - source code for nrlmsise-00
+nrlmsise-00_data.c - block data for nrlmsise-00
+nrlmsise-00_test.c - test-driver for nrlmsise-00
+makefile           - makefile for nrlmsise-test (gnu-make and gcc)
+
+
+4.2 Differences between FORTRAN and C version
+---------------------------------------------
+
+The C package does not save the last results internally to speed up
+program execution as the FORTRAN version does.
+
+The "switches" have to be specified before _every_ call.
+
+The "DL" array is not printed in the testing routine since it's not an
+output value.
+
+The C version probably contains some bugs and still has to be regarded
+more unstable than the FORTRAN release. Please report any bugs or
+incorrect values to the maintainer at mail@brodo.de
+
+
+
+5. INTERFACE
+============
+
+To access the NRLMSISE-00 functions you need to include the header
+file nrlmsise-00.h. In this file you can find comments which explain
+the in- and output, and the differences between the various functions.
+
+
+
+6. RELEASE NOTES
+================
+
+20020302	-	first release
+
+20040322	-	fix gtd7d output if sw->flags[0] is set 
+			(noted by Dr. Vasiliy Yurasov)
+
+20041227	-	bugfix against memory corruption 
+			(Donald F. Linton)
+
+20070727	-	bugfix concerning DFA being masked
+			(Stacey Gage)
+
+20100516	-	bugfix concerning Argon densities
+			(Dr. Choliy Vasyl)
+
+20131225	-	fix comment on switch 0, silence compiler warnings
+			(David F. Crouse)
+
+20150329	-	use fabs() instead of abs()
+			(David F. Crouse)
+
+20151122	-	fixes for gcc5, spelling fixes
+			(Jacco Geul)
+
+20170830	-	fix some compiler warninges
+			(noted by Steven Queen)
+
+20190709		fix output at 32.5 km
+			(Yoshiaki Ando)
+
+
+7. TESTING OUTPUT
+=================
+
+nrlmsise-test should generate the following output:
+
+
+
+6.665177E+05 1.138806E+08 1.998211E+07 4.022764E+05 3.557465E+03 4.074714E-15 3.475312E+04 4.095913E+06 2.667273E+04 1.250540E+03 1.241416E+03 
+
+3.407293E+06 1.586333E+08 1.391117E+07 3.262560E+05 1.559618E+03 5.001846E-15 4.854208E+04 4.380967E+06 6.956682E+03 1.166754E+03 1.161710E+03 
+
+1.123767E+05 6.934130E+04 4.247105E+01 1.322750E-01 2.618848E-05 2.756772E-18 2.016750E+04 5.741256E+03 2.374394E+04 1.239892E+03 1.239891E+03 
+
+5.411554E+07 1.918893E+11 6.115826E+12 1.225201E+12 6.023212E+10 3.584426E-10 1.059880E+07 2.615737E+05 2.819879E-42 1.027318E+03 2.068878E+02 
+
+1.851122E+06 1.476555E+08 1.579356E+07 2.633795E+05 1.588781E+03 4.809630E-15 5.816167E+04 5.478984E+06 1.264446E+03 1.212396E+03 1.208135E+03 
+
+8.673095E+05 1.278862E+08 1.822577E+07 2.922214E+05 2.402962E+03 4.355866E-15 3.686389E+04 3.897276E+06 2.667273E+04 1.220146E+03 1.212712E+03 
+
+5.776251E+05 6.979139E+07 1.236814E+07 2.492868E+05 1.405739E+03 2.470651E-15 5.291986E+04 1.069814E+06 2.667273E+04 1.116385E+03 1.112999E+03 
+
+3.740304E+05 4.782720E+07 5.240380E+06 1.759875E+05 5.501649E+02 1.571889E-15 8.896776E+04 1.979741E+06 9.121815E+03 1.031247E+03 1.024848E+03 
+
+6.748339E+05 1.245315E+08 2.369010E+07 4.911583E+05 4.578781E+03 4.564420E-15 3.244595E+04 5.370833E+06 2.667273E+04 1.306052E+03 1.293374E+03 
+
+5.528601E+05 1.198041E+08 3.495798E+07 9.339618E+05 1.096255E+04 4.974543E-15 2.686428E+04 4.889974E+06 2.805445E+04 1.361868E+03 1.347389E+03 
+
+1.375488E+14 0.000000E+00 2.049687E+19 5.498695E+18 2.451733E+17 1.261066E-03 0.000000E+00 0.000000E+00 0.000000E+00 1.027318E+03 2.814648E+02 
+
+4.427443E+13 0.000000E+00 6.597567E+18 1.769929E+18 7.891680E+16 4.059139E-04 0.000000E+00 0.000000E+00 0.000000E+00 1.027318E+03 2.274180E+02 
+
+2.127829E+12 0.000000E+00 3.170791E+17 8.506280E+16 3.792741E+15 1.950822E-05 0.000000E+00 0.000000E+00 0.000000E+00 1.027318E+03 2.374389E+02 
+
+1.412184E+11 0.000000E+00 2.104370E+16 5.645392E+15 2.517142E+14 1.294709E-06 0.000000E+00 0.000000E+00 0.000000E+00 1.027318E+03 2.795551E+02 
+
+1.254884E+10 0.000000E+00 1.874533E+15 4.923051E+14 2.239685E+13 1.147668E-07 0.000000E+00 0.000000E+00 0.000000E+00 1.027318E+03 2.190732E+02 
+
+5.196477E+05 1.274494E+08 4.850450E+07 1.720838E+06 2.354487E+04 5.881940E-15 2.500078E+04 6.279210E+06 2.667273E+04 1.426412E+03 1.408608E+03 
+
+4.260860E+07 1.241342E+11 4.929562E+12 1.048407E+12 4.993465E+10 2.914304E-10 8.831229E+06 2.252516E+05 2.415246E-42 1.027318E+03 1.934071E+02 
+
+
+DAY            172          81         172         172         172
+UT           29000       29000       75000       29000       29000
+ALT            400         400        1000         100         400
+LAT             60          60          60          60           0
+LONG           -70         -70         -70         -70         -70
+LST             16          16          16          16          16
+F107A          150         150         150         150         150
+F107           150         150         150         150         150
+
+
+TINF       1250.54     1166.75     1239.89     1027.32     1212.40
+TG         1241.42     1161.71     1239.89      206.89     1208.14
+HE       6.665e+05   3.407e+06   1.124e+05   5.412e+07   1.851e+06
+O        1.139e+08   1.586e+08   6.934e+04   1.919e+11   1.477e+08
+N2       1.998e+07   1.391e+07   4.247e+01   6.116e+12   1.579e+07
+O2       4.023e+05   3.263e+05   1.323e-01   1.225e+12   2.634e+05
+AR       3.557e+03   1.560e+03   2.619e-05   6.023e+10   1.589e+03
+H        3.475e+04   4.854e+04   2.017e+04   1.060e+07   5.816e+04
+N        4.096e+06   4.381e+06   5.741e+03   2.616e+05   5.479e+06
+ANM 0    2.667e+04   6.957e+03   2.374e+04   2.820e-42   1.264e+03
+RHO      4.075e-15   5.002e-15   2.757e-18   3.584e-10   4.810e-15
+
+
+DAY            172         172         172         172         172
+UT           29000       29000       29000       29000       29000
+ALT            400         400         400         400         400
+LAT             60          60          60          60          60
+LONG             0         -70         -70         -70         -70
+LST             16           4          16          16          16
+F107A          150         150          70         150         150
+F107           150         150         150         180         150
+
+
+TINF       1220.15     1116.39     1031.25     1306.05     1361.87
+TG         1212.71     1113.00     1024.85     1293.37     1347.39
+HE       8.673e+05   5.776e+05   3.740e+05   6.748e+05   5.529e+05
+O        1.279e+08   6.979e+07   4.783e+07   1.245e+08   1.198e+08
+N2       1.823e+07   1.237e+07   5.240e+06   2.369e+07   3.496e+07
+O2       2.922e+05   2.493e+05   1.760e+05   4.912e+05   9.340e+05
+AR       2.403e+03   1.406e+03   5.502e+02   4.579e+03   1.096e+04
+H        3.686e+04   5.292e+04   8.897e+04   3.245e+04   2.686e+04
+N        3.897e+06   1.070e+06   1.980e+06   5.371e+06   4.890e+06
+ANM 0    2.667e+04   2.667e+04   9.122e+03   2.667e+04   2.805e+04
+RHO      4.356e-15   2.471e-15   1.572e-15   4.564e-15   4.975e-15
+
+
+DAY            172         172         172         172         172
+UT           29000       29000       29000       29000       29000
+ALT              0          10          30          50          70
+LAT             60          60          60          60          60
+LONG           -70         -70         -70         -70         -70
+LST             16          16          16          16          16
+F107A          150         150         150         150         150
+F107           150         150         150         150         150
+
+
+TINF       1027.32     1027.32     1027.32     1027.32     1027.32
+TG          281.46      227.42      237.44      279.56      219.07
+HE       1.375e+14   4.427e+13   2.128e+12   1.412e+11   1.255e+10
+O        0.000e+00   0.000e+00   0.000e+00   0.000e+00   0.000e+00
+N2       2.050e+19   6.598e+18   3.171e+17   2.104e+16   1.875e+15
+O2       5.499e+18   1.770e+18   8.506e+16   5.645e+15   4.923e+14
+AR       2.452e+17   7.892e+16   3.793e+15   2.517e+14   2.240e+13
+H        0.000e+00   0.000e+00   0.000e+00   0.000e+00   0.000e+00
+N        0.000e+00   0.000e+00   0.000e+00   0.000e+00   0.000e+00
+ANM 0    0.000e+00   0.000e+00   0.000e+00   0.000e+00   0.000e+00
+RHO      1.261e-03   4.059e-04   1.951e-05   1.295e-06   1.148e-07
+
+
+Note: These values equal those of the official FORTRAN package with
+one notable exception: the FORTRAN version reports for "anomalous
+oxygen" in test-run 4 exactly 0.000E-00, while my C compiler
+generates code which calculates 2.820e-42. When only 16-bit wide
+double variables are used, this value reduces to 0.000E-00 as well.
+
+
+
+========================================================
+
+Frankfurt, Germany, on August 30, 2017
+
+Dominik Brodowski

--- a/src/models/atmosphere/MSIS/nrlmsise-00.c
+++ b/src/models/atmosphere/MSIS/nrlmsise-00.c
@@ -1,0 +1,1459 @@
+/* -------------------------------------------------------------------- */
+/* ---------  N R L M S I S E - 0 0    M O D E L    2 0 0 1  ---------- */
+/* -------------------------------------------------------------------- */
+
+/* This file is part of the NRLMSISE-00  C source code package - release
+ * 20041227
+ *
+ * The NRLMSISE-00 model was developed by Mike Picone, Alan Hedin, and
+ * Doug Drob. They also wrote a NRLMSISE-00 distribution package in
+ * FORTRAN which is available at
+ * http://uap-www.nrl.navy.mil/models_web/msis/msis_home.htm
+ *
+ * Dominik Brodowski implemented and maintains this C version. You can
+ * reach him at mail@brodo.de. See the file "DOCUMENTATION" for details,
+ * and check http://www.brodo.de/english/pub/nrlmsise/index.html for
+ * updated releases of this package.
+ */
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------ INCLUDES --------------------------- */
+/* ------------------------------------------------------------------- */
+
+#include "nrlmsise-00.h"   /* header for nrlmsise-00.h */
+#include <math.h>          /* maths functions */
+#include <stdio.h>         /* for error messages. TBD: remove this */
+#include <stdlib.h>        /* for malloc/free */
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------- SHARED VARIABLES ------------------------ */
+/* ------------------------------------------------------------------- */
+
+/* PARMB */
+static double gsurf;
+static double re;
+
+/* GTS3C */
+static double dd;
+
+/* DMIX */
+static double dm04, dm16, dm28, dm32, dm40, dm01, dm14;
+
+/* MESO7 */
+static double meso_tn1[5];
+static double meso_tn2[4];
+static double meso_tn3[5];
+static double meso_tgn1[2];
+static double meso_tgn2[2];
+static double meso_tgn3[2];
+
+/* POWER7 */
+extern double pt[150];
+extern double pd[9][150];
+extern double ps[150];
+extern double pdl[2][25];
+extern double ptl[4][100];
+extern double pma[10][100];
+extern double sam[100];
+
+/* LOWER7 */
+extern double ptm[10];
+extern double pdm[8][10];
+extern double pavgm[10];
+
+/* LPOLY */
+static double dfa;
+static double plg[4][9];
+static double ctloc, stloc;
+static double c2tloc, s2tloc;
+static double s3tloc, c3tloc;
+static double apdf, apt[4];
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------ TSELEC ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+void tselec(struct nrlmsise_flags *flags) {
+	int i;
+	for (i=0;i<24;i++) {
+		if (i!=9) {
+			if (flags->switches[i]==1)
+				flags->sw[i]=1;
+			else
+				flags->sw[i]=0;
+			if (flags->switches[i]>0)
+				flags->swc[i]=1;
+			else
+				flags->swc[i]=0;
+		} else {
+			flags->sw[i]=flags->switches[i];
+			flags->swc[i]=flags->switches[i];
+		}
+	}
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------ GLATF ------------------------------ */
+/* ------------------------------------------------------------------- */
+
+void glatf(double lat, double *gv, double *reff) {
+	double dgtr = 1.74533E-2;
+	double c2;
+	c2 = cos(2.0*dgtr*lat);
+	*gv = 980.616 * (1.0 - 0.0026373 * c2);
+	*reff = 2.0 * (*gv) / (3.085462E-6 + 2.27E-9 * c2) * 1.0E-5;
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------ CCOR ------------------------------- */
+/* ------------------------------------------------------------------- */
+
+double ccor(double alt, double r, double h1, double zh) {
+/*        CHEMISTRY/DISSOCIATION CORRECTION FOR MSIS MODELS
+ *         ALT - altitude
+ *         R - target ratio
+ *         H1 - transition scale length
+ *         ZH - altitude of 1/2 R
+ */
+	double e;
+	double ex;
+	e = (alt - zh) / h1;
+	if (e>70)
+		return exp(0);
+	if (e<-70)
+		return exp(r);
+	ex = exp(e);
+	e = r / (1.0 + ex);
+	return exp(e);
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------ CCOR ------------------------------- */
+/* ------------------------------------------------------------------- */
+
+double ccor2(double alt, double r, double h1, double zh, double h2) {
+/*        CHEMISTRY/DISSOCIATION CORRECTION FOR MSIS MODELS
+ *         ALT - altitude
+ *         R - target ratio
+ *         H1 - transition scale length
+ *         ZH - altitude of 1/2 R
+ *         H2 - transition scale length #2 ?
+ */
+	double e1, e2;
+	double ex1, ex2;
+	double ccor2v;
+	e1 = (alt - zh) / h1;
+	e2 = (alt - zh) / h2;
+	if ((e1 > 70) || (e2 > 70))
+		return exp(0);
+	if ((e1 < -70) && (e2 < -70))
+		return exp(r);
+	ex1 = exp(e1);
+	ex2 = exp(e2);
+	ccor2v = r / (1.0 + 0.5 * (ex1 + ex2));
+	return exp(ccor2v);
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- SCALH ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+double scalh(double alt, double xm, double temp) {
+	double g;
+	double rgas=831.4;
+	g = gsurf / (pow((1.0 + alt/re),2.0));
+	g = rgas * temp / (g * xm);
+	return g;
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* -------------------------------- DNET ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+double dnet (double dd, double dm, double zhm, double xmm, double xm) {
+/*       TURBOPAUSE CORRECTION FOR MSIS MODELS
+ *        Root mean density
+ *         DD - diffusive density
+ *         DM - full mixed density
+ *         ZHM - transition scale length
+ *         XMM - full mixed molecular weight
+ *         XM  - species molecular weight
+ *         DNET - combined density
+ */
+	double a;
+	double ylog;
+	a  = zhm / (xmm-xm);
+	if (!((dm>0) && (dd>0))) {
+		printf("dnet log error %e %e %e\n",dm,dd,xm);
+		if ((dd==0) && (dm==0))
+			dd=1;
+		if (dm==0)
+			return dd;
+		if (dd==0)
+			return dm;
+	} 
+	ylog = a * log(dm/dd);
+	if (ylog<-10)
+		return dd;
+	if (ylog>10)
+		return dm;
+	a = dd*pow((1.0 + exp(ylog)),(1.0/a));
+	return a;
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- SPLINI ---------------------------- */
+/* ------------------------------------------------------------------- */
+
+void splini (double *xa, double *ya, double *y2a, int n, double x, double *y) {
+/*      INTEGRATE CUBIC SPLINE FUNCTION FROM XA(1) TO X
+ *       XA,YA: ARRAYS OF TABULATED FUNCTION IN ASCENDING ORDER BY X
+ *       Y2A: ARRAY OF SECOND DERIVATIVES
+ *       N: SIZE OF ARRAYS XA,YA,Y2A
+ *       X: ABSCISSA ENDPOINT FOR INTEGRATION
+ *       Y: OUTPUT VALUE
+ */
+	double yi=0;
+	int klo=0;
+	int khi=1;
+	double xx, h, a, b, a2, b2;
+	while ((x>xa[klo]) && (khi<n)) {
+		xx=x;
+		if (khi<(n-1)) {
+			if (x<xa[khi])
+				xx=x;
+			else 
+				xx=xa[khi];
+		}
+		h = xa[khi] - xa[klo];
+		a = (xa[khi] - xx)/h;
+		b = (xx - xa[klo])/h;
+		a2 = a*a;
+		b2 = b*b;
+		yi += ((1.0 - a2) * ya[klo] / 2.0 + b2 * ya[khi] / 2.0 + ((-(1.0+a2*a2)/4.0 + a2/2.0) * y2a[klo] + (b2*b2/4.0 - b2/2.0) * y2a[khi]) * h * h / 6.0) * h;
+		klo++;
+		khi++;
+	}
+	*y = yi;
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- SPLINT ---------------------------- */
+/* ------------------------------------------------------------------- */
+
+void splint (double *xa, double *ya, double *y2a, int n, double x, double *y) {
+/*      CALCULATE CUBIC SPLINE INTERP VALUE
+ *       ADAPTED FROM NUMERICAL RECIPES BY PRESS ET AL.
+ *       XA,YA: ARRAYS OF TABULATED FUNCTION IN ASCENDING ORDER BY X
+ *       Y2A: ARRAY OF SECOND DERIVATIVES
+ *       N: SIZE OF ARRAYS XA,YA,Y2A
+ *       X: ABSCISSA FOR INTERPOLATION
+ *       Y: OUTPUT VALUE
+ */
+	int klo=0;
+	int khi=n-1;
+	int k;
+	double h;
+	double a, b, yi;
+	while ((khi-klo)>1) {
+		k=(khi+klo)/2;
+		if (xa[k]>x)
+			khi=k;
+		else
+			klo=k;
+	}
+	h = xa[khi] - xa[klo];
+	if (h==0.0)
+		printf("bad XA input to splint");
+	a = (xa[khi] - x)/h;
+	b = (x - xa[klo])/h;
+	yi = a * ya[klo] + b * ya[khi] + ((a*a*a - a) * y2a[klo] + (b*b*b - b) * y2a[khi]) * h * h/6.0;
+	*y = yi;
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- SPLINE ---------------------------- */
+/* ------------------------------------------------------------------- */
+
+void spline (double *x, double *y, int n, double yp1, double ypn, double *y2) {
+/*       CALCULATE 2ND DERIVATIVES OF CUBIC SPLINE INTERP FUNCTION
+ *       ADAPTED FROM NUMERICAL RECIPES BY PRESS ET AL
+ *       X,Y: ARRAYS OF TABULATED FUNCTION IN ASCENDING ORDER BY X
+ *       N: SIZE OF ARRAYS X,Y
+ *       YP1,YPN: SPECIFIED DERIVATIVES AT X[0] AND X[N-1]; VALUES
+ *                >= 1E30 SIGNAL SIGNAL SECOND DERIVATIVE ZERO
+ *       Y2: OUTPUT ARRAY OF SECOND DERIVATIVES
+ */
+	double *u;
+	double sig, p, qn, un;
+	int i, k;
+	u=malloc(sizeof(double)*(unsigned int)n);
+	if (u==NULL) {
+		printf("Out Of Memory in spline - ERROR");
+		return;
+	}
+	if (yp1>0.99E30) {
+		y2[0]=0;
+		u[0]=0;
+	} else {
+		y2[0]=-0.5;
+		u[0]=(3.0/(x[1]-x[0]))*((y[1]-y[0])/(x[1]-x[0])-yp1);
+	}
+	for (i=1;i<(n-1);i++) {
+		sig = (x[i]-x[i-1])/(x[i+1] - x[i-1]);
+		p = sig * y2[i-1] + 2.0;
+		y2[i] = (sig - 1.0) / p;
+		u[i] = (6.0 * ((y[i+1] - y[i])/(x[i+1] - x[i]) -(y[i] - y[i-1]) / (x[i] - x[i-1]))/(x[i+1] - x[i-1]) - sig * u[i-1])/p;
+	}
+	if (ypn>0.99E30) {
+		qn = 0;
+		un = 0;
+	} else {
+		qn = 0.5;
+		un = (3.0 / (x[n-1] - x[n-2])) * (ypn - (y[n-1] - y[n-2])/(x[n-1] - x[n-2]));
+	}
+	y2[n-1] = (un - qn * u[n-2]) / (qn * y2[n-2] + 1.0);
+	for (k=n-2;k>=0;k--)
+		y2[k] = y2[k] * y2[k+1] + u[k];
+
+	free(u);
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- DENSM ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+__inline_double zeta(double zz, double zl) {
+	return ((zz-zl)*(re+zl)/(re+zz));
+}
+
+double densm (double alt, double d0, double xm, double *tz, int mn3, double *zn3, double *tn3, double *tgn3, int mn2, double *zn2, double *tn2, double *tgn2) {
+/*      Calculate Temperature and Density Profiles for lower atmos.  */
+	double xs[10], ys[10], y2out[10];
+	double rgas = 831.4;
+	double z, z1, z2, t1, t2, zg, zgdif;
+	double yd1, yd2;
+	double x, y, yi;
+	double expl, gamm, glb;
+	double densm_tmp;
+	int mn;
+	int k;
+	densm_tmp=d0;
+	if (alt>zn2[0]) {
+		if (xm==0.0)
+			return *tz;
+		else
+			return d0;
+	}
+
+	/* STRATOSPHERE/MESOSPHERE TEMPERATURE */
+	if (alt>zn2[mn2-1])
+		z=alt;
+	else
+		z=zn2[mn2-1];
+	mn=mn2;
+	z1=zn2[0];
+	z2=zn2[mn-1];
+	t1=tn2[0];
+	t2=tn2[mn-1];
+	zg = zeta(z, z1);
+	zgdif = zeta(z2, z1);
+
+	/* set up spline nodes */
+	for (k=0;k<mn;k++) {
+		xs[k]=zeta(zn2[k],z1)/zgdif;
+		ys[k]=1.0 / tn2[k];
+	}
+	yd1=-tgn2[0] / (t1*t1) * zgdif;
+	yd2=-tgn2[1] / (t2*t2) * zgdif * (pow(((re+z2)/(re+z1)),2.0));
+
+	/* calculate spline coefficients */
+	spline (xs, ys, mn, yd1, yd2, y2out);
+	x = zg/zgdif;
+	splint (xs, ys, y2out, mn, x, &y);
+
+	/* temperature at altitude */
+	*tz = 1.0 / y;
+	if (xm!=0.0) {
+		/* calaculate stratosphere / mesospehere density */
+		glb = gsurf / (pow((1.0 + z1/re),2.0));
+		gamm = xm * glb * zgdif / rgas;
+
+		/* Integrate temperature profile */
+		splini(xs, ys, y2out, mn, x, &yi);
+		expl=gamm*yi;
+		if (expl>50.0)
+			expl=50.0;
+
+		/* Density at altitude */
+		densm_tmp = densm_tmp * (t1 / *tz) * exp(-expl);
+	}
+
+	if (alt>zn3[0]) {
+		if (xm==0.0)
+			return *tz;
+		else
+			return densm_tmp;
+	}
+
+	/* troposhere / stratosphere temperature */
+	z = alt;
+	mn = mn3;
+	z1=zn3[0];
+	z2=zn3[mn-1];
+	t1=tn3[0];
+	t2=tn3[mn-1];
+	zg=zeta(z,z1);
+	zgdif=zeta(z2,z1);
+
+	/* set up spline nodes */
+	for (k=0;k<mn;k++) {
+		xs[k] = zeta(zn3[k],z1) / zgdif;
+		ys[k] = 1.0 / tn3[k];
+	}
+	yd1=-tgn3[0] / (t1*t1) * zgdif;
+	yd2=-tgn3[1] / (t2*t2) * zgdif * (pow(((re+z2)/(re+z1)),2.0));
+
+	/* calculate spline coefficients */
+	spline (xs, ys, mn, yd1, yd2, y2out);
+	x = zg/zgdif;
+	splint (xs, ys, y2out, mn, x, &y);
+
+	/* temperature at altitude */
+	*tz = 1.0 / y;
+	if (xm!=0.0) {
+		/* calaculate tropospheric / stratosphere density */
+		glb = gsurf / (pow((1.0 + z1/re),2.0));
+		gamm = xm * glb * zgdif / rgas;
+
+		/* Integrate temperature profile */
+		splini(xs, ys, y2out, mn, x, &yi);
+		expl=gamm*yi;
+		if (expl>50.0)
+			expl=50.0;
+
+		/* Density at altitude */
+		densm_tmp = densm_tmp * (t1 / *tz) * exp(-expl);
+	}
+	if (xm==0.0)
+		return *tz;
+	else
+		return densm_tmp;
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- DENSU ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+double densu (double alt, double dlb, double tinf, double tlb, double xm, double alpha, double *tz, double zlb, double s2, int mn1, double *zn1, double *tn1, double *tgn1) {
+/*      Calculate Temperature and Density Profiles for MSIS models
+ *      New lower thermo polynomial
+ */
+	double yd2, yd1, x=0, y;
+	double rgas=831.4;
+	double densu_temp=1.0;
+	double za, z, zg2, tt, ta;
+	double dta, z1=0, z2, t1=0, t2, zg, zgdif=0;
+	int mn=0;
+	int k;
+	double glb;
+	double expl;
+	double yi;
+	double densa;
+	double gamma, gamm;
+	double xs[5], ys[5], y2out[5];
+	/* joining altitudes of Bates and spline */
+	za=zn1[0];
+	if (alt>za)
+		z=alt;
+	else
+		z=za;
+
+	/* geopotential altitude difference from ZLB */
+	zg2 = zeta(z, zlb);
+
+	/* Bates temperature */
+	tt = tinf - (tinf - tlb) * exp(-s2*zg2);
+	ta = tt;
+	*tz = tt;
+	densu_temp = *tz;
+
+	if (alt<za) {
+		/* calculate temperature below ZA
+		 * temperature gradient at ZA from Bates profile */
+		dta = (tinf - ta) * s2 * pow(((re+zlb)/(re+za)),2.0);
+		tgn1[0]=dta;
+		tn1[0]=ta;
+		if (alt>zn1[mn1-1])
+			z=alt;
+		else
+			z=zn1[mn1-1];
+		mn=mn1;
+		z1=zn1[0];
+		z2=zn1[mn-1];
+		t1=tn1[0];
+		t2=tn1[mn-1];
+		/* geopotental difference from z1 */
+		zg = zeta (z, z1);
+		zgdif = zeta(z2, z1);
+		/* set up spline nodes */
+		for (k=0;k<mn;k++) {
+			xs[k] = zeta(zn1[k], z1) / zgdif;
+			ys[k] = 1.0 / tn1[k];
+		}
+		/* end node derivatives */
+		yd1 = -tgn1[0] / (t1*t1) * zgdif;
+		yd2 = -tgn1[1] / (t2*t2) * zgdif * pow(((re+z2)/(re+z1)),2.0);
+		/* calculate spline coefficients */
+		spline (xs, ys, mn, yd1, yd2, y2out);
+		x = zg / zgdif;
+		splint (xs, ys, y2out, mn, x, &y);
+		/* temperature at altitude */
+		*tz = 1.0 / y;
+		densu_temp = *tz;
+	}
+	if (xm==0)
+		return densu_temp;
+
+	/* calculate density above za */
+	glb = gsurf / pow((1.0 + zlb/re),2.0);
+	gamma = xm * glb / (s2 * rgas * tinf);
+	expl = exp(-s2 * gamma * zg2);
+	if (expl>50.0)
+  		expl=50.0;
+	if (tt<=0)
+		expl=50.0;
+
+	/* density at altitude */
+	densa = dlb * pow((tlb/tt),((1.0+alpha+gamma))) * expl;
+	densu_temp=densa;
+	if (alt>=za)
+		return densu_temp;
+
+	/* calculate density below za */
+	glb = gsurf / pow((1.0 + z1/re),2.0);
+	gamm = xm * glb * zgdif / rgas;
+
+	/* integrate spline temperatures */
+	splini (xs, ys, y2out, mn, x, &yi);
+	expl = gamm * yi;
+	if (expl>50.0)
+		expl=50.0;
+	if (*tz<=0)
+		expl=50.0;
+
+	/* density at altitude */
+	densu_temp = densu_temp * pow ((t1 / *tz),(1.0 + alpha)) * exp(-expl);
+	return densu_temp;
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- GLOBE7 ---------------------------- */
+/* ------------------------------------------------------------------- */
+
+/*    3hr Magnetic activity functions */
+/*    Eq. A24d */
+__inline_double g0(double a, double *p) {
+	return (a - 4.0 + (p[25] - 1.0) * (a - 4.0 + (exp(-sqrt(p[24]*p[24]) * (a - 4.0)) - 1.0) / sqrt(p[24]*p[24])));
+}
+
+/*    Eq. A24c */
+__inline_double sumex(double ex) {
+	return (1.0 + (1.0 - pow(ex,19.0)) / (1.0 - ex) * pow(ex,0.5));
+}
+
+/*    Eq. A24a */
+__inline_double sg0(double ex, double *p, double *ap) {
+	return (g0(ap[1],p) + (g0(ap[2],p)*ex + g0(ap[3],p)*ex*ex + \
+                g0(ap[4],p)*pow(ex,3.0)	+ (g0(ap[5],p)*pow(ex,4.0) + \
+                g0(ap[6],p)*pow(ex,12.0))*(1.0-pow(ex,8.0))/(1.0-ex)))/sumex(ex);
+}
+
+double globe7(double *p, struct nrlmsise_input *input, struct nrlmsise_flags *flags) {
+/*       CALCULATE G(L) FUNCTION 
+ *       Upper Thermosphere Parameters */
+	double t[15];
+	int i,j;
+	double apd;
+	double tloc;
+	double c, s, c2, c4, s2;
+	double sr = 7.2722E-5;
+	double dgtr = 1.74533E-2;
+	double dr = 1.72142E-2;
+	double hr = 0.2618;
+	double cd32, cd18, cd14, cd39;
+	double df;
+	double f1, f2;
+	double tinf;
+	struct ap_array *ap;
+
+	tloc=input->lst;
+	for (j=0;j<14;j++)
+		t[j]=0;
+
+	/* calculate legendre polynomials */
+	c = sin(input->g_lat * dgtr);
+	s = cos(input->g_lat * dgtr);
+	c2 = c*c;
+	c4 = c2*c2;
+	s2 = s*s;
+
+	plg[0][1] = c;
+	plg[0][2] = 0.5*(3.0*c2 -1.0);
+	plg[0][3] = 0.5*(5.0*c*c2-3.0*c);
+	plg[0][4] = (35.0*c4 - 30.0*c2 + 3.0)/8.0;
+	plg[0][5] = (63.0*c2*c2*c - 70.0*c2*c + 15.0*c)/8.0;
+	plg[0][6] = (11.0*c*plg[0][5] - 5.0*plg[0][4])/6.0;
+/*      plg[0][7] = (13.0*c*plg[0][6] - 6.0*plg[0][5])/7.0; */
+	plg[1][1] = s;
+	plg[1][2] = 3.0*c*s;
+	plg[1][3] = 1.5*(5.0*c2-1.0)*s;
+	plg[1][4] = 2.5*(7.0*c2*c-3.0*c)*s;
+	plg[1][5] = 1.875*(21.0*c4 - 14.0*c2 +1.0)*s;
+	plg[1][6] = (11.0*c*plg[1][5]-6.0*plg[1][4])/5.0;
+/*      plg[1][7] = (13.0*c*plg[1][6]-7.0*plg[1][5])/6.0; */
+/*      plg[1][8] = (15.0*c*plg[1][7]-8.0*plg[1][6])/7.0; */
+	plg[2][2] = 3.0*s2;
+	plg[2][3] = 15.0*s2*c;
+	plg[2][4] = 7.5*(7.0*c2 -1.0)*s2;
+	plg[2][5] = 3.0*c*plg[2][4]-2.0*plg[2][3];
+	plg[2][6] =(11.0*c*plg[2][5]-7.0*plg[2][4])/4.0;
+	plg[2][7] =(13.0*c*plg[2][6]-8.0*plg[2][5])/5.0;
+	plg[3][3] = 15.0*s2*s;
+	plg[3][4] = 105.0*s2*s*c; 
+	plg[3][5] =(9.0*c*plg[3][4]-7.*plg[3][3])/2.0;
+	plg[3][6] =(11.0*c*plg[3][5]-8.*plg[3][4])/3.0;
+
+	if (!(((flags->sw[7]==0)&&(flags->sw[8]==0))&&(flags->sw[14]==0))) {
+		stloc = sin(hr*tloc);
+		ctloc = cos(hr*tloc);
+		s2tloc = sin(2.0*hr*tloc);
+		c2tloc = cos(2.0*hr*tloc);
+		s3tloc = sin(3.0*hr*tloc);
+		c3tloc = cos(3.0*hr*tloc);
+	}
+
+	cd32 = cos(dr*(input->doy-p[31]));
+	cd18 = cos(2.0*dr*(input->doy-p[17]));
+	cd14 = cos(dr*(input->doy-p[13]));
+	cd39 = cos(2.0*dr*(input->doy-p[38]));
+
+	/* F10.7 EFFECT */
+	df = input->f107 - input->f107A;
+	dfa = input->f107A - 150.0;
+	t[0] =  p[19]*df*(1.0+p[59]*dfa) + p[20]*df*df + p[21]*dfa + p[29]*pow(dfa,2.0);
+	f1 = 1.0 + (p[47]*dfa +p[19]*df+p[20]*df*df)*flags->swc[1];
+	f2 = 1.0 + (p[49]*dfa+p[19]*df+p[20]*df*df)*flags->swc[1];
+
+	/*  TIME INDEPENDENT */
+	t[1] = (p[1]*plg[0][2]+ p[2]*plg[0][4]+p[22]*plg[0][6]) + \
+	      (p[14]*plg[0][2])*dfa*flags->swc[1] +p[26]*plg[0][1];
+
+	/*  SYMMETRICAL ANNUAL */
+	t[2] = p[18]*cd32;
+
+	/*  SYMMETRICAL SEMIANNUAL */
+	t[3] = (p[15]+p[16]*plg[0][2])*cd18;
+
+	/*  ASYMMETRICAL ANNUAL */
+	t[4] =  f1*(p[9]*plg[0][1]+p[10]*plg[0][3])*cd14;
+
+	/*  ASYMMETRICAL SEMIANNUAL */
+	t[5] =    p[37]*plg[0][1]*cd39;
+
+        /* DIURNAL */
+	if (flags->sw[7]) {
+		double t71, t72;
+		t71 = (p[11]*plg[1][2])*cd14*flags->swc[5];
+		t72 = (p[12]*plg[1][2])*cd14*flags->swc[5];
+		t[6] = f2*((p[3]*plg[1][1] + p[4]*plg[1][3] + p[27]*plg[1][5] + t71) * \
+			   ctloc + (p[6]*plg[1][1] + p[7]*plg[1][3] + p[28]*plg[1][5] \
+				    + t72)*stloc);
+}
+
+	/* SEMIDIURNAL */
+	if (flags->sw[8]) {
+		double t81, t82;
+		t81 = (p[23]*plg[2][3]+p[35]*plg[2][5])*cd14*flags->swc[5];
+		t82 = (p[33]*plg[2][3]+p[36]*plg[2][5])*cd14*flags->swc[5];
+		t[7] = f2*((p[5]*plg[2][2]+ p[41]*plg[2][4] + t81)*c2tloc +(p[8]*plg[2][2] + p[42]*plg[2][4] + t82)*s2tloc);
+	}
+
+	/* TERDIURNAL */
+	if (flags->sw[14]) {
+		t[13] = f2 * ((p[39]*plg[3][3]+(p[93]*plg[3][4]+p[46]*plg[3][6])*cd14*flags->swc[5])* s3tloc +(p[40]*plg[3][3]+(p[94]*plg[3][4]+p[48]*plg[3][6])*cd14*flags->swc[5])* c3tloc);
+}
+
+	/* magnetic activity based on daily ap */
+	if (flags->sw[9]==-1) {
+		ap = input->ap_a;
+		if (p[51]!=0) {
+			double exp1;
+			exp1 = exp(-10800.0*sqrt(p[51]*p[51])/(1.0+p[138]*(45.0-sqrt(input->g_lat*input->g_lat))));
+			if (exp1>0.99999)
+				exp1=0.99999;
+			if (p[24]<1.0E-4)
+				p[24]=1.0E-4;
+			apt[0]=sg0(exp1,p,ap->a);
+			/* apt[1]=sg2(exp1,p,ap->a);
+			   apt[2]=sg0(exp2,p,ap->a);
+			   apt[3]=sg2(exp2,p,ap->a);
+			*/
+			if (flags->sw[9]) {
+				t[8] = apt[0]*(p[50]+p[96]*plg[0][2]+p[54]*plg[0][4]+ \
+     (p[125]*plg[0][1]+p[126]*plg[0][3]+p[127]*plg[0][5])*cd14*flags->swc[5]+ \
+     (p[128]*plg[1][1]+p[129]*plg[1][3]+p[130]*plg[1][5])*flags->swc[7]* \
+					       cos(hr*(tloc-p[131])));
+			}
+		}
+	} else {
+		double p44, p45;
+		apd=input->ap-4.0;
+		p44=p[43];
+		p45=p[44];
+		if (p44<0)
+			p44 = 1.0E-5;
+		apdf = apd + (p45-1.0)*(apd + (exp(-p44 * apd) - 1.0)/p44);
+		if (flags->sw[9]) {
+			t[8]=apdf*(p[32]+p[45]*plg[0][2]+p[34]*plg[0][4]+ \
+     (p[100]*plg[0][1]+p[101]*plg[0][3]+p[102]*plg[0][5])*cd14*flags->swc[5]+
+     (p[121]*plg[1][1]+p[122]*plg[1][3]+p[123]*plg[1][5])*flags->swc[7]*
+				    cos(hr*(tloc-p[124])));
+		}
+	}
+
+	if ((flags->sw[10])&&(input->g_long>-1000.0)) {
+
+		/* longitudinal */
+		if (flags->sw[11]) {
+			t[10] = (1.0 + p[80]*dfa*flags->swc[1])* \
+     ((p[64]*plg[1][2]+p[65]*plg[1][4]+p[66]*plg[1][6]\
+      +p[103]*plg[1][1]+p[104]*plg[1][3]+p[105]*plg[1][5]\
+      +flags->swc[5]*(p[109]*plg[1][1]+p[110]*plg[1][3]+p[111]*plg[1][5])*cd14)* \
+          cos(dgtr*input->g_long) \
+      +(p[90]*plg[1][2]+p[91]*plg[1][4]+p[92]*plg[1][6]\
+      +p[106]*plg[1][1]+p[107]*plg[1][3]+p[108]*plg[1][5]\
+      +flags->swc[5]*(p[112]*plg[1][1]+p[113]*plg[1][3]+p[114]*plg[1][5])*cd14)* \
+      sin(dgtr*input->g_long));
+		}
+
+		/* ut and mixed ut, longitude */
+		if (flags->sw[12]){
+			t[11]=(1.0+p[95]*plg[0][1])*(1.0+p[81]*dfa*flags->swc[1])*\
+				(1.0+p[119]*plg[0][1]*flags->swc[5]*cd14)*\
+				((p[68]*plg[0][1]+p[69]*plg[0][3]+p[70]*plg[0][5])*\
+				cos(sr*(input->sec-p[71])));
+			t[11]+=flags->swc[11]*\
+				(p[76]*plg[2][3]+p[77]*plg[2][5]+p[78]*plg[2][7])*\
+				cos(sr*(input->sec-p[79])+2.0*dgtr*input->g_long)*(1.0+p[137]*dfa*flags->swc[1]);
+		}
+
+		/* ut, longitude magnetic activity */
+		if (flags->sw[13]) {
+			if (flags->sw[9]==-1) {
+				if (p[51]) {
+					t[12]=apt[0]*flags->swc[11]*(1.+p[132]*plg[0][1])*\
+						((p[52]*plg[1][2]+p[98]*plg[1][4]+p[67]*plg[1][6])*\
+						 cos(dgtr*(input->g_long-p[97])))\
+						+apt[0]*flags->swc[11]*flags->swc[5]*\
+						(p[133]*plg[1][1]+p[134]*plg[1][3]+p[135]*plg[1][5])*\
+						cd14*cos(dgtr*(input->g_long-p[136])) \
+						+apt[0]*flags->swc[12]* \
+						(p[55]*plg[0][1]+p[56]*plg[0][3]+p[57]*plg[0][5])*\
+						cos(sr*(input->sec-p[58]));
+				}
+			} else {
+				t[12] = apdf*flags->swc[11]*(1.0+p[120]*plg[0][1])*\
+					((p[60]*plg[1][2]+p[61]*plg[1][4]+p[62]*plg[1][6])*\
+					cos(dgtr*(input->g_long-p[63])))\
+					+apdf*flags->swc[11]*flags->swc[5]* \
+					(p[115]*plg[1][1]+p[116]*plg[1][3]+p[117]*plg[1][5])* \
+					cd14*cos(dgtr*(input->g_long-p[118])) \
+					+ apdf*flags->swc[12]* \
+					(p[83]*plg[0][1]+p[84]*plg[0][3]+p[85]*plg[0][5])* \
+					cos(sr*(input->sec-p[75]));
+			}			
+		}
+	}
+
+	/* parms not used: 82, 89, 99, 139-149 */
+	tinf = p[30];
+	for (i=0;i<14;i++)
+		tinf = tinf + fabs(flags->sw[i+1])*t[i];
+	return tinf;
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- GLOB7S ---------------------------- */
+/* ------------------------------------------------------------------- */
+
+double glob7s(double *p, struct nrlmsise_input *input, struct nrlmsise_flags *flags) {
+/*    VERSION OF GLOBE FOR LOWER ATMOSPHERE 10/26/99 
+ */
+	double pset=2.0;
+	double t[14];
+	double tt;
+	double cd32, cd18, cd14, cd39;
+	int i,j;
+	double dr=1.72142E-2;
+	double dgtr=1.74533E-2;
+	/* confirm parameter set */
+	if (p[99]==0)
+		p[99]=pset;
+	if (p[99]!=pset) {
+		printf("Wrong parameter set for glob7s\n");
+		return -1;
+	}
+	for (j=0;j<14;j++)
+		t[j]=0.0;
+	cd32 = cos(dr*(input->doy-p[31]));
+	cd18 = cos(2.0*dr*(input->doy-p[17]));
+	cd14 = cos(dr*(input->doy-p[13]));
+	cd39 = cos(2.0*dr*(input->doy-p[38]));
+
+	/* F10.7 */
+	t[0] = p[21]*dfa;
+
+	/* time independent */
+	t[1]=p[1]*plg[0][2] + p[2]*plg[0][4] + p[22]*plg[0][6] + p[26]*plg[0][1] + p[14]*plg[0][3] + p[59]*plg[0][5];
+
+        /* SYMMETRICAL ANNUAL */
+	t[2]=(p[18]+p[47]*plg[0][2]+p[29]*plg[0][4])*cd32;
+
+        /* SYMMETRICAL SEMIANNUAL */
+	t[3]=(p[15]+p[16]*plg[0][2]+p[30]*plg[0][4])*cd18;
+
+        /* ASYMMETRICAL ANNUAL */
+	t[4]=(p[9]*plg[0][1]+p[10]*plg[0][3]+p[20]*plg[0][5])*cd14;
+
+	/* ASYMMETRICAL SEMIANNUAL */
+	t[5]=(p[37]*plg[0][1])*cd39;
+
+        /* DIURNAL */
+	if (flags->sw[7]) {
+		double t71, t72;
+		t71 = p[11]*plg[1][2]*cd14*flags->swc[5];
+		t72 = p[12]*plg[1][2]*cd14*flags->swc[5];
+		t[6] = ((p[3]*plg[1][1] + p[4]*plg[1][3] + t71) * ctloc + (p[6]*plg[1][1] + p[7]*plg[1][3] + t72) * stloc) ;
+	}
+
+	/* SEMIDIURNAL */
+	if (flags->sw[8]) {
+		double t81, t82;
+		t81 = (p[23]*plg[2][3]+p[35]*plg[2][5])*cd14*flags->swc[5];
+		t82 = (p[33]*plg[2][3]+p[36]*plg[2][5])*cd14*flags->swc[5];
+		t[7] = ((p[5]*plg[2][2] + p[41]*plg[2][4] + t81) * c2tloc + (p[8]*plg[2][2] + p[42]*plg[2][4] + t82) * s2tloc);
+	}
+
+	/* TERDIURNAL */
+	if (flags->sw[14]) {
+		t[13] = p[39] * plg[3][3] * s3tloc + p[40] * plg[3][3] * c3tloc;
+	}
+
+	/* MAGNETIC ACTIVITY */
+	if (flags->sw[9]) {
+		if (flags->sw[9]==1)
+			t[8] = apdf * (p[32] + p[45] * plg[0][2] * flags->swc[2]);
+		if (flags->sw[9]==-1)	
+			t[8]=(p[50]*apt[0] + p[96]*plg[0][2] * apt[0]*flags->swc[2]);
+	}
+
+	/* LONGITUDINAL */
+	if (!((flags->sw[10]==0) || (flags->sw[11]==0) || (input->g_long<=-1000.0))) {
+		t[10] = (1.0 + plg[0][1]*(p[80]*flags->swc[5]*cos(dr*(input->doy-p[81]))\
+		        +p[85]*flags->swc[6]*cos(2.0*dr*(input->doy-p[86])))\
+			+p[83]*flags->swc[3]*cos(dr*(input->doy-p[84]))\
+			+p[87]*flags->swc[4]*cos(2.0*dr*(input->doy-p[88])))\
+			*((p[64]*plg[1][2]+p[65]*plg[1][4]+p[66]*plg[1][6]\
+			+p[74]*plg[1][1]+p[75]*plg[1][3]+p[76]*plg[1][5]\
+			)*cos(dgtr*input->g_long)\
+			+(p[90]*plg[1][2]+p[91]*plg[1][4]+p[92]*plg[1][6]\
+			+p[77]*plg[1][1]+p[78]*plg[1][3]+p[79]*plg[1][5]\
+			)*sin(dgtr*input->g_long));
+	}
+	tt=0;
+	for (i=0;i<14;i++)
+		tt+=fabs(flags->sw[i+1])*t[i];
+	return tt;
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- GTD7 ------------------------------ */
+/* ------------------------------------------------------------------- */
+
+void gtd7(struct nrlmsise_input *input, struct nrlmsise_flags *flags, struct nrlmsise_output *output) {
+	double xlat;
+	double xmm;
+	int mn3 = 5;
+	double zn3[5]={32.5,20.0,15.0,10.0,0.0};
+	int mn2 = 4;
+	double zn2[4]={72.5,55.0,45.0,32.5};
+	double altt;
+	double zmix=62.5;
+	double tmp;
+	double dm28m;
+	double tz;
+	double dmc;
+	double dmr;
+	double dz28;
+	struct nrlmsise_output soutput;
+	int i;
+
+	tselec(flags);
+
+	/* Latitude variation of gravity (none for sw[2]=0) */
+	xlat=input->g_lat;
+	if (flags->sw[2]==0)
+		xlat=45.0;
+	glatf(xlat, &gsurf, &re);
+
+	xmm = pdm[2][4];
+
+	/* THERMOSPHERE / MESOSPHERE (above zn2[0]) */
+	if (input->alt>zn2[0])
+		altt=input->alt;
+	else
+		altt=zn2[0];
+
+	tmp=input->alt;
+	input->alt=altt;
+	gts7(input, flags, &soutput);
+	altt=input->alt;
+	input->alt=tmp;
+	if (flags->sw[0])   /* metric adjustment */
+		dm28m=dm28*1.0E6;
+	else
+		dm28m=dm28;
+	output->t[0]=soutput.t[0];
+	output->t[1]=soutput.t[1];
+	if (input->alt>=zn2[0]) {
+		for (i=0;i<9;i++)
+			output->d[i]=soutput.d[i];
+		return;
+	}
+
+/*       LOWER MESOSPHERE/UPPER STRATOSPHERE (between zn3[0] and zn2[0])
+ *         Temperature at nodes and gradients at end nodes
+ *         Inverse temperature a linear function of spherical harmonics
+ */
+	meso_tgn2[0]=meso_tgn1[1];
+	meso_tn2[0]=meso_tn1[4];
+        meso_tn2[1]=pma[0][0]*pavgm[0]/(1.0-flags->sw[20]*glob7s(pma[0], input, flags));
+        meso_tn2[2]=pma[1][0]*pavgm[1]/(1.0-flags->sw[20]*glob7s(pma[1], input, flags));
+        meso_tn2[3]=pma[2][0]*pavgm[2]/(1.0-flags->sw[20]*flags->sw[22]*glob7s(pma[2], input, flags));
+	meso_tgn2[1]=pavgm[8]*pma[9][0]*(1.0+flags->sw[20]*flags->sw[22]*glob7s(pma[9], input, flags))*meso_tn2[3]*meso_tn2[3]/(pow((pma[2][0]*pavgm[2]),2.0));
+	meso_tn3[0]=meso_tn2[3];
+
+	if (input->alt<=zn3[0]) {
+/*       LOWER STRATOSPHERE AND TROPOSPHERE (below zn3[0])
+ *         Temperature at nodes and gradients at end nodes
+ *         Inverse temperature a linear function of spherical harmonics
+ */
+		meso_tgn3[0]=meso_tgn2[1];
+		meso_tn3[1]=pma[3][0]*pavgm[3]/(1.0-flags->sw[22]*glob7s(pma[3], input, flags));
+		meso_tn3[2]=pma[4][0]*pavgm[4]/(1.0-flags->sw[22]*glob7s(pma[4], input, flags));
+		meso_tn3[3]=pma[5][0]*pavgm[5]/(1.0-flags->sw[22]*glob7s(pma[5], input, flags));
+		meso_tn3[4]=pma[6][0]*pavgm[6]/(1.0-flags->sw[22]*glob7s(pma[6], input, flags));
+		meso_tgn3[1]=pma[7][0]*pavgm[7]*(1.0+flags->sw[22]*glob7s(pma[7], input, flags)) *meso_tn3[4]*meso_tn3[4]/(pow((pma[6][0]*pavgm[6]),2.0));
+	}
+
+        /* LINEAR TRANSITION TO FULL MIXING BELOW zn2[0] */
+
+	dmc=0;
+	if (input->alt>zmix)
+		dmc = 1.0 - (zn2[0]-input->alt)/(zn2[0] - zmix);
+	dz28=soutput.d[2];
+	
+	/**** N2 density ****/
+	dmr=soutput.d[2] / dm28m - 1.0;
+	output->d[2]=densm(input->alt,dm28m,xmm, &tz, mn3, zn3, meso_tn3, meso_tgn3, mn2, zn2, meso_tn2, meso_tgn2);
+	output->d[2]=output->d[2] * (1.0 + dmr*dmc);
+
+	/**** HE density ****/
+	dmr = soutput.d[0] / (dz28 * pdm[0][1]) - 1.0;
+	output->d[0] = output->d[2] * pdm[0][1] * (1.0 + dmr*dmc);
+
+	/**** O density ****/
+	output->d[1] = 0;
+	output->d[8] = 0;
+
+	/**** O2 density ****/
+	dmr = soutput.d[3] / (dz28 * pdm[3][1]) - 1.0;
+	output->d[3] = output->d[2] * pdm[3][1] * (1.0 + dmr*dmc);
+
+	/**** AR density ***/
+	dmr = soutput.d[4] / (dz28 * pdm[4][1]) - 1.0;
+	output->d[4] = output->d[2] * pdm[4][1] * (1.0 + dmr*dmc);
+
+	/**** Hydrogen density ****/
+	output->d[6] = 0;
+
+	/**** Atomic nitrogen density ****/
+	output->d[7] = 0;
+
+	/**** Total mass density */
+	output->d[5] = 1.66E-24 * (4.0 * output->d[0] + 16.0 * output->d[1] + 28.0 * output->d[2] + 32.0 * output->d[3] + 40.0 * output->d[4] + output->d[6] + 14.0 * output->d[7]);
+
+	if (flags->sw[0])
+		output->d[5]=output->d[5]/1000;
+
+	/**** temperature at altitude ****/
+	dd = densm(input->alt, 1.0, 0, &tz, mn3, zn3, meso_tn3, meso_tgn3, mn2, zn2, meso_tn2, meso_tgn2);
+	output->t[1]=tz;
+
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- GTD7D ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+void gtd7d(struct nrlmsise_input *input, struct nrlmsise_flags *flags, struct nrlmsise_output *output) {
+	gtd7(input, flags, output);
+	output->d[5] = 1.66E-24 * (4.0 * output->d[0] + 16.0 * output->d[1] + 28.0 * output->d[2] + 32.0 * output->d[3] + 40.0 * output->d[4] + output->d[6] + 14.0 * output->d[7] + 16.0 * output->d[8]);
+	if (flags->sw[0])
+		output->d[5]=output->d[5]/1000;
+}
+ 
+
+
+/* ------------------------------------------------------------------- */
+/* -------------------------------- GHP7 ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+void ghp7(struct nrlmsise_input *input, struct nrlmsise_flags *flags, struct nrlmsise_output *output, double press) {
+	double bm = 1.3806E-19;
+	double rgas = 831.4;
+	double test = 0.00043;
+	double ltest = 12;
+	double pl, p;
+	double zi;
+	double z;
+	double cl, cl2;
+	double ca, cd;
+	double xn, xm, diff;
+	double g, sh;
+	int l;
+	pl = log10(press);
+	if (pl >= -5.0) {
+		if (pl>2.5)
+			zi = 18.06 * (3.00 - pl);
+		else if ((pl>0.075) && (pl<=2.5))
+			zi = 14.98 * (3.08 - pl);
+		else if ((pl>-1) && (pl<=0.075))
+			zi = 17.80 * (2.72 - pl);
+		else if ((pl>-2) && (pl<=-1))
+			zi = 14.28 * (3.64 - pl);
+		else if ((pl>-4) && (pl<=-2))
+			zi = 12.72 * (4.32 -pl);
+		else
+			zi = 25.3 * (0.11 - pl);
+		cl = input->g_lat/90.0;
+		cl2 = cl*cl;
+		if (input->doy<182)
+			cd = (1.0 - (double) input->doy) / 91.25;
+		else 
+			cd = ((double) input->doy) / 91.25 - 3.0;
+		ca = 0;
+		if ((pl > -1.11) && (pl<=-0.23))
+			ca = 1.0;
+		if (pl > -0.23)
+			ca = (2.79 - pl) / (2.79 + 0.23);
+		if ((pl <= -1.11) && (pl>-3))
+			ca = (-2.93 - pl)/(-2.93 + 1.11);
+		z = zi - 4.87 * cl * cd * ca - 1.64 * cl2 * ca + 0.31 * ca * cl;
+	} else
+		z = 22.0 * pow((pl + 4.0),2.0) + 110.0;
+
+	/* iteration  loop */
+	l = 0;
+	do {
+		l++;
+		input->alt = z;
+		gtd7(input, flags, output);
+		z = input->alt;
+		xn = output->d[0] + output->d[1] + output->d[2] + output->d[3] + output->d[4] + output->d[6] + output->d[7];
+		p = bm * xn * output->t[1];
+		if (flags->sw[0])
+			p = p*1.0E-6;
+		diff = pl - log10(p);
+		if (sqrt(diff*diff)<test)
+			return;
+		if (l==ltest) {
+			printf("ERROR: ghp7 not converging for press %e, diff %e",press,diff);
+			return;
+		}
+		xm = output->d[5] / xn / 1.66E-24;
+		if (flags->sw[0])
+			xm = xm * 1.0E3;
+		g = gsurf / (pow((1.0 + z/re),2.0));
+		sh = rgas * output->t[1] / (xm * g);
+
+		/* new altitude estimate using scale height */
+		if (l <  6)
+			z = z - sh * diff * 2.302;
+		else
+			z = z - sh * diff;
+	} while (1==1);
+}
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- GTS7 ------------------------------ */
+/* ------------------------------------------------------------------- */
+
+void gts7(struct nrlmsise_input *input, struct nrlmsise_flags *flags, struct nrlmsise_output *output) {
+/*     Thermospheric portion of NRLMSISE-00
+ *     See GTD7 for more extensive comments
+ *     alt > 72.5 km! 
+ */
+	double za;
+	int i, j;
+	double ddum, z;
+	double zn1[5] = {120.0, 110.0, 100.0, 90.0, 72.5};
+	double tinf;
+	int mn1 = 5;
+	double g0;
+	double tlb;
+	double s;
+	double db01, db04, db14, db16, db28, db32, db40;
+	double zh28, zh04, zh16, zh32, zh40, zh01, zh14;
+	double zhm28, zhm04, zhm16, zhm32, zhm40, zhm01, zhm14;
+	double xmd;
+	double b28, b04, b16, b32, b40, b01, b14;
+	double tz;
+	double g28, g4, g16, g32, g40, g1, g14;
+	double zhf, xmm;
+	double zc04, zc16, zc32, zc40, zc01, zc14;
+	double hc04, hc16, hc32, hc40, hc01, hc14;
+	double hcc16, hcc32, hcc01, hcc14;
+	double zcc16, zcc32, zcc01, zcc14;
+	double rc16, rc32, rc01, rc14;
+	double rl;
+	double g16h, db16h, tho, zsht, zmho, zsho;
+	double dgtr=1.74533E-2;
+	double dr=1.72142E-2;
+	double alpha[9]={-0.38, 0.0, 0.0, 0.0, 0.17, 0.0, -0.38, 0.0, 0.0};
+	double altl[8]={200.0, 300.0, 160.0, 250.0, 240.0, 450.0, 320.0, 450.0};
+	double dd;
+	double hc216, hcc232;
+	za = pdl[1][15];
+	zn1[0] = za;
+	for (j=0;j<9;j++) 
+		output->d[j]=0;
+
+	/* TINF VARIATIONS NOT IMPORTANT BELOW ZA OR ZN1(1) */
+	if (input->alt>zn1[0])
+		tinf = ptm[0]*pt[0] * \
+			(1.0+flags->sw[16]*globe7(pt,input,flags));
+	else
+		tinf = ptm[0]*pt[0];
+	output->t[0]=tinf;
+
+	/*  GRADIENT VARIATIONS NOT IMPORTANT BELOW ZN1(5) */
+	if (input->alt>zn1[4])
+		g0 = ptm[3]*ps[0] * \
+			(1.0+flags->sw[19]*globe7(ps,input,flags));
+	else
+		g0 = ptm[3]*ps[0];
+	tlb = ptm[1] * (1.0 + flags->sw[17]*globe7(pd[3],input,flags))*pd[3][0];
+	s = g0 / (tinf - tlb);
+
+/*      Lower thermosphere temp variations not significant for
+ *       density above 300 km */
+	if (input->alt<300.0) {
+		meso_tn1[1]=ptm[6]*ptl[0][0]/(1.0-flags->sw[18]*glob7s(ptl[0], input, flags));
+		meso_tn1[2]=ptm[2]*ptl[1][0]/(1.0-flags->sw[18]*glob7s(ptl[1], input, flags));
+		meso_tn1[3]=ptm[7]*ptl[2][0]/(1.0-flags->sw[18]*glob7s(ptl[2], input, flags));
+		meso_tn1[4]=ptm[4]*ptl[3][0]/(1.0-flags->sw[18]*flags->sw[20]*glob7s(ptl[3], input, flags));
+		meso_tgn1[1]=ptm[8]*pma[8][0]*(1.0+flags->sw[18]*flags->sw[20]*glob7s(pma[8], input, flags))*meso_tn1[4]*meso_tn1[4]/(pow((ptm[4]*ptl[3][0]),2.0));
+	} else {
+		meso_tn1[1]=ptm[6]*ptl[0][0];
+		meso_tn1[2]=ptm[2]*ptl[1][0];
+		meso_tn1[3]=ptm[7]*ptl[2][0];
+		meso_tn1[4]=ptm[4]*ptl[3][0];
+		meso_tgn1[1]=ptm[8]*pma[8][0]*meso_tn1[4]*meso_tn1[4]/(pow((ptm[4]*ptl[3][0]),2.0));
+	}
+
+	/* N2 variation factor at Zlb */
+	g28=flags->sw[21]*globe7(pd[2], input, flags);
+
+	/* VARIATION OF TURBOPAUSE HEIGHT */
+	zhf=pdl[1][24]*(1.0+flags->sw[5]*pdl[0][24]*sin(dgtr*input->g_lat)*cos(dr*(input->doy-pt[13])));
+	output->t[0]=tinf;
+	xmm = pdm[2][4];
+	z = input->alt;
+
+
+        /**** N2 DENSITY ****/
+
+	/* Diffusive density at Zlb */
+	db28 = pdm[2][0]*exp(g28)*pd[2][0];
+	/* Diffusive density at Alt */
+	output->d[2]=densu(z,db28,tinf,tlb,28.0,alpha[2],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+	dd=output->d[2];
+	/* Turbopause */
+	zh28=pdm[2][2]*zhf;
+	zhm28=pdm[2][3]*pdl[1][5]; 
+	xmd=28.0-xmm;
+	/* Mixed density at Zlb */
+	b28=densu(zh28,db28,tinf,tlb,xmd,(alpha[2]-1.0),&tz,ptm[5],s,mn1, zn1,meso_tn1,meso_tgn1);
+	if ((flags->sw[15])&&(z<=altl[2])) {
+		/*  Mixed density at Alt */
+		dm28=densu(z,b28,tinf,tlb,xmm,alpha[2],&tz,ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		/*  Net density at Alt */
+		output->d[2]=dnet(output->d[2],dm28,zhm28,xmm,28.0);
+	}
+
+
+        /**** HE DENSITY ****/
+
+	/*   Density variation factor at Zlb */
+	g4 = flags->sw[21]*globe7(pd[0], input, flags);
+	/*  Diffusive density at Zlb */
+	db04 = pdm[0][0]*exp(g4)*pd[0][0];
+        /*  Diffusive density at Alt */
+	output->d[0]=densu(z,db04,tinf,tlb, 4.,alpha[0],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+	dd=output->d[0];
+	if ((flags->sw[15]) && (z<altl[0])) {
+		/*  Turbopause */
+		zh04=pdm[0][2];
+		/*  Mixed density at Zlb */
+		b04=densu(zh04,db04,tinf,tlb,4.-xmm,alpha[0]-1.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		/*  Mixed density at Alt */
+		dm04=densu(z,b04,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		zhm04=zhm28;
+		/*  Net density at Alt */
+		output->d[0]=dnet(output->d[0],dm04,zhm04,xmm,4.);
+		/*  Correction to specified mixing ratio at ground */
+		rl=log(b28*pdm[0][1]/b04);
+		zc04=pdm[0][4]*pdl[1][0];
+		hc04=pdm[0][5]*pdl[1][1];
+		/*  Net density corrected at Alt */
+		output->d[0]=output->d[0]*ccor(z,rl,hc04,zc04);
+	}
+
+
+        /**** O DENSITY ****/
+
+	/*  Density variation factor at Zlb */
+	g16= flags->sw[21]*globe7(pd[1],input,flags);
+	/*  Diffusive density at Zlb */
+	db16 =  pdm[1][0]*exp(g16)*pd[1][0];
+        /*   Diffusive density at Alt */
+	output->d[1]=densu(z,db16,tinf,tlb, 16.,alpha[1],&output->t[1],ptm[5],s,mn1, zn1,meso_tn1,meso_tgn1);
+	dd=output->d[1];
+	if ((flags->sw[15]) && (z<=altl[1])) {
+		/*   Turbopause */
+		zh16=pdm[1][2];
+		/*  Mixed density at Zlb */
+		b16=densu(zh16,db16,tinf,tlb,16.0-xmm,(alpha[1]-1.0), &output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		/*  Mixed density at Alt */
+		dm16=densu(z,b16,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		zhm16=zhm28;
+		/*  Net density at Alt */
+		output->d[1]=dnet(output->d[1],dm16,zhm16,xmm,16.);
+		rl=pdm[1][1]*pdl[1][16]*(1.0+flags->sw[1]*pdl[0][23]*(input->f107A-150.0));
+		hc16=pdm[1][5]*pdl[1][3];
+		zc16=pdm[1][4]*pdl[1][2];
+		hc216=pdm[1][5]*pdl[1][4];
+		output->d[1]=output->d[1]*ccor2(z,rl,hc16,zc16,hc216);
+		/*   Chemistry correction */
+		hcc16=pdm[1][7]*pdl[1][13];
+		zcc16=pdm[1][6]*pdl[1][12];
+		rc16=pdm[1][3]*pdl[1][14];
+		/*  Net density corrected at Alt */
+		output->d[1]=output->d[1]*ccor(z,rc16,hcc16,zcc16);
+	}
+
+
+        /**** O2 DENSITY ****/
+
+        /*   Density variation factor at Zlb */
+	g32= flags->sw[21]*globe7(pd[4], input, flags);
+        /*  Diffusive density at Zlb */
+	db32 = pdm[3][0]*exp(g32)*pd[4][0];
+        /*   Diffusive density at Alt */
+	output->d[3]=densu(z,db32,tinf,tlb, 32.,alpha[3],&output->t[1],ptm[5],s,mn1, zn1,meso_tn1,meso_tgn1);
+	dd=output->d[3];
+	if (flags->sw[15]) {
+		if (z<=altl[3]) {
+			/*   Turbopause */
+			zh32=pdm[3][2];
+			/*  Mixed density at Zlb */
+			b32=densu(zh32,db32,tinf,tlb,32.-xmm,alpha[3]-1., &output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+			/*  Mixed density at Alt */
+			dm32=densu(z,b32,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+			zhm32=zhm28;
+			/*  Net density at Alt */
+			output->d[3]=dnet(output->d[3],dm32,zhm32,xmm,32.);
+			/*   Correction to specified mixing ratio at ground */
+			rl=log(b28*pdm[3][1]/b32);
+			hc32=pdm[3][5]*pdl[1][7];
+			zc32=pdm[3][4]*pdl[1][6];
+			output->d[3]=output->d[3]*ccor(z,rl,hc32,zc32);
+		}
+		/*  Correction for general departure from diffusive equilibrium above Zlb */
+		hcc32=pdm[3][7]*pdl[1][22];
+		hcc232=pdm[3][7]*pdl[0][22];
+		zcc32=pdm[3][6]*pdl[1][21];
+		rc32=pdm[3][3]*pdl[1][23]*(1.+flags->sw[1]*pdl[0][23]*(input->f107A-150.));
+		/*  Net density corrected at Alt */
+		output->d[3]=output->d[3]*ccor2(z,rc32,hcc32,zcc32,hcc232);
+	}
+
+
+        /**** AR DENSITY ****/
+
+        /*   Density variation factor at Zlb */
+	g40= flags->sw[21]*globe7(pd[5],input,flags);
+        /*  Diffusive density at Zlb */
+	db40 = pdm[4][0]*exp(g40)*pd[5][0];
+	/*   Diffusive density at Alt */
+	output->d[4]=densu(z,db40,tinf,tlb, 40.,alpha[4],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+	dd=output->d[4];
+	if ((flags->sw[15]) && (z<=altl[4])) {
+		/*   Turbopause */
+		zh40=pdm[4][2];
+		/*  Mixed density at Zlb */
+		b40=densu(zh40,db40,tinf,tlb,40.-xmm,alpha[4]-1.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		/*  Mixed density at Alt */
+		dm40=densu(z,b40,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		zhm40=zhm28;
+		/*  Net density at Alt */
+		output->d[4]=dnet(output->d[4],dm40,zhm40,xmm,40.);
+		/*   Correction to specified mixing ratio at ground */
+		rl=log(b28*pdm[4][1]/b40);
+		hc40=pdm[4][5]*pdl[1][9];
+		zc40=pdm[4][4]*pdl[1][8];
+		/*  Net density corrected at Alt */
+		output->d[4]=output->d[4]*ccor(z,rl,hc40,zc40);
+	  }
+
+
+        /**** HYDROGEN DENSITY ****/
+
+        /*   Density variation factor at Zlb */
+	g1 = flags->sw[21]*globe7(pd[6], input, flags);
+        /*  Diffusive density at Zlb */
+	db01 = pdm[5][0]*exp(g1)*pd[6][0];
+        /*   Diffusive density at Alt */
+	output->d[6]=densu(z,db01,tinf,tlb,1.,alpha[6],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+	dd=output->d[6];
+	if ((flags->sw[15]) && (z<=altl[6])) {
+		/*   Turbopause */
+		zh01=pdm[5][2];
+		/*  Mixed density at Zlb */
+		b01=densu(zh01,db01,tinf,tlb,1.-xmm,alpha[6]-1., &output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		/*  Mixed density at Alt */
+		dm01=densu(z,b01,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		zhm01=zhm28;
+		/*  Net density at Alt */
+		output->d[6]=dnet(output->d[6],dm01,zhm01,xmm,1.);
+		/*   Correction to specified mixing ratio at ground */
+		rl=log(b28*pdm[5][1]*sqrt(pdl[1][17]*pdl[1][17])/b01);
+		hc01=pdm[5][5]*pdl[1][11];
+		zc01=pdm[5][4]*pdl[1][10];
+		output->d[6]=output->d[6]*ccor(z,rl,hc01,zc01);
+		/*   Chemistry correction */
+		hcc01=pdm[5][7]*pdl[1][19];
+		zcc01=pdm[5][6]*pdl[1][18];
+		rc01=pdm[5][3]*pdl[1][20];
+		/*  Net density corrected at Alt */
+		output->d[6]=output->d[6]*ccor(z,rc01,hcc01,zcc01);
+}
+
+
+        /**** ATOMIC NITROGEN DENSITY ****/
+
+	/*   Density variation factor at Zlb */
+	g14 = flags->sw[21]*globe7(pd[7],input,flags);
+        /*  Diffusive density at Zlb */
+	db14 = pdm[6][0]*exp(g14)*pd[7][0];
+        /*   Diffusive density at Alt */
+	output->d[7]=densu(z,db14,tinf,tlb,14.,alpha[7],&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+	dd=output->d[7];
+	if ((flags->sw[15]) && (z<=altl[7])) {
+		/*   Turbopause */
+		zh14=pdm[6][2];
+		/*  Mixed density at Zlb */
+		b14=densu(zh14,db14,tinf,tlb,14.-xmm,alpha[7]-1., &output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		/*  Mixed density at Alt */
+		dm14=densu(z,b14,tinf,tlb,xmm,0.,&output->t[1],ptm[5],s,mn1,zn1,meso_tn1,meso_tgn1);
+		zhm14=zhm28;
+		/*  Net density at Alt */
+		output->d[7]=dnet(output->d[7],dm14,zhm14,xmm,14.);
+		/*   Correction to specified mixing ratio at ground */
+		rl=log(b28*pdm[6][1]*sqrt(pdl[0][2]*pdl[0][2])/b14);
+		hc14=pdm[6][5]*pdl[0][1];
+		zc14=pdm[6][4]*pdl[0][0];
+		output->d[7]=output->d[7]*ccor(z,rl,hc14,zc14);
+		/*   Chemistry correction */
+		hcc14=pdm[6][7]*pdl[0][4];
+		zcc14=pdm[6][6]*pdl[0][3];
+		rc14=pdm[6][3]*pdl[0][5];
+		/*  Net density corrected at Alt */
+		output->d[7]=output->d[7]*ccor(z,rc14,hcc14,zcc14);
+	}
+
+
+        /**** Anomalous OXYGEN DENSITY ****/
+
+	g16h = flags->sw[21]*globe7(pd[8],input,flags);
+	db16h = pdm[7][0]*exp(g16h)*pd[8][0];
+	tho = pdm[7][9]*pdl[0][6];
+	dd=densu(z,db16h,tho,tho,16.,alpha[8],&output->t[1],ptm[5],s,mn1, zn1,meso_tn1,meso_tgn1);
+	zsht=pdm[7][5];
+	zmho=pdm[7][4];
+	zsho=scalh(zmho,16.0,tho);
+	output->d[8]=dd*exp(-zsht/zsho*(exp(-(z-zmho)/zsht)-1.));
+
+
+	/* total mass density */
+	output->d[5] = 1.66E-24*(4.0*output->d[0]+16.0*output->d[1]+28.0*output->d[2]+32.0*output->d[3]+40.0*output->d[4]+ output->d[6]+14.0*output->d[7]);
+
+
+	/* temperature */
+	z = sqrt(input->alt*input->alt);
+	ddum = densu(z,1.0, tinf, tlb, 0.0, 0.0, &output->t[1], ptm[5], s, mn1, zn1, meso_tn1, meso_tgn1);
+	(void) ddum; /* silence gcc */
+	if (flags->sw[0]) {
+		for(i=0;i<9;i++)
+			output->d[i]=output->d[i]*1.0E6;
+		output->d[5]=output->d[5]/1000;
+	}
+}

--- a/src/models/atmosphere/MSIS/nrlmsise-00.h
+++ b/src/models/atmosphere/MSIS/nrlmsise-00.h
@@ -1,0 +1,222 @@
+/* -------------------------------------------------------------------- */
+/* ---------  N R L M S I S E - 0 0    M O D E L    2 0 0 1  ---------- */
+/* -------------------------------------------------------------------- */
+
+/* This file is part of the NRLMSISE-00  C source code package - release
+ * 20041227
+ *
+ * The NRLMSISE-00 model was developed by Mike Picone, Alan Hedin, and
+ * Doug Drob. They also wrote a NRLMSISE-00 distribution package in 
+ * FORTRAN which is available at
+ * http://uap-www.nrl.navy.mil/models_web/msis/msis_home.htm
+ *
+ * Dominik Brodowski implemented and maintains this C version. You can
+ * reach him at mail@brodo.de. See the file "DOCUMENTATION" for details,
+ * and check http://www.brodo.de/english/pub/nrlmsise/index.html for
+ * updated releases of this package.
+ */
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------- INPUT ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+struct nrlmsise_flags {
+	int switches[24];
+	double sw[24];
+	double swc[24];
+};
+/*   
+ *   Switches: to turn on and off particular variations use these switches.
+ *   0 is off, 1 is on, and 2 is main effects off but cross terms on.
+ *
+ *   Standard values are 0 for switch 0 and 1 for switches 1 to 23. The 
+ *   array "switches" needs to be set accordingly by the calling program. 
+ *   The arrays sw and swc are set internally.
+ *
+ *   switches[i]:
+ *    i - explanation
+ *   -----------------
+ *    0 - output in meters and kilograms instead of centimeters and grams
+ *    1 - F10.7 effect on mean
+ *    2 - time independent
+ *    3 - symmetrical annual
+ *    4 - symmetrical semiannual
+ *    5 - asymmetrical annual
+ *    6 - asymmetrical semiannual
+ *    7 - diurnal
+ *    8 - semidiurnal
+ *    9 - daily ap [when this is set to -1 (!) the pointer
+ *                  ap_a in struct nrlmsise_input must
+ *                  point to a struct ap_array]
+ *   10 - all UT/long effects
+ *   11 - longitudinal
+ *   12 - UT and mixed UT/long
+ *   13 - mixed AP/UT/LONG
+ *   14 - terdiurnal
+ *   15 - departures from diffusive equilibrium
+ *   16 - all TINF var
+ *   17 - all TLB var
+ *   18 - all TN1 var
+ *   19 - all S var
+ *   20 - all TN2 var
+ *   21 - all NLB var
+ *   22 - all TN3 var
+ *   23 - turbo scale height var
+ */
+
+struct ap_array {
+	double a[7];   
+};
+/* Array containing the following magnetic values:
+ *   0 : daily AP
+ *   1 : 3 hr AP index for current time
+ *   2 : 3 hr AP index for 3 hrs before current time
+ *   3 : 3 hr AP index for 6 hrs before current time
+ *   4 : 3 hr AP index for 9 hrs before current time
+ *   5 : Average of eight 3 hr AP indicies from 12 to 33 hrs 
+ *           prior to current time
+ *   6 : Average of eight 3 hr AP indicies from 36 to 57 hrs 
+ *           prior to current time 
+ */
+
+
+struct nrlmsise_input {
+	int year;      /* year, currently ignored */
+	int doy;       /* day of year */
+	double sec;    /* seconds in day (UT) */
+	double alt;    /* altitude in kilometers */
+	double g_lat;  /* geodetic latitude */
+	double g_long; /* geodetic longitude */
+	double lst;    /* local apparent solar time (hours), see note below */
+	double f107A;  /* 81 day average of F10.7 flux (centered on doy) */
+	double f107;   /* daily F10.7 flux for previous day */
+	double ap;     /* magnetic index(daily) */
+	struct ap_array *ap_a; /* see above */
+};
+/*
+ *   NOTES ON INPUT VARIABLES: 
+ *      UT, Local Time, and Longitude are used independently in the
+ *      model and are not of equal importance for every situation.  
+ *      For the most physically realistic calculation these three
+ *      variables should be consistent (lst=sec/3600 + g_long/15).
+ *      The Equation of Time departures from the above formula
+ *      for apparent local time can be included if available but
+ *      are of minor importance.
+ *
+ *      f107 and f107A values used to generate the model correspond
+ *      to the 10.7 cm radio flux at the actual distance of the Earth
+ *      from the Sun rather than the radio flux at 1 AU. The following
+ *      site provides both classes of values:
+ *      ftp://ftp.ngdc.noaa.gov/STP/SOLAR_DATA/SOLAR_RADIO/FLUX/
+ *
+ *      f107, f107A, and ap effects are neither large nor well
+ *      established below 80 km and these parameters should be set to
+ *      150., 150., and 4. respectively.
+ */
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------ OUTPUT ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+struct nrlmsise_output {
+	double d[9];   /* densities */
+	double t[2];   /* temperatures */
+};
+/* 
+ *   OUTPUT VARIABLES:
+ *      d[0] - HE NUMBER DENSITY(CM-3)
+ *      d[1] - O NUMBER DENSITY(CM-3)
+ *      d[2] - N2 NUMBER DENSITY(CM-3)
+ *      d[3] - O2 NUMBER DENSITY(CM-3)
+ *      d[4] - AR NUMBER DENSITY(CM-3)                       
+ *      d[5] - TOTAL MASS DENSITY(GM/CM3) [includes d[8] in td7d]
+ *      d[6] - H NUMBER DENSITY(CM-3)
+ *      d[7] - N NUMBER DENSITY(CM-3)
+ *      d[8] - Anomalous oxygen NUMBER DENSITY(CM-3)
+ *      t[0] - EXOSPHERIC TEMPERATURE
+ *      t[1] - TEMPERATURE AT ALT
+ * 
+ *
+ *      O, H, and N are set to zero below 72.5 km
+ *
+ *      t[0], Exospheric temperature, is set to global average for
+ *      altitudes below 120 km. The 120 km gradient is left at global
+ *      average value for altitudes below 72 km.
+ *
+ *      d[5], TOTAL MASS DENSITY, is NOT the same for subroutines GTD7 
+ *      and GTD7D
+ *
+ *        SUBROUTINE GTD7 -- d[5] is the sum of the mass densities of the
+ *        species labeled by indices 0-4 and 6-7 in output variable d.
+ *        This includes He, O, N2, O2, Ar, H, and N but does NOT include
+ *        anomalous oxygen (species index 8).
+ *
+ *        SUBROUTINE GTD7D -- d[5] is the "effective total mass density
+ *        for drag" and is the sum of the mass densities of all species
+ *        in this model, INCLUDING anomalous oxygen.
+ */
+
+
+
+/* ------------------------------------------------------------------- */
+/* --------------------------- PROTOTYPES ---------------------------- */
+/* ------------------------------------------------------------------- */
+
+/* GTD7 */
+/*   Neutral Atmosphere Empircial Model from the surface to lower
+ *   exosphere.
+ */
+void gtd7 (struct nrlmsise_input *input, \
+           struct nrlmsise_flags *flags, \
+           struct nrlmsise_output *output);
+
+
+/* GTD7D */
+/*   This subroutine provides Effective Total Mass Density for output
+ *   d[5] which includes contributions from "anomalous oxygen" which can
+ *   affect satellite drag above 500 km. See the section "output" for
+ *   additional details.
+ */
+void gtd7d(struct nrlmsise_input *input, \
+           struct nrlmsise_flags *flags, \
+           struct nrlmsise_output *output);
+
+
+/* GTS7 */
+/*   Thermospheric portion of NRLMSISE-00
+ */
+void gts7 (struct nrlmsise_input *input, \
+	   struct nrlmsise_flags *flags, \
+	   struct nrlmsise_output *output);
+
+
+/* GHP7 */
+/*   To specify outputs at a pressure level (press) rather than at
+ *   an altitude.
+ */
+void ghp7 (struct nrlmsise_input *input, \
+           struct nrlmsise_flags *flags, \
+           struct nrlmsise_output *output, \
+           double press);
+
+
+
+/* ------------------------------------------------------------------- */
+/* ----------------------- COMPILATION TWEAKS ------------------------ */
+/* ------------------------------------------------------------------- */
+
+/* "inlining" of functions */
+/*   Some compilers (e.g. gcc) allow the inlining of functions into the
+ *   calling routine. This means a lot of overhead can be removed, and
+ *   the execution of the program runs much faster. However, the filesize
+ *   and thus the loading time is increased.
+ */
+#ifdef INLINE
+#define __inline_double static inline double
+#else
+#define __inline_double double
+#endif

--- a/src/models/atmosphere/MSIS/nrlmsise-00_data.c
+++ b/src/models/atmosphere/MSIS/nrlmsise-00_data.c
@@ -1,13 +1,9 @@
-// MSIS-00 Data
-// Adapted for use in JSBSim
-// David Culp, davidculp2@comcast.net
-
 /* -------------------------------------------------------------------- */
 /* ---------  N R L M S I S E - 0 0    M O D E L    2 0 0 1  ---------- */
 /* -------------------------------------------------------------------- */
 
 /* This file is part of the NRLMSISE-00  C source code package - release
- * 20020503
+ * 20041227
  *
  * The NRLMSISE-00 model was developed by Mike Picone, Alan Hedin, and
  * Doug Drob. They also wrote a NRLMSISE-00 distribution package in 
@@ -15,7 +11,7 @@
  * http://uap-www.nrl.navy.mil/models_web/msis/msis_home.htm
  *
  * Dominik Brodowski implemented and maintains this C version. You can
- * reach him at devel@brodo.de. See the file "DOCUMENTATION" for details,
+ * reach him at mail@brodo.de. See the file "DOCUMENTATION" for details,
  * and check http://www.brodo.de/english/pub/nrlmsise/index.html for
  * updated releases of this package.
  */
@@ -25,8 +21,6 @@
 /* ------------------------------------------------------------------- */
 /* ------------------------ BLOCK DATA GTD7BK ------------------------ */
 /* ------------------------------------------------------------------- */
-
-namespace JSBSim {
 
 /* TEMPERATURE */
 double pt[150] = {
@@ -744,4 +738,3 @@ double pavgm[10] = {
      2.61000E+02, 2.64000E+02, 2.29000E+02, 2.17000E+02, 2.17000E+02,
      2.23000E+02, 2.86760E+02,-2.93940E+00, 2.50000E+00, 0.00000E+00 };
  
-} // namespace

--- a/src/models/atmosphere/MSIS/nrlmsise-00_test.c
+++ b/src/models/atmosphere/MSIS/nrlmsise-00_test.c
@@ -1,0 +1,168 @@
+/* -------------------------------------------------------------------- */
+/* ---------  N R L M S I S E - 0 0    M O D E L    2 0 0 1  ---------- */
+/* -------------------------------------------------------------------- */
+
+/* This file is part of the NRLMSISE-00  C source code package - release
+ * 20041227
+ *
+ * The NRLMSISE-00 model was developed by Mike Picone, Alan Hedin, and
+ * Doug Drob. They also wrote a NRLMSISE-00 distribution package in 
+ * FORTRAN which is available at
+ * http://uap-www.nrl.navy.mil/models_web/msis/msis_home.htm
+ *
+ * Dominik Brodowski implemented and maintains this C version. You can
+ * reach him at mail@brodo.de. See the file "DOCUMENTATION" for details,
+ * and check http://www.brodo.de/english/pub/nrlmsise/index.html for
+ * updated releases of this package.
+ */
+
+
+
+/* ------------------------------------------------------------------- */
+/* ------------------------------ INCLUDES --------------------------- */
+/* ------------------------------------------------------------------- */
+
+#include <stdio.h>
+#include "nrlmsise-00.h"
+
+
+
+/* ------------------------------------------------------------------- */
+/* ----------------------------- TEST_GTD7 --------------------------- */
+/* ------------------------------------------------------------------- */
+
+void test_gtd7(void) {
+  	struct nrlmsise_output output[17];
+	struct nrlmsise_input input[17];
+  	struct nrlmsise_flags flags;
+	struct ap_array aph;
+	int i;
+	int j;
+	/* input values */
+  	for (i=0;i<7;i++)
+		aph.a[i]=100;
+	flags.switches[0]=0;
+  	for (i=1;i<24;i++)
+  		flags.switches[i]=1;
+	for (i=0;i<17;i++) {
+		input[i].doy=172;
+		input[i].year=0; /* without effect */
+  		input[i].sec=29000;
+		input[i].alt=400;
+		input[i].g_lat=60;
+		input[i].g_long=-70;
+		input[i].lst=16;
+		input[i].f107A=150;
+		input[i].f107=150;
+		input[i].ap=4;
+	}
+	input[1].doy=81;
+	input[2].sec=75000;
+	input[2].alt=1000;
+	input[3].alt=100;
+	input[10].alt=0;
+	input[11].alt=10;
+	input[12].alt=30;
+	input[13].alt=50;
+	input[14].alt=70;
+	input[16].alt=100;
+	input[4].g_lat=0;
+	input[5].g_long=0;
+	input[6].lst=4;
+	input[7].f107A=70;
+	input[8].f107=180;
+	input[9].ap=40;
+	input[15].ap_a=&aph;
+	input[16].ap_a=&aph;
+	/* evaluate 0 to 14 */
+  	for (i=0;i<15;i++)
+  		gtd7(&input[i], &flags, &output[i]);
+	/* evaluate 15 and 16 */
+  	flags.switches[9]=-1;
+  	for (i=15;i<17;i++)
+  		gtd7(&input[i], &flags, &output[i]);
+	/* output type 1 */
+  	for (i=0;i<17;i++) {
+		printf("\n");
+		for (j=0;j<9;j++)
+			printf("%E ",output[i].d[j]);
+		printf("%E ",output[i].t[0]);
+		printf("%E \n",output[i].t[1]);
+		/* DL omitted */
+  	}
+
+	/* output type 2 */
+	for (i=0;i<3;i++) {
+		printf("\n");
+		printf("\nDAY   ");
+		for (j=0;j<5;j++)
+			printf("         %3i",input[i*5+j].doy);
+		printf("\nUT    ");
+		for (j=0;j<5;j++)
+			printf("       %5.0f",input[i*5+j].sec);
+		printf("\nALT   ");
+		for (j=0;j<5;j++)
+			printf("        %4.0f",input[i*5+j].alt);
+		printf("\nLAT   ");
+		for (j=0;j<5;j++)
+			printf("         %3.0f",input[i*5+j].g_lat);
+		printf("\nLONG  ");
+		for (j=0;j<5;j++)
+			printf("         %3.0f",input[i*5+j].g_long);
+		printf("\nLST   ");
+		for (j=0;j<5;j++)
+			printf("       %5.0f",input[i*5+j].lst);
+		printf("\nF107A ");
+		for (j=0;j<5;j++)
+			printf("         %3.0f",input[i*5+j].f107A);
+		printf("\nF107  ");
+		for (j=0;j<5;j++)
+			printf("         %3.0f",input[i*5+j].f107);
+		printf("\n\n");
+  		printf("\nTINF  ");
+		for (j=0;j<5;j++)
+			printf("     %7.2f",output[i*5+j].t[0]);
+		printf("\nTG    ");
+		for (j=0;j<5;j++)
+			printf("     %7.2f",output[i*5+j].t[1]);
+		printf("\nHE    ");
+		for (j=0;j<5;j++)
+			printf("   %1.3e",output[i*5+j].d[0]);
+		printf("\nO     ");
+		for (j=0;j<5;j++)
+			printf("   %1.3e",output[i*5+j].d[1]);
+		printf("\nN2    ");
+		for (j=0;j<5;j++)
+			printf("   %1.3e",output[i*5+j].d[2]);
+		printf("\nO2    ");
+		for (j=0;j<5;j++)
+			printf("   %1.3e",output[i*5+j].d[3]);
+		printf("\nAR    ");
+		for (j=0;j<5;j++)
+			printf("   %1.3e",output[i*5+j].d[4]);
+		printf("\nH     ");
+		for (j=0;j<5;j++)
+			printf("   %1.3e",output[i*5+j].d[6]);
+		printf("\nN     ");
+		for (j=0;j<5;j++)
+			printf("   %1.3e",output[i*5+j].d[7]);
+		printf("\nANM 0 ");
+		for (j=0;j<5;j++)
+			printf("   %1.3e",output[i*5+j].d[8]);
+		printf("\nRHO   ");
+		for (j=0;j<5;j++)
+			printf("   %1.3e",output[i*5+j].d[5]);
+		printf("\n");
+	}
+	printf("\n");
+}
+
+
+/* ------------------------------------------------------------------- */
+/* -------------------------------- MAIN ----------------------------- */
+/* ------------------------------------------------------------------- */
+
+int main(void) {
+	test_gtd7();
+	return 0;
+}

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(${CXXTEST_INCLUDE_DIR})
 
 set(CMAKE_CXX_STANDARD 14)
 
@@ -19,16 +18,27 @@ set(UNIT_TESTS FGColumnVector3Test
                FGConditionTest
                FGPropertyManagerTest
                FGAtmosphereTest
-               FGAuxiliaryTest)
+               FGAuxiliaryTest
+               FGMSISTest)
+
 
 foreach(test ${UNIT_TESTS})
   cxxtest_add_test(${test}1 ${test}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${test}.h)
   target_link_libraries(${test}1 libJSBSim)
+  target_include_directories(${test}1 PUBLIC ${CXXTEST_INCLUDE_DIR})
   add_coverage(${test}1)
 endforeach()
 
-# Windows needs the DLL to be copied locally for unit tests to run.
 if(WIN32 AND BUILD_SHARED_LIBS)
+  # Windows cannot locate the symbol gtd7 as it is not exported in the JSBSim
+  # DLL. To keep NRLMSIS source files pristine, the option chosen is to
+  # compile NRLMSIS alongside the unit test FGMSISTest1.
+  set(MSIS_SOURCE_DIR ${PROJECT_SOURCE_DIR}/src/models/atmosphere/MSIS)
+  target_sources(FGMSISTest1 PUBLIC
+                  ${MSIS_SOURCE_DIR}/nrlmsise-00.c
+                  ${MSIS_SOURCE_DIR}/nrlmsise-00_data.c)
+
+  # Windows needs the DLL to be copied locally for unit tests to run.
   list(GET UNIT_TESTS 0 FIRST_UNIT_TEST) # Any target name will do so we just pick the first.
   add_custom_command(TARGET ${FIRST_UNIT_TEST}1 POST_BUILD
                       COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/tests/unit_tests/FGMSISTest.h
+++ b/tests/unit_tests/FGMSISTest.h
@@ -1,0 +1,328 @@
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <cxxtest/TestSuite.h>
+
+#include <FGFDMExec.h>
+#include <models/atmosphere/FGMSIS.h>
+#include <input_output/string_utilities.h>
+
+using namespace JSBSim;
+
+class DummyMSIS : public FGMSIS
+{
+public:
+  DummyMSIS(FGFDMExec* fdmex) : FGMSIS(fdmex) {
+    in.altitudeASL = 0.0;
+    in.GeodLatitudeDeg = 0.0;
+    in.LongitudeDeg = 0.0;
+  }
+
+  ~DummyMSIS() { PropertyManager->Unbind(this); }
+
+  // Getters for the protected members
+  double GetR(void) { return Reng; }
+  static constexpr double GetRstar(void) { return Rstar; }
+  static constexpr double GetBeta(void) { return Beta; }
+  static constexpr double GetSutherlandConstant(void) { return SutherlandConstant; }
+  static constexpr double GetPSFtoPa(void) { return psftopa; }
+  static constexpr double GetPSFtoInHg(void) { return psftoinhg; }
+  // Setters for the protected members
+  void SetDay(double day) { day_of_year = day; }
+  void SetSeconds(double seconds) { seconds_in_day = seconds; }
+  void SetF107A(double value) { input.f107A = value; }
+  void SetF107(double value) { input.f107 = value; }
+  void SetAP(double value) { input.ap = value; }
+};
+
+constexpr double Rstar = DummyMSIS::GetRstar();
+constexpr double gama = FGAtmosphere::SHRatio;
+constexpr double beta = DummyMSIS::GetBeta();
+constexpr double k = DummyMSIS::GetSutherlandConstant();
+constexpr double psftopa = DummyMSIS::GetPSFtoPa();
+constexpr double psftombar = psftopa/100.;
+constexpr double psftoinhg = DummyMSIS::GetPSFtoInHg();
+
+class FGMSISTest : public CxxTest::TestSuite, FGJSBBase
+{
+public:
+  static constexpr double kmtoft = 1000. / fttom;
+  static constexpr double gcm3_to_slugft3 = 1000. * kgtoslug / m3toft3;
+  static constexpr double gtoslug = kgtoslug / 1000.;
+
+  FGFDMExec fdmex;
+  std::shared_ptr<FGAtmosphere> std_atm;
+  vector<unsigned int> MSIS_iyd, MSIS_sec;
+  vector<double> MSIS_alt, MSIS_glat, MSIS_glon, MSIS_f107a, MSIS_f107, MSIS_ap,
+                 MSIS_T, MSIS_rho, MSIS_mair;
+
+  FGMSISTest() {
+    std_atm = fdmex.GetAtmosphere();
+    fdmex.GetPropertyManager()->Unbind(std_atm.get());
+
+    const double species_mmol[8] {28.0134, 31.9988, 31.9988/2.0, 4.0, 1.0, 39.948,
+                                  28.0134/2.0, 31.9988/2.0};
+    double n[8];
+    enum {N2=0, O2, O, He, H, Ar, N, OA};
+    struct nrlmsise_output output;
+	  struct nrlmsise_input input[15];
+  	struct nrlmsise_flags flags;
+    int i;
+    /* input values */
+  	flags.switches[0]=0;
+  	for (i=1;i<24;i++)
+  		flags.switches[i]=1;
+    for (i=0;i<15;i++) {
+      input[i].doy=172;
+      input[i].year=0; /* without effect */
+      input[i].sec=29000;
+      input[i].alt=400;
+      input[i].g_lat=60;
+      input[i].g_long=-70;
+      input[i].lst=16;
+      input[i].f107A=150;
+      input[i].f107=150;
+      input[i].ap=4;
+    }
+    input[1].doy=81;
+    input[2].sec=75000;
+    input[2].alt=1000;
+    input[3].alt=100;
+    input[10].alt=0;
+    input[11].alt=10;
+    input[12].alt=30;
+    input[13].alt=50;
+    input[14].alt=70;
+    input[6].alt=100;
+    input[4].g_lat=0;
+    input[5].g_long=0;
+    // input[6].lst=4;
+    input[7].f107A=70;
+    input[8].f107=180;
+    input[9].ap=40;
+    /* evaluate 0 to 14 */
+    for (i=0;i<15;i++) {
+      double mol = 0.0;
+      double mmol = 0.0;
+
+      input[i].lst = input[i].sec/3600.+input[i].g_long/15.;
+      MSIS_iyd.push_back(input[i].doy);
+      MSIS_sec.push_back(input[i].sec);
+      MSIS_alt.push_back(input[i].alt);
+      MSIS_glat.push_back(input[i].g_lat);
+      MSIS_glon.push_back(input[i].g_long);
+      MSIS_f107a.push_back(input[i].f107A);
+      MSIS_f107.push_back(input[i].f107);
+      MSIS_ap.push_back(input[i].ap);
+      gtd7(&input[i], &flags, &output);
+      MSIS_T.push_back(output.t[1]);
+      MSIS_rho.push_back(output.d[5]);
+      n[He] = output.d[0];
+      n[O] = output.d[1];
+      n[N2] = output.d[2];
+      n[O2] = output.d[3];
+      n[Ar] = output.d[4];
+      n[H] = output.d[6];
+      n[N] = output.d[7];
+      n[OA] = 0.0;
+
+      for(unsigned j=N2; j<=OA; ++j) {
+        mmol += n[j]*species_mmol[j];
+        mol += n[j];
+      }
+      MSIS_mair.push_back(mmol/mol);
+    }
+  }
+
+  void testConstructor()
+  {
+    auto atm = DummyMSIS(&fdmex);
+
+    double h = MSIS_alt[0]*kmtoft;
+
+    atm.SetDay(MSIS_iyd[0]);
+    atm.SetSeconds(MSIS_sec[0]);
+    atm.in.altitudeASL = h;
+    atm.in.GeodLatitudeDeg = MSIS_glat[0];
+    atm.in.LongitudeDeg = MSIS_glon[0];
+    atm.SetF107A(MSIS_f107a[0]);
+    atm.SetF107(MSIS_f107[0]);
+    atm.SetAP(MSIS_ap[0]);
+
+    double T = KelvinToRankine(MSIS_T[0]);
+    TS_ASSERT_EQUALS(atm.GetTemperatureSL(), 1.8);
+    TS_ASSERT_EQUALS(atm.GetTemperature(), 1.8);
+    TS_ASSERT_DELTA(atm.GetTemperature(h)/T, 1.0, 1E-5);
+    TS_ASSERT_EQUALS(atm.GetTemperatureRatio(), 1.0);
+    TS_ASSERT_DELTA(atm.GetTemperatureRatio(h)*1.8/T, 1.0, 1E-5);
+
+    double rho = MSIS_rho[0]*gcm3_to_slugft3;
+    TS_ASSERT_EQUALS(atm.GetDensitySL(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetDensity(), 0.0);
+    TS_ASSERT_DELTA(atm.GetDensity(h)/rho, 1.0, 2E-4);
+    TS_ASSERT_EQUALS(atm.GetDensityRatio(), 0.0);
+
+    double R = Rstar / (MSIS_mair[0]*gtoslug);
+    double P = rho*R*T;
+    TS_ASSERT_EQUALS(atm.GetPressureSL(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetPressure(), 0.0);
+    TS_ASSERT_DELTA(atm.GetPressure(h)/P, 1.0, 2E-4);
+    TS_ASSERT_EQUALS(atm.GetPressureRatio(), 0.0);
+
+    double a = sqrt(gama*R*T);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeedSL(), 1.0);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeed(), 0.0);
+    TS_ASSERT_DELTA(atm.GetSoundSpeed(h)/a, 1.0, 1E-4);
+    TS_ASSERT_EQUALS(atm.GetSoundSpeedRatio(), 0.0);
+
+    TS_ASSERT_EQUALS(atm.GetDensityAltitude(), 0.0);
+    TS_ASSERT_EQUALS(atm.GetPressureAltitude(), 0.0);
+
+    TS_ASSERT_EQUALS(atm.GetAbsoluteViscosity(), 0.0);
+    TS_ASSERT_EQUALS(atm.GetKinematicViscosity(), 0.0);
+  }
+
+  void testInitModel()
+  {
+    auto pm = fdmex.GetPropertyManager();
+    auto theta_node = pm->GetNode("atmosphere/theta");
+    auto sigma_node = pm->GetNode("atmosphere/sigma");
+    auto delta_node = pm->GetNode("atmosphere/delta");
+    auto a_ratio_node = pm->GetNode("atmosphere/a-ratio");
+
+    auto atm = DummyMSIS(&fdmex);
+    TS_ASSERT(atm.InitModel());
+
+    for (unsigned int i=0; i<MSIS_iyd.size(); ++i) {
+      double h = MSIS_alt[i]*kmtoft;
+
+      atm.SetDay(MSIS_iyd[i]);
+      atm.SetSeconds(MSIS_sec[i]);
+      atm.in.altitudeASL = h;
+      atm.in.GeodLatitudeDeg = MSIS_glat[i];
+      atm.in.LongitudeDeg = MSIS_glon[i];
+      atm.SetF107A(MSIS_f107a[i]);
+      atm.SetF107(MSIS_f107[i]);
+      atm.SetAP(MSIS_ap[i]);
+
+      double T = KelvinToRankine(MSIS_T[i]);
+      TS_ASSERT_DELTA(atm.GetTemperature(h)/T, 1.0, 1E-4);
+      TS_ASSERT_EQUALS(atm.GetTemperatureRatio(), 1.0);
+      TS_ASSERT_EQUALS(theta_node->getDoubleValue(), 1.0);
+
+      double rho = MSIS_rho[i]*gcm3_to_slugft3;
+      TS_ASSERT_DELTA(atm.GetDensity(h)/rho, 1.0, 5E-4);
+      TS_ASSERT_EQUALS(atm.GetDensityRatio(), 1.0);
+      TS_ASSERT_EQUALS(sigma_node->getDoubleValue(), 1.0);
+
+      double R = Rstar / (MSIS_mair[i]*gtoslug);
+      double P = rho*R*T;
+      TS_ASSERT_DELTA(atm.GetPressure(h)/P, 1.0, 5E-4);
+      TS_ASSERT_EQUALS(atm.GetPressureRatio(), 1.0);
+      TS_ASSERT_EQUALS(delta_node->getDoubleValue(), 1.0);
+
+      double a = sqrt(gama*R*T);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed(h)/a, 1.0, 1E-4);
+      TS_ASSERT_EQUALS(atm.GetSoundSpeedRatio(), 1.0);
+      TS_ASSERT_EQUALS(a_ratio_node->getDoubleValue(), 1.0);
+
+      double p_alt = atm.GetPressureAltitude();
+      double P_SL = atm.GetPressureSL();
+      TS_ASSERT_DELTA(std_atm->GetPressure(p_alt), P_SL, 1E-8);
+
+      double rho_alt = atm.GetDensityAltitude();
+      double rho_SL = atm.GetDensitySL();
+      TS_ASSERT_DELTA(std_atm->GetDensity(rho_alt)/rho_SL, 1.0, 1E-8);
+    }
+  }
+
+  void testRun()
+  {
+    auto pm = fdmex.GetPropertyManager();
+    auto T_node = pm->GetNode("atmosphere/T-R");
+    auto rho_node = pm->GetNode("atmosphere/rho-slugs_ft3");
+    auto P_node = pm->GetNode("atmosphere/P-psf");
+    auto a_node = pm->GetNode("atmosphere/a-fps");
+    auto T0_node = pm->GetNode("atmosphere/T-sl-R");
+    auto rho0_node = pm->GetNode("atmosphere/rho-sl-slugs_ft3");
+    auto a0_node = pm->GetNode("atmosphere/a-sl-fps");
+    auto theta_node = pm->GetNode("atmosphere/theta");
+    auto sigma_node = pm->GetNode("atmosphere/sigma");
+    auto delta_node = pm->GetNode("atmosphere/delta");
+    auto a_ratio_node = pm->GetNode("atmosphere/a-ratio");
+    auto density_altitude_node = pm->GetNode("atmosphere/density-altitude");
+    auto pressure_altitude_node = pm->GetNode("atmosphere/pressure-altitude");
+
+    auto atm = DummyMSIS(&fdmex);
+    TS_ASSERT(atm.InitModel());
+
+    for (unsigned int i=0; i<MSIS_iyd.size(); ++i) {
+      double h = MSIS_alt[i]*kmtoft;
+
+      atm.SetDay(MSIS_iyd[i]);
+      atm.SetSeconds(MSIS_sec[i]);
+      atm.in.altitudeASL = h;
+      atm.in.GeodLatitudeDeg = MSIS_glat[i];
+      atm.in.LongitudeDeg = MSIS_glon[i];
+      atm.SetF107A(MSIS_f107a[i]);
+      atm.SetF107(MSIS_f107[i]);
+      atm.SetAP(MSIS_ap[i]);
+
+      TS_ASSERT(atm.Run(false) == false);
+
+      double T = KelvinToRankine(MSIS_T[i]);
+      double T_SL = atm.GetTemperatureSL();
+      double T0 = atm.GetTemperature(0.0);
+      TS_ASSERT_DELTA(atm.GetTemperature()/T, 1.0, 1E-4);
+      TS_ASSERT_DELTA(T_node->getDoubleValue()/T, 1.0, 1E-4);
+      TS_ASSERT_EQUALS(T_SL, T0);
+      TS_ASSERT_EQUALS(T0_node->getDoubleValue(), T_SL);
+      TS_ASSERT_DELTA(atm.GetTemperatureRatio()*T_SL/T, 1.0, 1E-4);
+      TS_ASSERT_DELTA(theta_node->getDoubleValue()*T_SL/T, 1.0, 1E-4);
+
+      double rho = MSIS_rho[i]*gcm3_to_slugft3;
+      double rho_SL = atm.GetDensitySL();
+      double rho0= atm.GetDensity(0.0);
+      TS_ASSERT_DELTA(atm.GetDensity()/rho, 1.0, 5E-4);
+      TS_ASSERT_DELTA(rho_node->getDoubleValue()/rho, 1.0, 5E-4);
+      TS_ASSERT_EQUALS(rho_SL, rho0);
+      TS_ASSERT_EQUALS(rho0_node->getDoubleValue(), rho_SL);
+      TS_ASSERT_DELTA(atm.GetDensityRatio()*rho_SL/rho, 1.0, 5E-4);
+      TS_ASSERT_DELTA(sigma_node->getDoubleValue()*rho_SL/rho, 1.0, 5E-4);
+
+      double R = Rstar / (MSIS_mair[i]*gtoslug);
+      double P = rho*R*T;
+      double P_SL = atm.GetPressureSL();
+      double P0 = atm.GetPressure(0.0);
+      TS_ASSERT_DELTA(atm.GetPressure()/P, 1.0, 5E-4);
+      TS_ASSERT_DELTA(P_node->getDoubleValue()/P, 1.0, 5E-4);
+      TS_ASSERT_EQUALS(P_SL, P0);
+      TS_ASSERT_DELTA(atm.GetPressureRatio()*P_SL/P, 1.0, 5E-4);
+      TS_ASSERT_DELTA(delta_node->getDoubleValue()*P_SL/P, 1.0, 5E-4);
+
+      double a = sqrt(gama*R*T);
+      double a_SL = atm.GetSoundSpeedSL();
+      double a0 = atm.GetSoundSpeed(0.0);
+      TS_ASSERT_DELTA(atm.GetSoundSpeed()/a, 1.0, 1E-4);
+      TS_ASSERT_DELTA(a_node->getDoubleValue()/a, 1.0, 1E-4);
+      TS_ASSERT_EQUALS(a_SL, a0);
+      TS_ASSERT_EQUALS(a0_node->getDoubleValue(), a_SL);
+      TS_ASSERT_DELTA(atm.GetSoundSpeedRatio()*a_SL/a, 1.0, 1E-4);
+      TS_ASSERT_DELTA(a_ratio_node->getDoubleValue()*a_SL/a, 1.0, 1E-4);
+
+      double mu = beta*T*sqrt(T)/(k+T);
+      double nu = mu/rho;
+      TS_ASSERT_DELTA(atm.GetAbsoluteViscosity(), mu, 1E-4);
+      TS_ASSERT_DELTA(atm.GetKinematicViscosity()/nu, 1.0, 5E-4);
+
+
+      double p_alt = atm.GetPressureAltitude();
+      TS_ASSERT_DELTA(std_atm->GetPressure(p_alt), P, 1E-8);
+      TS_ASSERT_EQUALS(pressure_altitude_node->getDoubleValue(), p_alt);
+      double rho_alt = atm.GetDensityAltitude();
+      TS_ASSERT_DELTA(std_atm->GetDensity(rho_alt)/rho, 1.0, 1E-8);
+      TS_ASSERT_EQUALS(density_altitude_node->getDoubleValue(), rho_alt);
+    }
+  }
+};


### PR DESCRIPTION
This PR is a followup of the PRs #902 and #908.

This patch brings a major update to the `FGMSIS` class but does not plug it in yet. The ability to switch JSBSim atmosphere model to "MSIS" will be brought by another PR meaning that this PR code is non operational.

The changes are:
* The NRLMSIS00 code will be pure C code rather than being wrapped in a C++ class as is currently done in `FGMSIS.cpp`, `FGMSIS.h` and `FGMSISData.cpp`. This change is motivated by maintenance considerations: as the C code is kept pristine with respect to [Dominik Brodowski original code](https://www.brodo.de/space/nrlmsise/index.html), any update from Brodowski will only require a simple copy/paste of the files to update JSBSim rather manually updating some C++ code based on a diff.
* `FGMSIS` is now inheriting from `FGStandardAtmosphere` instead of `FGAtmosphere`. This is needed to compute the pressure and density altitudes.
  * The default value of `FGStandardAtmosphere::SaturatedVaporPressure` as been modified: it is now equal to `StdDaySLpressure` rather than being initialized to 0. This change is required to avoid a division by zero during the bind/unbind process (which is already tested by the unit test `FGMSISTest`).
* The management of the current day and hour has been moved from `FGAuxiliary` to `FGMSIS`. The latter is the only class that uses the current day and hour so this avoids splitting responsibilities between classes. IMHO would the current day and hour be needed by another class, I'd rather move them in `FGFDMExec` as it already manages the simulation time.
* A unit test `FGMSISTest` has been added.
* The CI workflow now validates the C code of NRLMSIS00 by checking that the output from `nrlmsise-00_test.c` complies with the reference output documented in the `DOCUMENTATION` file from D. Brodowski.