### PR TITLE
Reduce console output when debug level is zero

### DIFF
--- a/src/models/FGInertial.cpp
+++ b/src/models/FGInertial.cpp
@@ -118,10 +118,12 @@ bool FGInertial::Load(Element* el)
   GroundCallback->SetEllipse(a, b);
 
   // Messages to warn the user about possible inconsistencies.
-  if (a != b && J2 == 0.0)
-    cout << "Gravitational constant J2 is null for a non-spherical planet." << endl;
-  if (a == b && J2 != 0.0)
-    cout << "Gravitational constant J2 is non-zero for a spherical planet." << endl;
+  if (debug_lvl > 0) {
+    if (a != b && J2 == 0.0)
+      cout << "Gravitational constant J2 is null for a non-spherical planet." << endl;
+    if (a == b && J2 != 0.0)
+      cout << "Gravitational constant J2 is non-zero for a spherical planet." << endl;
+  }
 
   Debug(2);
 

--- a/src/models/FGLGear.cpp
+++ b/src/models/FGLGear.cpp
@@ -542,8 +542,10 @@ void FGLGear::ReportTakeoffOrLanding(void)
 
   if (lastWOW != WOW)
   {
-    cout << "GEAR_CONTACT: " << fdmex->GetSimTime() << " seconds: " << name
-         << " " << WOW << endl;
+    if (debug_lvl > 0) {
+      cout << "GEAR_CONTACT: " << fdmex->GetSimTime() << " seconds: " << name
+           << " " << WOW << endl;
+    }
   }
 }
 
@@ -557,7 +559,10 @@ void FGLGear::CrashDetect(void)
       GetMoments().Magnitude() > 5000000000.0 ||
       SinkRate > 1.4666*30 ) && !fdmex->IntegrationSuspended())
   {
-    cout << "*CRASH DETECTED* " << fdmex->GetSimTime() << " seconds: " << name;
+    if (debug_lvl > 0) {
+      cout << "*CRASH DETECTED* " << fdmex->GetSimTime() << " seconds: " << name;
+    }
+
     // fdmex->SuspendIntegration();
   }
 }


### PR DESCRIPTION
Throughout the codebase console output is generally only happening when the debug level is greater than zero. That is a useful feature and this change checks the debug level for additional cases.