### PR TITLE
Provide possibility to reopen telnet connection

### DIFF
--- a/src/input_output/FGfdmSocket.cpp
+++ b/src/input_output/FGfdmSocket.cpp
@@ -320,6 +320,7 @@ void FGfdmSocket::Close(void)
 #else
   close(sckt_in);
 #endif
+sckt_in = INVALID_SOCKET;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Based on the discussion:
[https://github.com/JSBSim-Team/jsbsim/discussions/1074](https://github.com/JSBSim-Team/jsbsim/discussions/1074)

On connection close, the following assignment is needed:
```
sckt_in = INVALID_SOCKET;
```
to make further connections possible.
