### PR TITLE
Added ability to dynamically change thruster location via property

### DIFF
--- a/src/models/propulsion/FGForce.h
+++ b/src/models/propulsion/FGForce.h
@@ -261,9 +261,9 @@ public:
   inline void SetLocationX(double x) {vXYZn(eX) = x; vActingXYZn(eX) = x;}
   inline void SetLocationY(double y) {vXYZn(eY) = y; vActingXYZn(eY) = y;}
   inline void SetLocationZ(double z) {vXYZn(eZ) = z; vActingXYZn(eZ) = z;}
-  inline double SetActingLocationX(double x) {vActingXYZn(eX) = x; return x;}
-  inline double SetActingLocationY(double y) {vActingXYZn(eY) = y; return y;}
-  inline double SetActingLocationZ(double z) {vActingXYZn(eZ) = z; return z;}
+  inline void SetActingLocationX(double x) {vActingXYZn(eX) = x;}
+  inline void SetActingLocationY(double y) {vActingXYZn(eY) = y;}
+  inline void SetActingLocationZ(double z) {vActingXYZn(eZ) = z;}
   inline void SetLocation(const FGColumnVector3& vv) { vXYZn = vv; SetActingLocation(vv);}
   inline void SetActingLocation(const FGColumnVector3& vv) { vActingXYZn = vv; }
 

--- a/src/models/propulsion/FGThruster.cpp
+++ b/src/models/propulsion/FGThruster.cpp
@@ -79,6 +79,13 @@ FGThruster::FGThruster(FGFDMExec *FDMExec, Element *el, int num ): FGForce(FDMEx
   string property_name, base_property_name;
   base_property_name = CreateIndexedPropertyName("propulsion/engine", EngineNum);
 
+  property_name = base_property_name + "/x-position";
+  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetLocationX, &FGForce::SetLocationX);
+  property_name = base_property_name + "/y-position";
+  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetLocationY, &FGForce::SetLocationY);
+  property_name = base_property_name + "/z-position";
+  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetLocationZ, &FGForce::SetLocationZ);
+
   element = thruster_element->FindElement("pointing");
   if (element)  {
 

--- a/src/models/propulsion/FGThruster.cpp
+++ b/src/models/propulsion/FGThruster.cpp
@@ -79,12 +79,18 @@ FGThruster::FGThruster(FGFDMExec *FDMExec, Element *el, int num ): FGForce(FDMEx
   string property_name, base_property_name;
   base_property_name = CreateIndexedPropertyName("propulsion/engine", EngineNum);
 
+  property_name = base_property_name + "/x-reference-position";
+  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetLocationX);
+  property_name = base_property_name + "/y-reference-position";
+  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetLocationY);
+  property_name = base_property_name + "/z-reference-position";
+  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetLocationZ);
   property_name = base_property_name + "/x-position";
-  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetLocationX, &FGForce::SetLocationX);
+  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetActingLocationX, &FGForce::SetActingLocationX);
   property_name = base_property_name + "/y-position";
-  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetLocationY, &FGForce::SetLocationY);
+  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetActingLocationY, &FGForce::SetActingLocationY);
   property_name = base_property_name + "/z-position";
-  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetLocationZ, &FGForce::SetLocationZ);
+  PropertyManager->Tie(property_name.c_str(), (FGForce*)this, &FGForce::GetActingLocationZ, &FGForce::SetActingLocationZ);
 
   element = thruster_element->FindElement("pointing");
   if (element)  {


### PR DESCRIPTION
In vehicle's such as tiltrotors the rotor must be both translated (i.e. `x_position = cos(theta)*rotor_height + base_x`) and rotated, only the `pitch-angle-rad` is exposed via property and prevents scripting a tilt-rotor adequately.