### PR TITLE
Linearization from console executable and xml script 

### DIFF
--- a/scripts/737_cruise_steady_turn_linearize.xml
+++ b/scripts/737_cruise_steady_turn_linearize.xml
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="http://jsbsim.sf.net/JSBSimScript.xsl"?>
+<runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://jsbsim.sf.net/JSBSimScript.xsd"
+    name="Cruise flight with steady turn in 737.">
+
+  <description>
+    This is a very simple script that trims the aircraft with running
+    engines, exports linearized equations, and runs out to 10 seconds.
+  </description>
+
+  <use aircraft="737" initialize="cruise_steady_turn_init"/> 
+
+  <run start="0" end="10" dt="0.008333">
+
+    <property value="0"> simulation/notify-time-trigger </property>
+
+    <event name="Set engines running">
+      <condition> simulation/sim-time-sec le 0.1 </condition>
+      <set name="propulsion/engine[0]/set-running" value="1"/>
+      <set name="propulsion/engine[1]/set-running" value="1"/>
+      <notify/>
+    </event>
+
+    <!--
+      For "do_simple_trim" (Classic trim):
+      0: Longitudinal
+      1: Full
+      2: Ground
+      3: Pullup
+      4: Custom
+      5: Turn
+      6: None
+    -->
+    
+    <event name="Trim">
+      <condition>
+        simulation/sim-time-sec gt 0.1
+      </condition>
+      <set name="simulation/do_simple_trim" value="5"/>
+      <delay>0.0</delay>
+      <notify>
+        <property>propulsion/engine[0]/n2</property>
+        <property>propulsion/engine[1]/n2</property>
+        <property>propulsion/engine[0]/thrust-lbs</property>
+        <property>propulsion/engine[1]/thrust-lbs</property>
+        <property>velocities/vc-kts</property>
+        <property>velocities/vc-fps</property>
+        <property>velocities/vt-fps</property>
+        <property>attitude/phi-rad</property>
+        <property>attitude/theta-rad</property>
+        <property>attitude/psi-rad</property>
+      </notify>
+    </event>
+    
+    <event name="Linearization">
+      <condition> simulation/sim-time-sec gt 1.0 </condition>
+      <set name="simulation/do_linearization" value="1"/>
+      <delay>0.0</delay>
+      <notify>
+        <property>propulsion/engine[0]/n2</property>
+        <property>propulsion/engine[0]/thrust-lbs</property>
+        <property>propulsion/engine[1]/n2</property>
+        <property>propulsion/engine[1]/thrust-lbs</property>
+        <property>velocities/vc-kts</property>
+        <property>velocities/vc-fps</property>
+        <property>velocities/vt-fps</property>
+        <property>attitude/phi-rad</property>
+        <property>attitude/theta-rad</property>
+        <property>attitude/psi-rad</property>
+      </notify>
+    </event>
+
+    <event name="Repeating Notify" persistent="true">
+      <description>Output message at 5 second intervals</description>
+      <notify>
+        <property>propulsion/engine[0]/n2</property>
+        <property>propulsion/engine[1]/n2</property>
+        <property>propulsion/engine[0]/thrust-lbs</property>
+        <property>propulsion/engine[1]/thrust-lbs</property>
+        <property>position/h-agl-ft</property>
+        <property>velocities/vc-kts</property>
+        <property>velocities/vc-fps</property>
+        <property>velocities/vt-fps</property>
+        <property>attitude/phi-rad</property>
+        <property>attitude/theta-rad</property>
+        <property>attitude/psi-rad</property>
+      </notify>
+      <condition> simulation/sim-time-sec >= simulation/notify-time-trigger </condition>
+      <set name="simulation/notify-time-trigger" value="5" type="FG_DELTA"/>
+    </event>
+
+  </run>
+
+</runscript>

--- a/scripts/737_cruise_steady_turn_linearize.xml
+++ b/scripts/737_cruise_steady_turn_linearize.xml
@@ -33,42 +33,12 @@
       6: None
     -->
     
-    <event name="Trim">
+    <event name="Trim and linearize">
       <condition>
         simulation/sim-time-sec gt 0.1
       </condition>
       <set name="simulation/do_simple_trim" value="5"/>
-      <delay>0.0</delay>
-      <notify>
-        <property>propulsion/engine[0]/n2</property>
-        <property>propulsion/engine[1]/n2</property>
-        <property>propulsion/engine[0]/thrust-lbs</property>
-        <property>propulsion/engine[1]/thrust-lbs</property>
-        <property>velocities/vc-kts</property>
-        <property>velocities/vc-fps</property>
-        <property>velocities/vt-fps</property>
-        <property>attitude/phi-rad</property>
-        <property>attitude/theta-rad</property>
-        <property>attitude/psi-rad</property>
-      </notify>
-    </event>
-    
-    <event name="Linearization">
-      <condition> simulation/sim-time-sec gt 1.0 </condition>
-      <set name="simulation/do_linearization" value="1"/>
-      <delay>0.0</delay>
-      <notify>
-        <property>propulsion/engine[0]/n2</property>
-        <property>propulsion/engine[0]/thrust-lbs</property>
-        <property>propulsion/engine[1]/n2</property>
-        <property>propulsion/engine[1]/thrust-lbs</property>
-        <property>velocities/vc-kts</property>
-        <property>velocities/vc-fps</property>
-        <property>velocities/vt-fps</property>
-        <property>attitude/phi-rad</property>
-        <property>attitude/theta-rad</property>
-        <property>attitude/psi-rad</property>
-      </notify>
+      <set name="simulation/do_linearization" value="0"/>
     </event>
 
     <event name="Repeating Notify" persistent="true">

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -159,7 +159,6 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   Constructing = true;
   typedef int (FGFDMExec::*iPMF)(void) const;
   instance->Tie("simulation/do_simple_trim", this, (iPMF)0, &FGFDMExec::DoTrim);
-  // instance->Tie("simulation/do_simplex_trim", this, (iPMF)0, &FGFDMExec::DoSimplexTrim);
   instance->Tie("simulation/do_linearization", this, (iPMF)0, &FGFDMExec::DoLinearization);
   instance->Tie("simulation/reset", this, (iPMF)0, &FGFDMExec::ResetToInitialConditions);
   instance->Tie("simulation/disperse", this, &FGFDMExec::GetDisperse);
@@ -1320,8 +1319,10 @@ void FGFDMExec::DoTrim(int mode)
 
 void FGFDMExec::DoLinearization(int)
 {
+  double dt0 = this->GetDeltaT();
   FGLinearization lin(this);
   lin.WriteScicoslab();
+  this->Setdt(dt0);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -161,7 +161,7 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   typedef int (FGFDMExec::*iPMF)(void) const;
   instance->Tie("simulation/do_simple_trim", this, (iPMF)0, &FGFDMExec::DoTrim);
   instance->Tie("simulation/do_simplex_trim", this, (iPMF)0, &FGFDMExec::DoSimplexTrim);
-  instance->Tie("simulation/do_linearization", this, &FGFDMExec::DoLinearization);
+  instance->Tie("simulation/do_linearization", this, (iPMF)0, &FGFDMExec::DoLinearization);
   instance->Tie("simulation/reset", this, (iPMF)0, &FGFDMExec::ResetToInitialConditions);
   instance->Tie("simulation/disperse", this, &FGFDMExec::GetDisperse);
   instance->Tie("simulation/randomseed", this, (iPMF)&FGFDMExec::SRand, &FGFDMExec::SRand);
@@ -1336,7 +1336,7 @@ void FGFDMExec::DoSimplexTrim(int mode)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGFDMExec::DoLinearization(int mode)
+void FGFDMExec::DoLinearization(void)
 {
   double saved_time;
   if (Constructing) return;

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -60,7 +60,6 @@ INCLUDES
 #include "models/FGAuxiliary.h"
 #include "models/FGInput.h"
 #include "initialization/FGTrim.h"
-#include "initialization/FGSimplexTrim.h"
 #include "initialization/FGLinearization.h"
 #include "input_output/FGScript.h"
 #include "input_output/FGXMLFileRead.h"
@@ -160,7 +159,7 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   Constructing = true;
   typedef int (FGFDMExec::*iPMF)(void) const;
   instance->Tie("simulation/do_simple_trim", this, (iPMF)0, &FGFDMExec::DoTrim);
-  instance->Tie("simulation/do_simplex_trim", this, (iPMF)0, &FGFDMExec::DoSimplexTrim);
+  // instance->Tie("simulation/do_simplex_trim", this, (iPMF)0, &FGFDMExec::DoSimplexTrim);
   instance->Tie("simulation/do_linearization", this, (iPMF)0, &FGFDMExec::DoLinearization);
   instance->Tie("simulation/reset", this, (iPMF)0, &FGFDMExec::ResetToInitialConditions);
   instance->Tie("simulation/disperse", this, &FGFDMExec::GetDisperse);
@@ -1319,30 +1318,10 @@ void FGFDMExec::DoTrim(int mode)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGFDMExec::DoSimplexTrim(int mode)
+void FGFDMExec::DoLinearization(int)
 {
-  double saved_time;
-  if (Constructing) return;
-  if (mode < 0 || mode > JSBSim::tNone) {
-      cerr << endl << "Illegal trimming mode!" << endl << endl;
-      return;
-  }
-  saved_time = sim_time;
-  FGSimplexTrim trim(this, (JSBSim::TrimMode)mode);
-  Setsim_time(saved_time);
-  std::cout << "dT: " << dT << std::endl;
-  trim_completed = 1;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void FGFDMExec::DoLinearization(void)
-{
-  double saved_time;
-  if (Constructing) return;
-  saved_time = sim_time;
   FGLinearization lin(this);
-  Setsim_time(saved_time);
+  lin.WriteScicoslab();
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -474,12 +474,11 @@ public:
   * - tTurn
   * - tNone  */
   void DoTrim(int mode);
-  void DoSimplexTrim(int mode);
 
   /** Executes linearization with state-space output
    * You must trim first to get an accurate state-space model
    */
-  void DoLinearization(void);
+  void DoLinearization(int);
   
   /// Disables data logging to all outputs.
   void DisableOutput(void) { Output->Disable(); }

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -479,7 +479,7 @@ public:
   /** Executes linearization with state-space output
    * You must trim first to get an accurate state-space model
    */
-  void DoLinearization(int mode);
+  void DoLinearization(void);
   
   /// Disables data logging to all outputs.
   void DisableOutput(void) { Output->Disable(); }

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -474,7 +474,13 @@ public:
   * - tTurn
   * - tNone  */
   void DoTrim(int mode);
+  void DoSimplexTrim(int mode);
 
+  /** Executes linearization with state-space output
+   * You must trim first to get an accurate state-space model
+   */
+  void DoLinearization(int mode);
+  
   /// Disables data logging to all outputs.
   void DisableOutput(void) { Output->Disable(); }
   /// Enables data logging to all outputs.

--- a/src/initialization/FGLinearization.cpp
+++ b/src/initialization/FGLinearization.cpp
@@ -87,9 +87,10 @@ void FGLinearization::WriteScicoslab() const {
 }
 
 void FGLinearization::WriteScicoslab(std::string& path) const {
-    int width=10;
+    int width=20;
+    int precision=10;
     std::ofstream scicos(path.c_str());
-    scicos.precision(10);
+    scicos.precision(precision);
     width=20;
     scicos  << std::scientific
             << aircraft_name << ".x0=..\n" << std::setw(width) << x0 << ";\n"
@@ -101,6 +102,60 @@ void FGLinearization::WriteScicoslab(std::string& path) const {
             << std::setw(width) << D << ");\n"
             << aircraft_name << ".tfm = ss2tf(" << aircraft_name << ".sys);\n"
             << std::endl;
+    scicos.close();
+
+    // Export A Matrix to CSV file - - - - - - - - - - - - -
+    std::ofstream aFile("a.csv");
+    aFile.precision(10);
+
+    // States Names
+    for (unsigned int i = 0; i < x_names.size(); i++)
+      aFile << x_names[i] << ",";
+    aFile << "\n";
+
+    // A matrix
+    for (int i = 0; i < A.size(); i++) {
+      for (int j = 0; j < A[i].size(); j++)
+        aFile << std::scientific << std::setw(width) << A[i][j] << ",";
+      aFile << "\n";
+    }
+    aFile.close();
+
+    cout << "\n\nState Matrix written to file. States:\n";
+    for (unsigned int i = 0; i < x_names.size(); i++)
+      cout << std::setw(width) << x_names[i] << ",";
+    cout << "\n";
+    for (unsigned int i = 0; i < x_units.size(); i++) {
+      cout << std::setw(width) << x_units[i] << ",";
+    }
+    cout << "\n";
+
+    // Export B Matrix to CSV file - - - - - - - - - - - - -
+    std::ofstream bFile("b.csv");
+    bFile.precision(10);
+
+    // Control Names
+    for (unsigned int i = 0; i < u_names.size(); i++)
+      bFile << u_names[i] << ",";
+    bFile << "\n";
+
+    // B matrix
+    for (int i = 0; i < B.size(); i++) {
+      for (int j = 0; j < B[i].size(); j++)
+        bFile << std::scientific << std::setw(width) << B[i][j] << ",";
+      bFile << "\n";
+    }
+    bFile.close();
+    
+    cout << "\n\nControl Matrix written to file. Control inputs:\n";
+    for (unsigned int i = 0; i < u_names.size(); i++)
+      cout << std::setw(width) << u_names[i] << ",";
+    cout << "\n";
+    for (unsigned int i = 0; i < u_units.size(); i++) {
+      cout << std::setw(width) << u_units[i] << ",";
+    }
+    cout << "\n";
+
 }
 
 } // JSBSim

--- a/src/initialization/FGLinearization.cpp
+++ b/src/initialization/FGLinearization.cpp
@@ -104,58 +104,6 @@ void FGLinearization::WriteScicoslab(std::string& path) const {
             << std::endl;
     scicos.close();
 
-    // Export A Matrix to CSV file - - - - - - - - - - - - -
-    std::ofstream aFile("a.csv");
-    aFile.precision(10);
-
-    // States Names
-    for (unsigned int i = 0; i < x_names.size(); i++)
-      aFile << x_names[i] << ",";
-    aFile << "\n";
-
-    // A matrix
-    for (int i = 0; i < A.size(); i++) {
-      for (int j = 0; j < A[i].size(); j++)
-        aFile << std::scientific << std::setw(width) << A[i][j] << ",";
-      aFile << "\n";
-    }
-    aFile.close();
-
-    cout << "\n\nState Matrix written to file. States:\n";
-    for (unsigned int i = 0; i < x_names.size(); i++)
-      cout << std::setw(width) << x_names[i] << ",";
-    cout << "\n";
-    for (unsigned int i = 0; i < x_units.size(); i++) {
-      cout << std::setw(width) << x_units[i] << ",";
-    }
-    cout << "\n";
-
-    // Export B Matrix to CSV file - - - - - - - - - - - - -
-    std::ofstream bFile("b.csv");
-    bFile.precision(10);
-
-    // Control Names
-    for (unsigned int i = 0; i < u_names.size(); i++)
-      bFile << u_names[i] << ",";
-    bFile << "\n";
-
-    // B matrix
-    for (int i = 0; i < B.size(); i++) {
-      for (int j = 0; j < B[i].size(); j++)
-        bFile << std::scientific << std::setw(width) << B[i][j] << ",";
-      bFile << "\n";
-    }
-    bFile.close();
-    
-    cout << "\n\nControl Matrix written to file. Control inputs:\n";
-    for (unsigned int i = 0; i < u_names.size(); i++)
-      cout << std::setw(width) << u_names[i] << ",";
-    cout << "\n";
-    for (unsigned int i = 0; i < u_units.size(); i++) {
-      cout << std::setw(width) << u_units[i] << ",";
-    }
-    cout << "\n";
-
 }
 
 } // JSBSim


### PR DESCRIPTION
This pull request corresponds to issue #989. Enables linearization from console executable and xml script; this workflow was available in previous JSBSim versions. The example script shows how to use the feature with the existing 737 aircraft model.

I think we can ultimately do better than this workaround:
https://github.com/JSBSim-Team/jsbsim/issues/989#issuecomment-1819929733
