### PR TITLE
Fix inconsistent property name (sea-level-radius-ft)

### DIFF
--- a/src/models/FGInertial.cpp
+++ b/src/models/FGInertial.cpp
@@ -255,7 +255,7 @@ void FGInertial::SetGravityType(int gt)
 
 void FGInertial::bind(void)
 {
-  PropertyManager->Tie("inertial/sea-level-radius_ft", &in.Position,
+  PropertyManager->Tie("inertial/sea-level-radius-ft", &in.Position,
                        &FGLocation::GetSeaLevelRadius);
   PropertyManager->Tie("simulation/gravity-model", this, &FGInertial::GetGravityType,
                        &FGInertial::SetGravityType);


### PR DESCRIPTION
In all other instances the unit appendix is separated by a dash rather than underscore.

Should the property be published under the inconsistent name also to maintain compatibility with existing code?