### PR TITLE
Some improvements to the socket code.

### DIFF
--- a/src/input_output/FGInputSocket.cpp
+++ b/src/input_output/FGInputSocket.cpp
@@ -243,7 +243,7 @@ void FGInputSocket::Read(bool Holding)
       } else if (command == "quit") {               // QUIT
 
         // close the socket connection
-        socket->Reply("Closing connection\r\n");
+        socket->Send("Closing connection\r\n");
         socket->Close();
 
       } else if (command == "info") {               // INFO

--- a/src/input_output/FGfdmSocket.cpp
+++ b/src/input_output/FGfdmSocket.cpp
@@ -251,10 +251,11 @@ FGfdmSocket::FGfdmSocket(int port, int protocol, int precision)
 FGfdmSocket::~FGfdmSocket()
 {
   // Release the file descriptors to the OS.
-  if (sckt_in != INVALID_SOCKET) shutdown(sckt_in, SHUT_RDWR);
 #ifdef _WIN32
+  if (sckt_in != INVALID_SOCKET) shutdown(sckt_in, SD_BOTH);
   if (sckt != INVALID_SOCKET) closesocket(sckt);
 #else
+  if (sckt_in != INVALID_SOCKET) shutdown(sckt_in, SHUT_RDWR);
   if (sckt != INVALID_SOCKET) close(sckt);
 #endif
   Debug(1);

--- a/src/input_output/FGfdmSocket.cpp
+++ b/src/input_output/FGfdmSocket.cpp
@@ -251,12 +251,11 @@ FGfdmSocket::FGfdmSocket(int port, int protocol, int precision)
 FGfdmSocket::~FGfdmSocket()
 {
   // Release the file descriptors to the OS.
+  if (sckt_in != INVALID_SOCKET) shutdown(sckt_in, SHUT_RDWR);
 #ifdef _WIN32
   if (sckt != INVALID_SOCKET) closesocket(sckt);
-  if (sckt_in != INVALID_SOCKET) closesocket(sckt_in);
 #else
   if (sckt != INVALID_SOCKET) close(sckt);
-  if (sckt_in != INVALID_SOCKET) close(sckt_in);
 #endif
   Debug(1);
 }

--- a/src/input_output/FGfdmSocket.h
+++ b/src/input_output/FGfdmSocket.h
@@ -189,6 +189,7 @@ private:
   std::ostringstream buffer;
   int precision;
   bool connected;
+  void PrintSocketError(void);
   void Debug(int from);
 };
 }

--- a/src/input_output/FGfdmSocket.h
+++ b/src/input_output/FGfdmSocket.h
@@ -189,7 +189,7 @@ private:
   std::ostringstream buffer;
   int precision;
   bool connected;
-  void PrintSocketError(const std::string& msg);
+  void LogSocketError(const std::string& msg);
   void Debug(int from);
 };
 }

--- a/src/input_output/FGfdmSocket.h
+++ b/src/input_output/FGfdmSocket.h
@@ -58,10 +58,14 @@ namespace JSBSim {
 CLASS DOCUMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-/** Encapsulates an object that enables JSBSim to communicate via socket (input
-    and/or output).
-    
-  */
+/**
+ * @brief The FGfdmSocket class enables JSBSim to communicate via sockets.
+ *
+ * This class provides functionality for sending and receiving data over a socket
+ * connection.
+ * It can behave as both a client and/or a server, depending on the constructor used.
+ * The socket can use either UDP or TCP protocol for communication.
+ */
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 CLASS DECLARATION
@@ -70,26 +74,107 @@ CLASS DECLARATION
 class FGfdmSocket : public FGJSBBase
 {
 public:
+  /**
+   * @brief Construct a client socket.
+   *
+   * @param address The IP address or hostname of the server to connect to.
+   * @param port The port number to connect to.
+   * @param protocol The protocol to use for communication (ptUDP or ptTCP).
+   * @param precision The precision to use for floating-point numbers (default is 7).
+   */
   FGfdmSocket(const std::string& address, int port, int protocol, int precision = 7);
-  FGfdmSocket(int port, int protocol, int precision = 7);
-  ~FGfdmSocket();
-  void Send(void);
-  void Send(const char *data, int length);
 
+  /**
+   * @brief Construct a server socket.
+   *
+   * @param port The port number to listen on.
+   * @param protocol The protocol to use for communication (ptUDP or ptTCP).
+   * @param precision The precision to use for floating-point numbers (default is 7).
+   */
+  FGfdmSocket(int port, int protocol, int precision = 7);
+
+  ~FGfdmSocket();
+
+  /// Send the internal buffer over the socket connection.
+  void Send(void);
+
+  /**
+   * @brief Send the specified data over the socket connection.
+   *
+   * @param data The data to send.
+   * @param length The length of the data.
+   */
+  void Send(const char *data, int length);
+  void Send(const std::string& data) { Send(data.c_str(), data.length()); }
+
+  /**
+   * @brief Receive data from the socket connection.
+   *
+   * @return The received data as a string.
+   */
   std::string Receive(void);
+
+  /**
+   * @brief Send a reply to the client ending by a prompt "JSBSim>"
+   *
+   * @param text The reply text to send.
+   * @return The number of bytes sent.
+   */
   int Reply(const std::string& text);
+
+  /**
+   * @brief Append the specified string to the internal buffer.
+   *
+   * @param s The string to append.
+   */
   void Append(const std::string& s) {Append(s.c_str());}
+
+  /**
+   * @brief Append the specified C-style string to the internal buffer.
+   *
+   * @param s The C-style string to append.
+   */
   void Append(const char*);
-  void Append(double);
-  void Append(long);
+
+  /**
+   * @brief Append the specified double value to the internal buffer.
+   *
+   * @param value The double value to append.
+   */
+  void Append(double value);
+
+  /**
+   * @brief Append the specified long value to the internal buffer.
+   *
+   * @param value The long value to append.
+   */
+  void Append(long value);
+
+  /// Clear the internal buffer.
   void Clear(void);
+
+  /**
+   * @brief Clear the internal buffer and appends the specified string.
+   *
+   * @param s The string to append after clearing the buffer.
+   */
   void Clear(const std::string& s);
+
+  /// Close the socket connection if the protocol is TCP.
   void Close(void);
+
+  /**
+   * @brief Return the connection status of the socket.
+   *
+   * @return True if the socket is connected, false otherwise.
+   */
   bool GetConnectStatus(void) {return connected;}
+
+  /// Wait until the TCP socket is readable.
   void WaitUntilReadable(void);
 
   enum ProtocolType {ptUDP, ptTCP};
- 
+
 private:
 #if defined(_MSC_VER) || defined(__MINGW32__)
   SOCKET sckt;

--- a/src/input_output/FGfdmSocket.h
+++ b/src/input_output/FGfdmSocket.h
@@ -189,7 +189,7 @@ private:
   std::ostringstream buffer;
   int precision;
   bool connected;
-  void PrintSocketError(void);
+  void PrintSocketError(const std::string& msg);
   void Debug(int from);
 };
 }


### PR DESCRIPTION
While investigating the "socket" code to address the topics discussed in #1079, I have found a number of small details that could be improved. I don't think these will resolve the discussion #1079 but I'm pushing this PR nonetheless for the record.

### Minor changes / documentation
* The first thing that stroke me is that the 2 constructors of `FGfdmSocket` have actually very different purposes as one constructor is returning a socket for a **client connection** while the other one returns a socket for a **server connection**. To document that, I have added comments to `FGfdmSocket.h`. Note that the documentation has been generated by an AI (*GitHub Copilot*) and reviewed by a non native English speaker (myself) so brace yourself before reading 😄
* I've moved `connected=true` to a location that makes its purpose more obvious as the previous location of this line of code was misleadingly suggesting that `connected=true` was indicating that the call to `accept()` had succeeded.
* In `FGInputSocket.cpp`, when the command `quit`is issued to JSBSim, the method `FGfdmSocket::Send()` is now called to return "*Closing connection*" instead of calling `FGfdmSocket::Reply()`. This avoids displaying the prompt `JSBSim>` just after the message "*Connection closed*" which looks weird to me.

### Improvements to the error management
* If the calls to `bind()` or `listen()` fail, `FGfdmSocket` now closes the socket `sckt` and sets it to `INVALID_SOCKET` which is a good practice in order to release unused file descriptors to the OS (see StackOverflow [Should I call close() on bind() or listen() error](https://stackoverflow.com/questions/48400232/should-i-call-close-on-bind-or-listen-error))
* Following the same idea, the destructor `~FGfdmSocket()` shutdowns `sckt_in` and closes `sckt` (in that order otherwise it crashes according to my tests) to release the file descriptors to the OS.
* The call to `recv` in `FGfdmSocket::Receive()` is now enclosed in an `if (Protocol == ptTCP) { ... }` as calling `recv` is meaningless for UDP sockets.
* It is now checked that `sckt != INVALID_SOCKET` before calling `send` in `FGfdmSocket::Send()`. Also `send` is now using `sckt_in` if the socket is using the TCP protocol. Indeed this method is called from the class `FGOutputSocket` which can define a socket with either protocol UDP or TCP.
* It is now checked that `sckt != INVALID_SOCKET` before calling `select` in `FGfdmSocket::WaitUntilReadable()`. Also I have added an assert to check that `Protocol == ptTCP` so that we are sure that this method is never called for a UDP socket. At the moment, `FGfdmSocket::WaitUntilReadable()` is only called by the class `FGInputSocket` which is guaranteed to be a TCP socket so the assert passes.
