### PR TITLE
Release XML element when property value node was bound

### DIFF
--- a/src/math/FGPropertyValue.cpp
+++ b/src/math/FGPropertyValue.cpp
@@ -49,8 +49,12 @@ FGPropertyValue::FGPropertyValue(const std::string& propName,
     Sign = -1.0;
   }
 
-  if (PropertyManager->HasNode(PropertyName))
+  if (PropertyManager->HasNode(PropertyName)) {
     PropertyNode = PropertyManager->GetNode(PropertyName);
+
+    assert(PropertyNode);
+    XML_def = nullptr; // Now that the property is bound, we no longer need that.
+  }
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Analog to GetNode().

This significantly reduces memory cost by not keeping a large number of XML elements around in the common case of successfully binding the property in the constructor.
