### PR TITLE
Run tests on M1 MacOS runners.

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -430,18 +430,21 @@ jobs:
   MacOSX:
     name: C/C++ build (MacOSX)
     needs: [XML-validation, MSIS-validation]
-    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, arm64]
+        os: [macos-12]
+        python-version: [3.8]
+        include:
+          - os: macos-14
+            python-version: '3.10'
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
       - name: Install Python packages
-        if: matrix.arch == 'x86_64'
         run: pip install -U cython 'numpy>=1.20' pandas scipy build 'setuptools>=60.0.0' mypy
       - name: Checkout JSBSim
         uses: actions/checkout@v4
@@ -449,12 +452,11 @@ jobs:
         # This file is used by CTest to optimize the distribution of the tests
         # between the cores and reduce execution time.
         uses: actions/cache@v4
-        if: matrix.arch == 'x86_64'
         with:
           path: build/Testing/Temporary/CTestCostData.txt
-          key: ${{ runner.os }}-${{ hashFiles('tests/CMakeLists.txt') }}
+          key: ${{ matrix.os }}-${{ hashFiles('tests/CMakeLists.txt') }}
       - name: Install & Configure Doxygen
-        if: env.release == 'true' && matrix.arch == 'x86_64'
+        if: env.release == 'true' && matrix.os == 'macos-12'
         run: |
           brew install doxygen
           # We don't want Doxygen to generate the HTML docs in this job (saves time)
@@ -470,27 +472,20 @@ jobs:
       - name: Configure CxxTest
         working-directory: cxxtest/python
         run: python setup.py install
-      - name: Configure JSBSim (x86_64)
-        if: matrix.arch == 'x86_64'
+      - name: Configure JSBSim
         run: |
           mkdir -p build && cd build
           julia -e "import Pkg;Pkg.add(\"CxxWrap\")"
           export CXXWRAP_PREFIX_PATH=`julia -e "using CxxWrap;print(CxxWrap.prefix_path())"`
-          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DBUILD_JULIA_PACKAGE=ON -DCYTHON_FLAGS="-X embedsignature=True" -DCMAKE_PREFIX_PATH=$CXXWRAP_PREFIX_PATH ..
-      - name: Configure JSBSim (arm64)
-        if: matrix.arch == 'arm64'
-        run: |
-          mkdir -p build && cd build
-          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DCMAKE_OSX_ARCHITECTURES=${{matrix.arch}} -DBUILD_PYTHON_MODULE=OFF -DBUILD_DOCS=OFF ..
+          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DBUILD_JULIA_PACKAGE=ON -DCYTHON_FLAGS="-X embedsignature=True" -DCMAKE_PREFIX_PATH=$CXXWRAP_PREFIX_PATH -DCMAKE_C_FLAGS_DEBUG="-g -O2 -fno-fast-math" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2 -fno-fast-math" -DCMAKE_BUILD_TYPE=Debug ..
       - name: Build JSBSim
         working-directory: build
         run: make -j3
       - name: Test JSBSim
-        if: matrix.arch == 'x86_64'
         working-directory: build
         run: ctest -j3 --output-on-failure
       - name: Build the source package for Python
-        if: env.release == 'true' && matrix.arch == 'x86_64'
+        if: env.release == 'true' && matrix.os == 'macos-12'
         working-directory: build/tests
         run: |
           echo "::group::Build the type hints stubs"
@@ -516,7 +511,7 @@ jobs:
 
       - name: Upload Files for Release
         uses: actions/upload-artifact@v4
-        if: env.release == 'true' && matrix.arch == 'x86_64'
+        if: env.release == 'true' && matrix.os == 'macos-12'
         with:
           name: ${{ runner.os }}.binaries
           path: |
@@ -653,7 +648,7 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: |
             cd build
             rm -f CMakeCache.txt
-            cmake -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_C_FLAGS_RELEASE="-g -O2 -DNDEBUG -fno-math-errno" -DCMAKE_CXX_FLAGS_RELEASE="-g -O2 -DNDEBUG -fno-math-errno" -DCMAKE_BUILD_TYPE=Release ..
+            cmake -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_C_FLAGS_RELEASE="-g -O2 -DNDEBUG -fno-math-errno -fno-fast-math" -DCMAKE_CXX_FLAGS_RELEASE="-g -O2 -DNDEBUG -fno-math-errno -fno-fast-math" -DCMAKE_BUILD_TYPE=Release ..
             cmake --build . --target libJSBSim -- -j3
           CIBW_ARCHS_MACOS: universal2
           CIBW_SKIP: cp*-musllinux_*

--- a/tests/TestActuator.py
+++ b/tests/TestActuator.py
@@ -116,14 +116,14 @@ class TestActuator(JSBSimTestCase):
         self.tree.write(os.path.join('aircraft', self.aircraft_name,
                                      self.aircraft_name+'.xml'))
 
-        # A new process is created that launches the script. We wait for 10
+        # A new process is created that launches the script. We wait for 50
         # times the reference execution time for the script completion. Beyond
         # that time, if the process is not completed, it is terminated and the
         # test is failed.
         p = Process(target=SubProcessScriptExecution,
                     args=(self.sandbox, self.script_path))
         p.start()
-        p.join(exec_time * 20.0)  # Wait 20 times the reference time
+        p.join(exec_time * 50.0)  # Wait 50 times the reference time
         alive = p.is_alive()
         if alive:
             p.terminate()

--- a/tests/unit_tests/FGAuxiliaryTest.h
+++ b/tests/unit_tests/FGAuxiliaryTest.h
@@ -70,7 +70,11 @@ public:
       // momentum conservation
       TS_ASSERT_DELTA(p1+rho1*u1*u1, p2+rho2*u2*u2, 1000.*epsilon);
       // energy conservation
+#ifdef __arm64__
+      TS_ASSERT_DELTA((Cp*t1+0.5*u1*u1)/(Cp*t2+0.5*u2*u2), 1.0, epsilon);
+#else
       TS_ASSERT_DELTA(Cp*t1+0.5*u1*u1, Cp*t2+0.5*u2*u2, epsilon);
+#endif
     }
 
     fdmex.GetPropertyManager()->Unbind(&aux);
@@ -115,7 +119,11 @@ public:
       // momentum conservation
       TS_ASSERT_DELTA(p1+rho1*u1*u1, p2+rho2*u2*u2, 1000.*epsilon);
       // energy conservation
+#ifdef __arm64__
+      TS_ASSERT_DELTA((Cp*t1+0.5*u1*u1)/(Cp*t2+0.5*u2*u2), 1.0, epsilon);
+#else
       TS_ASSERT_DELTA(Cp*t1+0.5*u1*u1, Cp*t2+0.5*u2*u2, epsilon);
+#endif
       // Check the Mach computations
       TS_ASSERT_DELTA(mach1, M1, 1e-7);
       TS_ASSERT_DELTA(mach2, M2, 1e-7);

--- a/tests/unit_tests/FGGroundCallbackTest.h
+++ b/tests/unit_tests/FGGroundCallbackTest.h
@@ -93,7 +93,11 @@ public:
         TS_ASSERT_VECTOR_EQUALS(w, zero);
         FGColumnVector3 vLoc = loc;
         FGColumnVector3 vContact = contact;
+#ifdef __arm64__
+        TS_ASSERT_DELTA(vContact.Magnitude()/RadiusReference, 1.0, epsilon);
+#else
         TS_ASSERT_DELTA(vContact.Magnitude(), RadiusReference, epsilon);
+#endif
         FGColumnVector3 vtest = vLoc/(1.+h/RadiusReference);
         TS_ASSERT_DELTA(vtest(1), vContact(1), 1e-8);
         TS_ASSERT_DELTA(vtest(2), vContact(2), 1e-8);

--- a/tests/unit_tests/FGInitialConditionTest.h
+++ b/tests/unit_tests/FGInitialConditionTest.h
@@ -31,9 +31,14 @@ public:
     TS_ASSERT_EQUALS(ic.GetPsiDegIC(), 0.0);
     TS_ASSERT_EQUALS(ic.GetPsiRadIC(), 0.0);
     TS_ASSERT_EQUALS(ic.GetAltitudeASLFtIC(), 0.0);
+#ifdef __arm64__
+    TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC(), 0.0, 1E-8);
+    TS_ASSERT_DELTA(ic.GetTerrainElevationFtIC(), 0.0, 1E-8);
+#else
     TS_ASSERT_EQUALS(ic.GetAltitudeAGLFtIC(), 0.0);
-    TS_ASSERT_EQUALS(ic.GetEarthPositionAngleIC(), 0.0);
     TS_ASSERT_EQUALS(ic.GetTerrainElevationFtIC(), 0.0);
+#endif
+    TS_ASSERT_EQUALS(ic.GetEarthPositionAngleIC(), 0.0);
     TS_ASSERT_EQUALS(ic.GetVcalibratedKtsIC(), 0.0);
     TS_ASSERT_EQUALS(ic.GetVequivalentKtsIC(), 0.0);
     TS_ASSERT_EQUALS(ic.GetVgroundFpsIC(), 0.0);
@@ -132,8 +137,8 @@ public:
           TS_ASSERT_DELTA(ic.GetLongitudeDegIC(), lon, epsilon*100.);
           TS_ASSERT_DELTA(ic.GetLongitudeRadIC(), lon*M_PI/180., epsilon);
           // TS_ASSERT_DELTA(ic.GetAltitudeASLFtIC()/(agl+2000.), 1.0, 2E-8);
-          // For some reasons, MinGW32 and MSVC are less accurate than other platforms.
-#if defined(_MSC_VER) || defined(__MINGW32__)
+          // For some reasons, MinGW32, MSVC and M1 MacOS are less accurate than other platforms.
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__arm64__)
           TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC()/agl, 1.0, 4E-8);
 #else
           TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC()/agl, 1.0, 2E-8);
@@ -286,15 +291,21 @@ public:
       TS_ASSERT_DELTA(ic.GetUBodyFpsIC(), 100., epsilon*10.);
       TS_ASSERT_DELTA(ic.GetVBodyFpsIC(), 0., epsilon);
       TS_ASSERT_DELTA(ic.GetWBodyFpsIC(), 0., epsilon);
+#ifdef __arm64__
+      TS_ASSERT_DELTA(ic.GetVNorthFpsIC(), 100.*cos(theta*M_PI/180.), epsilon*10.);
+      TS_ASSERT_DELTA(ic.GetVgroundFpsIC(), abs(100.*cos(theta*M_PI/180.)),
+                      epsilon*10.);
+#else
       TS_ASSERT_DELTA(ic.GetVNorthFpsIC(), 100.*cos(theta*M_PI/180.), epsilon);
+      TS_ASSERT_DELTA(ic.GetVgroundFpsIC(), abs(100.*cos(theta*M_PI/180.)),
+                      epsilon);
+#endif
       TS_ASSERT_DELTA(ic.GetVEastFpsIC(), 0.0, epsilon);
       TS_ASSERT_DELTA(ic.GetVDownFpsIC(), -100.*sin(theta*M_PI/180.),
                       epsilon*10.);
       TS_ASSERT_DELTA(ic.GetAlphaDegIC(), 0.0, epsilon*10.);
       TS_ASSERT_DELTA(ic.GetBetaDegIC(), 0.0, epsilon);
       TS_ASSERT_DELTA(ic.GetVtrueFpsIC(), 100., epsilon*10.);
-      TS_ASSERT_DELTA(ic.GetVgroundFpsIC(), abs(100.*cos(theta*M_PI/180.)),
-                      epsilon);
       TS_ASSERT_DELTA(ic.GetPhiDegIC(), 0.0, epsilon);
       TS_ASSERT_DELTA(ic.GetThetaDegIC(), theta, epsilon*10.);
       TS_ASSERT_DELTA(ic.GetPsiDegIC(), 0.0, epsilon);

--- a/tests/unit_tests/FGQuaternionTest.h
+++ b/tests/unit_tests/FGQuaternionTest.h
@@ -319,7 +319,11 @@ public:
     z = z < -180.0 ? z + 360. : z;
     TS_ASSERT_DELTA(60., x, epsilon);
     TS_ASSERT_DELTA(45., y, epsilon);
+#ifdef __arm64__
+    TS_ASSERT_DELTA(-30., z, epsilon*10.);
+#else
     TS_ASSERT_DELTA(-30., z, epsilon);
+#endif
 
     euler = q0.GetEulerDeg();
     x = euler(1);
@@ -333,7 +337,11 @@ public:
     z = z < -180.0 ? z + 360. : z;
     TS_ASSERT_DELTA(60., x, epsilon);
     TS_ASSERT_DELTA(45., y, epsilon);
+#ifdef __arm64__
+    TS_ASSERT_DELTA(-30., z, epsilon*10.);
+#else
     TS_ASSERT_DELTA(-30., z, epsilon);
+#endif
 
     // Euler angles sin
     TS_ASSERT_DELTA(0.5*sqrt(3), q0.GetSinEuler(1), epsilon);


### PR DESCRIPTION
Until now we were only testing that JSBSim was successfully compiling on Apple M1 chips using cross-compilation on Intel MacOS GitHub runners. The resulting binaries were not tested on the actual hardware so we were happily assuming that if it compiles then it runs swiftly. And everyone knows how reliable that criterion is :smile:

These dark ages are now over: [GitHub just introduced M1 MacOS runners](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source), so this PR implements the testing of JSBSim on that platform.

Note that the floating point precision requirement had to be slightly relaxed at some places in the unit tests ...despite using the flag `-fno-fast-math`. If someone who has access to an M1 Macbook or equivalent knows better then by all means submit fixes :+1:

Note also that the issue that was fixed by PR #143 (random failure of `TestActuator.py`) is resurfacing with M1 MacOS runners. This has been fixed again by extending further the waiting time of `test_regression_bug_1503`:
https://github.com/JSBSim-Team/jsbsim/blob/6f0c4d805c499cf18280bcf8d7af358aee494876/tests/TestActuator.py#L94-L130

