### PR TITLE
Maintenance / Minor changes

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -737,7 +737,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:
-          working-directory: build/lcov/data/capture
+          directory: build/lcov/data/capture
           files: all_targets.info
 
   Rolling-Release:

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Debian packages for Ubuntu Linux "Bionic" 18.04 LTS and "Focal" 20.04 LTS for 64
 
 * `JSBSim_1.1.13-986.amd64.deb` which installs the executables `JSBSim` and `aeromatic`
 * `JSBSim-devel_1.1.13-986.amd64.deb` which installs the development resources (headers and libraries)
-* `python3-JSBSim_1.1.13-986.amd64.deb` which installs the Python 3.6 module of JSBSim
+* `python3-JSBSim_1.1.13-986.amd64.deb` which installs the Python module of JSBSim
 
 ### Python module
 
-JSBSim provides binary wheel packages for its Python module on Windows, Mac OSX and Linux platforms for several Python versions (3.6, 3.7, 3.8, 3.9 and 3.10). These can be installed using either `pip` or `conda`.
+JSBSim provides binary wheel packages for its Python module on Windows, Mac OSX and Linux platforms for several Python versions (3.7, 3.8, 3.9, 3.10 and 3.11). These can be installed using either `pip` or `conda`.
 
 #### Installation with `pip`
 

--- a/python/jsbsim.pxd
+++ b/python/jsbsim.pxd
@@ -38,7 +38,7 @@ cdef extern from "ExceptionManagement.h":
 cdef extern from "initialization/FGInitialCondition.h" namespace "JSBSim":
     cdef cppclass c_FGInitialCondition "JSBSim::FGInitialCondition":
         c_FGInitialCondition(c_FGInitialCondition* ic)
-        bool Load(const c_SGPath& rstfile, bool useStoredPath)
+        bool Load(const c_SGPath& rstfile, bool useAircraftPath)
 
 cdef extern from "initialization/FGLinearization.h" namespace "JSBSim":
     cdef cppclass c_FGLinearization "JSBSim::FGLinearization":

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -752,7 +752,7 @@ cdef class FGFDMExec(FGJSBBase):
                                       model.encode(), add_model_to_path)
 
     def load_script(self, script: str, delta_t: float = 0.0, initfile:str = "") -> bool:
-        """@Dox(JSBSim::FGFDMExec::LoadScript) """
+        """@Dox(JSBSim::FGFDMExec::LoadScript)"""
         scriptfile = os.path.join(self.get_root_dir(), script)
         if not os.path.exists(scriptfile):
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
@@ -951,15 +951,15 @@ cdef class FGFDMExec(FGJSBBase):
         """@Dox(JSBSim::FGFDMExec::GetDebugLevel) """
         return self.thisptr.GetDebugLevel()
 
-    def load_ic(self, rstfile: str, useStoredPath: bool) -> bool:
+    def load_ic(self, rstfile: str, useAircraftPath: bool) -> bool:
         reset_file = _append_xml(rstfile)
-        if useStoredPath and not os.path.isabs(reset_file):
+        if useAircraftPath and not os.path.isabs(reset_file):
             reset_file = os.path.join(self.get_full_aircraft_path(), reset_file)
         if not os.path.exists(reset_file):
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
                                     reset_file)
         return deref(self.thisptr.GetIC()).Load(c_SGPath(rstfile.encode(), NULL),
-                                                useStoredPath)
+                                                useAircraftPath)
 
     def get_propagate(self) -> FGPropagate:
         """@Dox(JSBSim::FGFDMExec::GetPropagate)"""

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -796,7 +796,7 @@ bool FGFDMExec::LoadPlanet(Element* element)
       string model = atm_element->GetAttributeValue("model");
       if (model == "MSIS") {
         // Replace the existing atmosphere model
-        instance->Unbind(Models[eAtmosphere].get());
+        instance->Unbind(Models[eAtmosphere]);
         Models[eAtmosphere] = std::make_shared<FGMSIS>(this);
         Atmosphere = static_cast<FGAtmosphere*>(Models[eAtmosphere].get());
 

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -300,6 +300,10 @@ int main(int argc, char* argv[])
     std::cerr << "FATAL ERROR: JSBSim terminated with an exception."
               << std::endl << "The message was: " << msg << std::endl;
     return 1;
+  } catch (const JSBSim::BaseException& e) {
+    std::cerr << "FATAL ERROR: JSBSim terminated with an exception."
+              << std::endl << "The message was: " << e.what() << std::endl;
+    return 1;
   } catch (...) {
     std::cerr << "FATAL ERROR: JSBSim terminated with an unknown exception."
               << std::endl;
@@ -794,7 +798,7 @@ void PrintHelp(void)
     cout << "    --nice  specifies to run at lower CPU usage" << endl;
     cout << "    --nohighlight  specifies that console output should be pure text only (no color)" << endl;
     cout << "    --suspend  specifies to suspend the simulation after initialization" << endl;
-    cout << "    --initfile=<filename>  specifies an initilization file" << endl;
+    cout << "    --initfile=<filename>  specifies an initialization file" << endl;
     cout << "    --planet=<filename>  specifies a planet definition file" << endl;
     cout << "    --catalog specifies that all properties for this aircraft model should be printed" << endl;
     cout << "              (catalog=aircraftname is an optional format)" << endl;

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -1002,10 +1002,10 @@ double FGInitialCondition::GetBodyVelFpsIC(int idx) const
 
 //******************************************************************************
 
-bool FGInitialCondition::Load(const SGPath& rstfile, bool useStoredPath)
+bool FGInitialCondition::Load(const SGPath& rstfile, bool useAircraftPath)
 {
   SGPath init_file_name;
-  if(useStoredPath && rstfile.isRelative()) {
+  if(useAircraftPath && rstfile.isRelative()) {
     init_file_name = fdmex->GetFullAircraftPath()/rstfile.utf8Str();
   } else {
     init_file_name = rstfile;
@@ -1022,7 +1022,7 @@ bool FGInitialCondition::Load(const SGPath& rstfile, bool useStoredPath)
     throw BaseException(s.str());
   }
 
-  if (document->GetName() != string("initialize")) {
+  if (document->GetName() != "initialize") {
     stringstream s;
     s << "File: " << init_file_name << " is not a reset file.";
     cerr << s.str() << endl;

--- a/src/initialization/FGInitialCondition.h
+++ b/src/initialization/FGInitialCondition.h
@@ -667,9 +667,9 @@ public:
 
   /** Loads the initial conditions.
       @param rstname The name of an initial conditions file
-      @param useStoredPath true if the stored path to the IC file should be used
+      @param useAircraftPath true if path is given relative to the aircraft path.
       @return true if successful */
-  bool Load(const SGPath& rstname, bool useStoredPath = true );
+  bool Load(const SGPath& rstname, bool useAircraftPath = true );
 
   /** Is an engine running ?
       @param index of the engine to be checked

--- a/src/input_output/FGPropertyManager.cpp
+++ b/src/input_output/FGPropertyManager.cpp
@@ -61,7 +61,7 @@ void FGPropertyManager::Unbind(void)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropertyManager::Unbind(void* instance)
+void FGPropertyManager::Unbind(const void* instance)
 {
   auto it = tied_properties.begin();
 

--- a/src/input_output/FGPropertyManager.h
+++ b/src/input_output/FGPropertyManager.h
@@ -43,6 +43,7 @@ INCLUDES
 
 #include <string>
 #include <list>
+#include <memory>
 #include "simgear/props/props.hxx"
 #if !PROPS_STANDALONE
 # include "simgear/math/SGMath.hxx"
@@ -437,8 +438,21 @@ class JSBSIM_API FGPropertyManager
      *
      * Classes should use this function to release control of any
      * properties they have bound using this property manager.
+     * @param instance The instance which properties shall be unbound.
      */
-    void Unbind(void* instance);
+    void Unbind(const void* instance);
+
+    /**
+     * Unbind all properties bound by this manager to an instance.
+     *
+     * Classes should use this function to release control of any
+     * properties they have bound using this property manager.
+     * Helper function for shared_ptr
+     * @see Unbind(const void*)
+     */
+    template <typename T> void Unbind(const std::shared_ptr<T>& instance) {
+      Unbind(instance.get());
+    }
 
     /**
      * Tie a property to an external variable.
@@ -615,10 +629,10 @@ class JSBSIM_API FGPropertyManager
   private:
     struct PropertyState {
       SGPropertyNode_ptr node;
-      void* BindingInstance = nullptr;
+      const void* BindingInstance = nullptr;
       bool WriteAttribute = true;
       bool ReadAttribute = true;
-      PropertyState(SGPropertyNode* property, void* instance)
+      PropertyState(SGPropertyNode* property, const void* instance)
         : node(property), BindingInstance(instance) {
         WriteAttribute = node->getAttribute(SGPropertyNode::WRITE);
         ReadAttribute = node->getAttribute(SGPropertyNode::READ);

--- a/src/math/FGParameterValue.h
+++ b/src/math/FGParameterValue.h
@@ -34,8 +34,6 @@
   INCLUDES
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <stdexcept>
-
 #include "math/FGRealValue.h"
 #include "math/FGPropertyValue.h"
 #include "input_output/FGXMLElement.h"

--- a/src/models/FGInertial.cpp
+++ b/src/models/FGInertial.cpp
@@ -292,7 +292,7 @@ void FGInertial::Debug(int from)
       cout << "    Semi minor axis: " << b << endl;
       cout << "    Rotation rate  : " << scientific << vOmegaPlanet(eZ) << endl;
       cout << "    GM             : " << GM << endl;
-      cout << "    J2             : " << J2 << endl << defaultfloat;
+      cout << "    J2             : " << J2 << endl << defaultfloat << endl;
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification

--- a/src/models/FGInertial.h
+++ b/src/models/FGInertial.h
@@ -133,7 +133,7 @@ public:
   }
 
   /** Set the simulation time.
-      The elapsed time can be used by the ground callbck to assess the planet
+      The elapsed time can be used by the ground callback to assess the planet
       rotation or the movement of objects.
       @param time elapsed time in seconds since the simulation started.
   */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,5 +54,5 @@ set(PYTHON_TESTS ResetOutputFiles
 
 foreach(test ${PYTHON_TESTS})
   add_test(NAME ${test}
-    COMMAND ${Python3_EXECUTABLE} -B ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py)
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${test}.py)
 endforeach()

--- a/tests/JSBSim_utils.py
+++ b/tests/JSBSim_utils.py
@@ -266,9 +266,8 @@ def FindDifferences(ref, other, tol):
     delta = np.abs(ref - other)
 
     idxmax = delta.idxmax()
-    ref_max = pd.Series(ref.lookup(idxmax, ref.columns), index=ref.columns)
-    other_max = pd.Series(other.lookup(idxmax, other.columns),
-                          index=other.columns)
+    ref_max = pd.Series(np.diag(ref.loc[idxmax]), index=ref.columns)
+    other_max = pd.Series(np.diag(other.loc[idxmax]), index=other.columns)
     diff = pd.concat([idxmax, delta.max(), ref_max, other_max], axis=1)
     diff.columns = ['Time', 'delta', 'ref value', 'value']
     return diff[diff['delta'] > tol]

--- a/tests/TestInputSocket.py
+++ b/tests/TestInputSocket.py
@@ -45,7 +45,7 @@ class TelnetInterface:
         return self.getOutput()
 
     def getOutput(self):
-        time.sleep(0.5) # Wait for the socket to process all the data.
+        time.sleep(1.0) # Wait for the socket to process all the data.
         return self.tn.read_very_eager().decode()
 
     def getPropertyValue(self, property):

--- a/tests/unit_tests/FGAtmosphereTest.h
+++ b/tests/unit_tests/FGAtmosphereTest.h
@@ -58,7 +58,7 @@ public:
 
   FGAtmosphereTest() {
     auto atm = fdmex.GetAtmosphere();
-    fdmex.GetPropertyManager()->Unbind(atm.get());
+    fdmex.GetPropertyManager()->Unbind(atm);
   }
 
   void testDefaultValuesBeforeInit()

--- a/tests/unit_tests/FGAtmosphereTest.h
+++ b/tests/unit_tests/FGAtmosphereTest.h
@@ -34,7 +34,6 @@ public:
   }
   // Getters for the protected members
   static constexpr double GetR(void) { return Reng0; }
-  static constexpr double GetGamma(void) { return SHRatio; }
   static constexpr double GetBeta(void) { return Beta; }
   static constexpr double GetSutherlandConstant(void) { return SutherlandConstant; }
   static constexpr double GetPSFtoPa(void) { return psftopa; }
@@ -44,7 +43,7 @@ private:
 };
 
 constexpr double R = DummyAtmosphere::GetR();
-constexpr double gama = DummyAtmosphere::GetGamma();
+constexpr double gama = FGAtmosphere::SHRatio;
 constexpr double beta = DummyAtmosphere::GetBeta();
 constexpr double k = DummyAtmosphere::GetSutherlandConstant();
 constexpr double psftopa = DummyAtmosphere::GetPSFtoPa();

--- a/tests/unit_tests/FGAuxiliaryTest.h
+++ b/tests/unit_tests/FGAuxiliaryTest.h
@@ -20,16 +20,24 @@ public:
 
 constexpr double R = DummyAtmosphere::GetR();
 
-class FGAtmosphereTest : public CxxTest::TestSuite
+class FGAuxiliaryTest : public CxxTest::TestSuite
 {
 public:
   static constexpr double gama = FGAtmosphere::SHRatio;
 
-  void testPitotTotalPressure() {
-    FGFDMExec fdmex;
-    auto atm = fdmex.GetAtmosphere();
-    auto aux = FGAuxiliary(&fdmex);
+  FGFDMExec fdmex;
+  std::shared_ptr<FGAtmosphere> atm;
+
+  FGAuxiliaryTest() {
+    auto aux = fdmex.GetAuxiliary();
+    atm = fdmex.GetAtmosphere();
     atm->InitModel();
+    fdmex.GetPropertyManager()->Unbind(aux);
+  }
+
+  void testPitotTotalPressure() {
+    auto aux = FGAuxiliary(&fdmex);
+    aux.in.vLocation = fdmex.GetAuxiliary()->in.vLocation;
 
     // Ambient conditions far upstream (i.e. upstream the normal schock
     // in supersonic flight)
@@ -64,13 +72,13 @@ public:
       // energy conservation
       TS_ASSERT_DELTA(Cp*t1+0.5*u1*u1, Cp*t2+0.5*u2*u2, epsilon);
     }
+
+    fdmex.GetPropertyManager()->Unbind(&aux);
   }
 
   void testMachFromImpactPressure() {
-    FGFDMExec fdmex;
-    auto atm = fdmex.GetAtmosphere();
     auto aux = FGAuxiliary(&fdmex);
-    atm->InitModel();
+    aux.in.vLocation = fdmex.GetAuxiliary()->in.vLocation;
 
     // Ambient conditions far upstream (i.e. upstream the normal schock
     // in supersonic flight)
@@ -112,14 +120,14 @@ public:
       TS_ASSERT_DELTA(mach1, M1, 1e-7);
       TS_ASSERT_DELTA(mach2, M2, 1e-7);
     }
+
+    fdmex.GetPropertyManager()->Unbind(&aux);
   }
 
   void testCASConversion() {
-    FGFDMExec fdmex;
-    auto atm = fdmex.GetAtmosphere();
     auto aux = FGAuxiliary(&fdmex);
-    atm->InitModel();
     aux.in.StdDaySLsoundspeed = atm->StdDaySLsoundspeed;
+    aux.in.vLocation = fdmex.GetAuxiliary()->in.vLocation;
 
     // Ambient conditions far upstream (i.e. upstream the normal schock
     // in supersonic flight)
@@ -176,5 +184,7 @@ public:
 
       TS_ASSERT_DELTA(aux.VcalibratedFromMach(M1, p1)/(mach*asl), 1.0, 1e-8);
     }
+
+    fdmex.GetPropertyManager()->Unbind(&aux);
   }
 };

--- a/tests/unit_tests/FGMSISTest.h
+++ b/tests/unit_tests/FGMSISTest.h
@@ -58,7 +58,7 @@ public:
 
   FGMSISTest() {
     std_atm = fdmex.GetAtmosphere();
-    fdmex.GetPropertyManager()->Unbind(std_atm.get());
+    fdmex.GetPropertyManager()->Unbind(std_atm);
 
     const double species_mmol[8] {28.0134, 31.9988, 31.9988/2.0, 4.0, 1.0, 39.948,
                                   28.0134/2.0, 31.9988/2.0};


### PR DESCRIPTION
This PR brings a number of minor changes:
* Fixes a number of typos.
* Fixes the list of supported versions of the Python interpreter in `README.md`.
* The last parameter of `FGInitialCondition::Load()` is renamed from `useStoredPath` to `useAircraftPath` which, I think, is more explicit.
* Adds a helper method `FGPropertyManager::Unbind()` that takes a `std::shared_ptr` argument. This avoids explicitly calling the method `std::shared_ptr::get()` when using `Unbind()` i.e. this is syntactic sugar :smiley:
* Fixes the function `FindDifferences` in `JSBSim_utils.py` as the `DataFrames.lookup` method [is now obsolete in the library `pandas` 2.0](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#removal-of-prior-version-deprecations-changes).
* The sleep time of the method `getOutput` has been increased from 0.5s to 1.0s in the test case `TestInputSocket.py`. This is to avoid this test to randomly fail with MSVC when our CI workflow is executed on GitHub.