### PR TITLE
Documentation updates.

### DIFF
--- a/python/jsbsim.pxd
+++ b/python/jsbsim.pxd
@@ -76,7 +76,7 @@ cdef extern from "input_output/FGPropertyManager.h" namespace "JSBSim":
         const string& GetName() const
         const string& GetFullyQualifiedName() const
         double getDoubleValue() const
-        void setDoubleValue(double value)
+        bool setDoubleValue(double value)
 
 cdef extern from "input_output/FGPropertyManager.h" namespace "JSBSim":
     cdef cppclass c_FGPropertyManager "JSBSim::FGPropertyManager":

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -170,14 +170,19 @@ cdef class FGPropertyNode:
         return node.__validate_node_pointer(create)
 
     def get_double_value(self) -> float:
-        """@Dox(SGPropertyNode::getDoubleValue)"""
+        """Get the property value.
+
+           :return: The property value as a double."""
         self.__intercept_invalid_pointer()
         return self.thisptr.ptr().getDoubleValue()
 
-    def set_double_value(self, value: float) -> None:
-        """@Dox(SGPropertyNode::setDoubleValue)"""
+    def set_double_value(self, value: float) -> bool:
+        """Set the property value.
+
+           :param value: The new value.
+           :return: True if the assignment succeeded, False otherwise."""
         self.__intercept_invalid_pointer()
-        self.thisptr.ptr().setDoubleValue(value)
+        return self.thisptr.ptr().setDoubleValue(value)
 
 cdef class FGPropertyManager:
     """@Dox(JSBSim::FGPropertyManager)"""

--- a/src/models/FGFCS.h
+++ b/src/models/FGFCS.h
@@ -199,7 +199,7 @@ public:
 
   /** Runs the Flight Controls model; called by the Executive
       Can pass in a value indicating if the executive is directing the simulation to Hold.
-      @param Holding if true, the executive has been directed to hold the sim from 
+      @param Holding if true, the executive has been directed to hold the sim from
                      advancing time. Some models may ignore this flag, such as the Input
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
@@ -243,9 +243,13 @@ public:
 
   const std::vector<double>& GetThrottleCmd() const {return ThrottleCmd;}
 
-  /** Gets the mixture command.
-      @param engine engine ID number
-      @return mixture command in range from 0 - 1.0 for the given engine */
+/** Gets the mixture command.
+    @param engine engine ID number
+    @return mixture command for the given engine
+    @note The mixture command is generally in range from 0 - 1.0, but some
+          models might set it to a value above 1.0.
+    @note JSBSim does not check nor enforce the value to be within 0.0-1.0.
+*/
   double GetMixtureCmd(int engine) const { return MixtureCmd[engine]; }
 
   const std::vector<double>& GetMixtureCmd() const {return MixtureCmd;}
@@ -324,7 +328,11 @@ public:
 
   /** Gets the mixture position.
       @param engine engine ID number
-      @return mixture position for the given engine in range from 0 - 1.0 */
+      @return mixture position for the given engine
+      @note The mixture position is generally in range from 0 - 1.0, but some
+            models might set it to a value above 1.0.
+      @note JSBSim does not check nor enforce the value to be within 0.0-1.0.
+  */
   double GetMixturePos(int engine) const { return MixturePos[engine]; }
 
   const std::vector<double>& GetMixturePos() const {return MixturePos;}
@@ -416,7 +424,11 @@ public:
 
   /** Sets the mixture command for the specified engine
       @param engine engine ID number
-      @param cmd normalized mixture command (0.0 - 1.0)*/
+      @param cmd normalized mixture command
+      @note The mixture command is generally in range from 0 - 1.0, but some
+            models handle values above 1.0.
+      @note JSBSim does not check nor enforce the value to be within 0.0-1.0.
+  */
   void SetMixtureCmd(int engine, double cmd);
 
   /** Set the gear extend/retract command, defaults to down
@@ -471,7 +483,14 @@ public:
 
   /** Sets the actual mixture setting for the specified engine
       @param engine engine ID number
-      @param cmd normalized mixture setting (0.0 - 1.0)*/
+      @param cmd normalized mixture setting
+      @note The mixture position is typically within the range of 0 to 1.0, but
+            some models can handle values above 1.0. In the default piston
+            engine model, a mixture position of 1.0 corresponds to the full
+            power setting, and the full rich setting is reached at a value
+            higher than 1.0.
+      @note JSBSim does not check nor enforce the value to be within 0.0-1.0.
+  */
   void SetMixturePos(int engine, double cmd);
 
   /** Set the gear extend/retract position, defaults to down
@@ -531,7 +550,7 @@ public:
   double GetCBrake(void) const {return BrakePos[FGLGear::bgCenter];}
   //@}
 
-  enum SystemType { stFCS, stSystem, stAutoPilot }; 
+  enum SystemType { stFCS, stSystem, stAutoPilot };
 
   /** Loads the Flight Control System.
       Load() is called from FGFDMExec.


### PR DESCRIPTION
This PR addresses 2 issues related to documentation:
* Issue #922 where the build process crashes if the Python documentation generation is triggered.
* Issue #1037 where the documentation is misleading in claiming that mixture position and command shall be constrained within the range from 0.0 to 1.0

Regarding the first issue, the problem is due to the lack of Doxygen documentation in `src/simgear/props/props.hxx` which makes `python/Doxy2PyDocStrings.py` crash. The problem has been fixed by including the documentation of `FGPropertyNode.get_double_value()` and `FGPropertyNode.get_double_value()` directly in `python/JSBSim.pyx.in`.

In the process, `FGPropertyNode.set_double_value()` has been fixed to behave like its C++ counterpart (returns a boolean to indicate if the update of the property value has succeeded).