### PR TITLE
CI workflow fixes

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -737,6 +737,7 @@ jobs:
         with:
           file: ./build/lcov/data/capture/all_targets.info
           token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
           fail_ci_if_error: true
 
   Rolling-Release:

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-22.04, windows-latest ]
+        os: [ macos-12, ubuntu-22.04, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout JSBSim
@@ -447,6 +447,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Python packages
         run: pip install -U cython 'numpy>=1.20' pandas scipy build 'setuptools>=60.0.0' mypy
+      - name: Set up Julia
+        uses: julia-actions/setup-julia@v2
       - name: Checkout JSBSim
         uses: actions/checkout@v4
       - name: Cache CTest cost data
@@ -575,7 +577,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11, windows-2019]
+        os: [ubuntu-latest, macos-12, windows-2019]
 
     steps:
       - name: Checkout JSBSim
@@ -592,7 +594,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install doxygen
       - name: Install Doxygen (MacOSX)
-        if: matrix.os == 'macos-11'
+        if: matrix.os == 'macos-12'
         run: brew install doxygen
       - name: Install Doxygen (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -53,7 +53,7 @@ jobs:
           cmake ../src/models/atmosphere/MSIS
       - name: Build the JSBSim test program
         working-directory: build
-        run: make -j2
+        run: make --jobs=3
       - name: Run the NRLMSIS-00 C package
         working-directory: src/models/atmosphere/MSIS
         run: |
@@ -125,7 +125,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('tests/CMakeLists.txt') }}
       - name: Build JSBSim
         working-directory: build
-        run: make -j2
+        run: make --jobs=$(nproc)
       - name: Test with Valgrind
         run: |
           valgrind --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes --xml=yes --xml-file=valgrind_Short_S23_3.xml build/src/JSBSim scripts/Short_S23_3.xml --end-time=5.
@@ -136,7 +136,7 @@ jobs:
         run: LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/src ctest -R fpectl -V
       - name: Test JSBSim
         working-directory: build
-        run: LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/src ctest -j2 --output-on-failure
+        run: LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/src ctest --parallel $(nproc) --output-on-failure
       - name: Build Ubuntu packages
         if: env.static_link == 'true'
         working-directory: build
@@ -186,7 +186,7 @@ jobs:
           cmake -DBUILD_MATLAB_SFUNCTION=ON ..
       - name: Build JSBSim S-Function
         working-directory: build
-        run: cmake --build . --config RelWithDebInfo --target JSBSim_SFunction
+        run: cmake --build . --config RelWithDebInfo --target JSBSim_SFunction --parallel 3
       - name: Prepare Tests
         working-directory: matlab
         # The script will be run from the directory 'matlab' so we need to copy
@@ -263,14 +263,14 @@ jobs:
           cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=${{matrix.shared_libs}} -DBUILD_JULIA_PACKAGE=ON -DCMAKE_INCLUDE_PATH="$(get-location)\..\cxxtest" -DBUILD_PYTHON_MODULE=OFF -DBUILD_DOCS=OFF -DCMAKE_PREFIX_PATH="$CXXWRAP_PREFIX_PATH" ..
       - name: Build JSBSim
         working-directory: build
-        run: mingw32-make -j2
+        run: mingw32-make --jobs=$Env:NUMBER_OF_PROCESSORS
       - name: Test executable
         run: build/src/JSBSim.exe scripts/c1721.xml
       - name: Run JSBSim tests
         working-directory: build
         run: |
           cp src/libJSBSim.* julia/.
-          ctest -j2 --output-on-failure
+          ctest --parallel $Env:NUMBER_OF_PROCESSORS --output-on-failure
 
     # Upload files
       - name: On failure - Upload logs
@@ -335,13 +335,13 @@ jobs:
           cmake -DCMAKE_INCLUDE_PATH="$(get-location)\..\cxxtest" -DCMAKE_PREFIX_PATH="$(get-location)\..\backward-cpp" -DBUILD_SHARED_LIBS=${{matrix.shared_libs}} -DFPECTL_DISPLAY_STACK_TRACE=ON -DSTACK_DETAILS_AUTO_DETECT=FALSE ..
       - name: Build JSBSim
         working-directory: build
-        run: cmake --build . --config RelWithDebInfo
+        run: cmake --build . --config RelWithDebInfo --parallel $Env:NUMBER_OF_PROCESSORS
       - name: Test the Display of the Stack Trace when an FPE is raised
         working-directory: build
         run: ctest -R fpectl --build-config RelWithDebInfo -V
       - name: Test JSBSim
         working-directory: build
-        run: ctest -j2 --build-config RelWithDebInfo --output-on-failure
+        run: ctest -- parallel $Env:NUMBER_OF_PROCESSORS --build-config RelWithDebInfo --output-on-failure
 
     # On failure, upload logs
       - name: On failure - Upload logs
@@ -483,10 +483,10 @@ jobs:
           cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DBUILD_JULIA_PACKAGE=ON -DCYTHON_FLAGS="-X embedsignature=True" -DCMAKE_PREFIX_PATH=$CXXWRAP_PREFIX_PATH -DCMAKE_C_FLAGS_DEBUG="-g -O2 -fno-fast-math" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2 -fno-fast-math" -DCMAKE_BUILD_TYPE=Debug ..
       - name: Build JSBSim
         working-directory: build
-        run: make -j3
+        run: make --jobs=$(sysctl -n hw.logicalcpu)
       - name: Test JSBSim
         working-directory: build
-        run: ctest -j3 --output-on-failure
+        run: ctest --parallel $(sysctl -n hw.logicalcpu) --output-on-failure
       - name: Build the source package for Python
         if: env.release == 'true' && matrix.os == 'macos-12'
         working-directory: build/tests
@@ -630,12 +630,12 @@ jobs:
           New-Item -Path .\build -ItemType Directory -Force
           cd build
           cmake ..
-          cmake --build . --target libJSBSim --config RelWithDebInfo
+          cmake --build . --target libJSBSim --config RelWithDebInfo --parallel $Env:NUMBER_OF_PROCESSORS
           echo "::endgroup::"
 
           echo "::group::Get Python package sources"
           New-Item python\jsbsim\py.typed
-          cd ..\python/dist
+          cd ..\python\dist
           $PyPackage = Get-ChildItem .\*.tar.gz -Name
           tar zxvf $PyPackage
           Copy-Item -Path .\JSBSim-*\jsbsim\*.pyi -Destination ..\..\build\python\jsbsim
@@ -647,12 +647,12 @@ jobs:
             cd build
             rm -f CMakeCache.txt
             cmake -DCMAKE_C_FLAGS_RELEASE="-g -O2 -DNDEBUG -fno-math-errno" -DCMAKE_CXX_FLAGS_RELEASE="-g -O2 -DNDEBUG -fno-math-errno" -DCMAKE_BUILD_TYPE=Release ..
-            cmake --build . --target libJSBSim -- -j2
+            cmake --build . --target libJSBSim --parallel $(nproc)
           CIBW_BEFORE_ALL_MACOS: |
             cd build
             rm -f CMakeCache.txt
             cmake -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_C_FLAGS_RELEASE="-g -O2 -DNDEBUG -fno-math-errno -fno-fast-math" -DCMAKE_CXX_FLAGS_RELEASE="-g -O2 -DNDEBUG -fno-math-errno -fno-fast-math" -DCMAKE_BUILD_TYPE=Release ..
-            cmake --build . --target libJSBSim -- -j3
+            cmake --build . --target libJSBSim --parallel $(sysctl -n hw.logicalcpu)
           CIBW_ARCHS_MACOS: universal2
           CIBW_SKIP: cp*-musllinux_*
           CIBW_ARCHS_WINDOWS: native
@@ -725,7 +725,7 @@ jobs:
           cmake -DENABLE_COVERAGE=ON -DBUILD_PYTHON_MODULE=OFF -DBUILD_DOCS=OFF ..
       - name: Build JSBSim
         working-directory: build
-        run: make -j2
+        run: make --jobs=$(nproc)
       - name: Run JSBSim tests
         working-directory: build
         run: ctest -R Test1 --output-on-failure

--- a/tests/unit_tests/CMakeModules/FindLcov.cmake
+++ b/tests/unit_tests/CMakeModules/FindLcov.cmake
@@ -293,11 +293,12 @@ function (lcov_capture_tgt TNAME)
 	# Add target for generating html output for this target only.
 	file(MAKE_DIRECTORY ${LCOV_HTML_PATH}/${TNAME})
 	add_custom_target(${TNAME}-genhtml
-		COMMAND ${GENHTML_BIN} --quiet --sort --prefix ${PROJECT_SOURCE_DIR}
+		COMMAND ${GENHTML_BIN} --quiet --sort ${GENHTML_CPPFILT_FLAG}
+                        --prefix ${PROJECT_SOURCE_DIR}
 			--baseline-file ${LCOV_DATA_PATH_INIT}/${TNAME}.info
 			--output-directory ${LCOV_HTML_PATH}/${TNAME}
 			--title "${CMAKE_PROJECT_NAME} - target ${TNAME}"
-			${GENHTML_CPPFILT_FLAG} ${OUTFILE}
+			${OUTFILE}
 		DEPENDS ${TNAME}-geninfo ${TNAME}-capture-init
 	)
 endfunction (lcov_capture_tgt)
@@ -326,11 +327,11 @@ function (lcov_capture)
 	if (NOT TARGET lcov)
 		file(MAKE_DIRECTORY ${LCOV_HTML_PATH}/all_targets)
 		add_custom_target(lcov
-			COMMAND ${GENHTML_BIN} --quiet --sort
+			COMMAND ${GENHTML_BIN} --quiet --sort ${GENHTML_CPPFILT_FLAG}
 				--baseline-file ${LCOV_DATA_PATH_INIT}/all_targets.info
 				--output-directory ${LCOV_HTML_PATH}/all_targets
 				--title "${CMAKE_PROJECT_NAME}" --prefix "${PROJECT_SOURCE_DIR}"
-				${GENHTML_CPPFILT_FLAG} ${OUTFILE}
+				${OUTFILE}
 			DEPENDS lcov-geninfo-init lcov-geninfo
 		)
 	endif ()


### PR DESCRIPTION
This PR fixes a number of issues that have crept in our CI workflow:

* GitHub's `macos-latest` is now set to `macos-14` which is a runner with M1 chips but:
  * Julia is no longer installed by default on these runners (most likely due to the fact that [Julia on M1 chips is untested according to the Julia community itself](https://github.com/julia-actions/setup-julia)).
  * We are limited to Matlab R2022a since the SimuLink file [ex737cruise.slx](https://github.com/JSBSim-Team/jsbsim/blob/master/matlab/ex737cruise.slx) is only compatible with R2022a and [Apple Silicon chips are only supported since Matlab R2023b](https://www.mathworks.com/matlabcentral/answers/641925-is-matlab-supported-on-apple-silicon-macs).
* Took the opportunity to remove `macos-11` as [it has been deprecated and will no longer be supported after June 28, 2024](https://docs.github.com/fr/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories).
* [GitHub runners now provide 4 CPUs for open source projects !](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/) Our CI workflow now automatically picks the number of cores to take the opportunity of this speed increase and to save ourselves the trouble of updating the number of cores used by parallel jobs (mostly compiler & test jobs):
  * Using the variable `$(nproc)` on Linux
  * Using the environment variable `%NUMBER_OF_PROCESSORS%` (or `$Env:NUMBER_OF_PROCESSORS` in PowerShell) on Windows
  * Calling `$(sysctl -n hw.logicalcpu)` on MacOSX.
* The coverage job has been updated:
  * Automatic search of coverage data by the Codecov script is now disabled so that only the relevant coverage data is uploaded to Codecov.
  * CMake-codecov : The PR RWTH-HPC/CMake-codecov#40 has been pushed to JSBSim to support lcov 2.0 (which is the default version on my Linux PC since I've upgraded it to Fedora 39).