### PR TITLE
Enable the usage of the NRLMSIS00 atmospheric model.

### DIFF
--- a/tests/MSIS.xml
+++ b/tests/MSIS.xml
@@ -1,0 +1,6 @@
+<planet name="Earth">
+  <atmosphere model="MSIS">
+    <day>172</day>    <!--  Jun 21st  -->
+    <utc>29000</utc>  <!-- 08:03:20AM -->
+  </atmosphere>
+</planet>

--- a/tests/TestPlanet.py
+++ b/tests/TestPlanet.py
@@ -61,6 +61,20 @@ class TestPlanet(JSBSimTestCase):
 
         self.assertAlmostEqual(self.fdm['metrics/terrain-radius']*0.3048/1736000, 1.0)
 
+    def test_load_MSIS_atmosphere(self):
+        tripod = FlightModel(self, 'tripod')
+        MSIS_file = self.sandbox.path_to_jsbsim_file('tests/MSIS.xml')
+        self.fdm = tripod.start()
+        self.fdm.load_planet(MSIS_file, False)
+        self.fdm['ic/h-sl-ft'] = 0.0
+        self.fdm['ic/long-gc-deg'] = -70.0
+        self.fdm['ic/lat-geod-deg'] = 60.0
+        self.fdm.run_ic()
+
+        self.assertAlmostEqual(self.fdm['atmosphere/T-R']*5/9, 281.46476, delta=1E-5)
+        self.assertAlmostEqual(self.fdm['atmosphere/rho-slugs_ft3']/0.001940318, 1.263428, delta=1E-6)
+        self.assertAlmostEqual(self.fdm['atmosphere/P-psf'], 2132.294, delta=1E-3)
+
     def test_planet_geographic_error1(self):
         # Check that a negative equatorial radius raises an exception
         tripod = FlightModel(self, 'tripod')


### PR DESCRIPTION
This PR is the last step to enable the MSIS atmospheric model in JSBSim (the previous PRs were #902, #908 and #916).

After this PR will be merged, the usage of the MSIS atmosphere will be triggered by the following XML code:
```xml
<planet name="Earth">
  <atmosphere model="MSIS">
    <day>172</day>    <!--  Jun 21st  -->
    <utc>29000</utc>  <!-- 08:03:20AM -->
  </atmosphere>
</planet>
```
The XML can either be embedded in an aircraft definition file or supplied to `JSBSim.exe` via the `--planet` option or loaded with the C++ method `FGFDMExec::LoadPlanet()` or the Python method `FGFDMExec.load_planet()`.

At the moment the date shall be supplied as the day of the year, counting from Jan 1st which is day 1 to Dec 31st which is day 365. The time zone is [UTC+00:00](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) and the time is supplied as the number of seconds elapsed since 00:00 (12:00AM).

This PR adds a test to `TestPlanet.py` to check that the pressure, density and temperature are computed by the MSIS model when the XML file above is supplied.