### PR TITLE
Unreal Engine Mac compatibility

### DIFF
--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
@@ -403,13 +403,15 @@ void UJSBSimMovementComponent::InitializeJSBSim()
 		UE_LOG(LogJSBSim, Display, TEXT("Initializing JSBSimFlightDynamicsModel using Data in '%s'"), *RootDir);
 
 		// Set data paths...
-		FString AircraftPath(TEXT("aircraft"));
-		FString EnginePath(TEXT("engine"));
-		FString SystemPath(TEXT("systems"));
-		Exec->SetRootDir(SGPath(*RootDir));
-		Exec->SetAircraftPath(SGPath(*AircraftPath));
-		Exec->SetEnginePath(SGPath(*EnginePath));
-		Exec->SetSystemsPath(SGPath(*SystemPath));
+        std::string RootPath = std::string(TCHAR_TO_UTF8(*RootDir));
+        std::string AircraftPath = "aircraft";
+        std::string EnginePath = "engine";
+        std::string SystemPath = "systems";
+
+        Exec->SetRootDir(SGPath(RootPath));
+        Exec->SetAircraftPath(SGPath(AircraftPath));
+        Exec->SetEnginePath(SGPath(EnginePath));
+        Exec->SetSystemsPath(SGPath(SystemPath));
 
 		// Prepare Initial Conditions
 		TrimNeeded = true;

--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/ThirdParty/JSBSim.Build.cs
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/ThirdParty/JSBSim.Build.cs
@@ -45,5 +45,19 @@ public class JSBSim : ModuleRules
             }
             RuntimeDependencies.Add("$(BinaryOutputDir)/" + "JSBSim.dll", DllFullPath);
 		}
+
+		if (Target.Platform == UnrealTargetPlatform.Mac)
+		{
+			// Include headers
+			PublicSystemIncludePaths.Add(Path.Combine(ModuleDirectory, JSBSimLocalFolder, "Include"));
+
+			string LibFolderName = "Lib";
+			string LibPath = Path.Combine(ModuleDirectory, JSBSimLocalFolder, LibFolderName);
+            PublicAdditionalLibraries.Add(Path.Combine(LibPath, "libJSBSim.a"));
+
+			// Stage DLL along the binaries files
+			string DllFullPath = Path.Combine(LibPath, "libJSBSim.a");
+            RuntimeDependencies.Add(Path.Combine("$(BinaryOutputdir)/" + "libJSBSim.a", DllFullPath));
+		}
 	}
 }

--- a/UnrealEngine/UEReferenceApp.uproject
+++ b/UnrealEngine/UEReferenceApp.uproject
@@ -42,6 +42,7 @@
 		}
 	],
 	"TargetPlatforms": [
-		"Windows"
+		"Windows",
+		"Mac"
 	]
 }

--- a/build_macos_ue5.sh
+++ b/build_macos_ue5.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 
-# get the directory containing this script
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 # make build folder and cd into it
-mkdir build
+mkdir -p build
 cd build
 
 # build the jsbsim library with cmake
-cmake ../JSBSim
+cmake ../
 make
 
 # cd back to the root directory

--- a/build_macos_ue5.sh
+++ b/build_macos_ue5.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# get the directory containing this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# make build folder and cd into it
+mkdir build
+cd build
+
+# build the jsbsim library with cmake
+cmake ../JSBSim
+make
+
+# cd back to the root directory
+cd ..
+
+# set the unreal plugin folder for use in the script
+UNREAL_PLUGIN_FOLDER=./UnrealEngine/Plugins/JSBSimFlightDynamicsModel
+UNREAL_PLUGIN_INCLUDE_FOLDER=$UNREAL_PLUGIN_FOLDER/Source/ThirdParty/JSBSim/Include
+UNREAL_PLUGIN_LIB_FOLDER=$UNREAL_PLUGIN_FOLDER/Source/ThirdParty/JSBSim/Lib
+UNREAL_PLUGIN_RESOURCES_FOLDER=$UNREAL_PLUGIN_FOLDER/Resources/JSBSim
+
+echo "Copying JSBSim header files to Unreal plugin folder: $UNREAL_PLUGIN_INCLUDE_FOLDER"
+# make the  unreal plugin thirdparty/jsbsim/include folder
+rm -rf $UNREAL_PLUGIN_INCLUDE_FOLDER
+mkdir -p $UNREAL_PLUGIN_INCLUDE_FOLDER
+# copy the include files (.h,.hxx) from src (and its subdirectories) into unreal
+# plugin thirdparty/jsbsim/include folder, keeping the same directory structure
+# as in src. Since we're on macos, we use rsync instead of cp to preserve the
+# directory structure
+cd src
+find . -type f -iname "*.h**" -exec rsync --relative {} ../$UNREAL_PLUGIN_INCLUDE_FOLDER \;
+cd ..
+
+echo "Copying JSBSim library to Unreal plugin folder: $UNREAL_PLUGIN_LIB_FOLDER"
+# make the unreal plugin thirdparty/jsbsim/lib folder
+mkdir -p $UNREAL_PLUGIN_LIB_FOLDER
+# copy the jsbsim library (.a) from the build folder into the unreal plugin
+# thirdparty/jsbsim/lib folder
+cp ./build/src/libJSBSim.a $UNREAL_PLUGIN_FOLDER/Source/ThirdParty/JSBSim/Lib/.
+
+echo "Copying JSBSim resources to Unreal plugin folder: $UNREAL_PLUGIN_RESOURCES_FOLDER"
+# make the unreal plugin resources folder
+mkdir -p $UNREAL_PLUGIN_RESOURCES_FOLDER
+# copy the aircraft, engine, and systems folders into the unreal plugin resources folder
+cp -r ./aircraft $UNREAL_PLUGIN_FOLDER/Resources/JSBSim/.
+cp -r ./engine $UNREAL_PLUGIN_FOLDER/Resources/JSBSim/.
+cp -r ./systems $UNREAL_PLUGIN_FOLDER/Resources/JSBSim/.


### PR DESCRIPTION
This PR addresses the following issues related to the UnrealEngine JSBSim project:

1. The default `UnrealEngine` project does not support Mac as a build target
2. The existing movement component fails to compile on UE 5.2 Mac 

and additionally adds a `build_macos_ue5.sh` script which uses cmake to build the `jsbsim` library (.a), then copies the relevant headers, resources, and libs into the `ThirdParty` directory within the unreal engine plugin for building on MacOS.