### PR TITLE
Fix incompatibilities with NumPy 2.0

### DIFF
--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -80,13 +80,13 @@ def _append_xml(name: str) -> str:
 
 
 cdef _convertToNumpyMat(const c_FGMatrix33& m):
-    return numpy.mat([[m.Entry(1, 1), m.Entry(1, 2), m.Entry(1, 3)],
-                      [m.Entry(2, 1), m.Entry(2, 2), m.Entry(2, 3)],
-                      [m.Entry(3, 1), m.Entry(3, 2), m.Entry(3, 3)]])
+    return numpy.asmatrix([[m.Entry(1, 1), m.Entry(1, 2), m.Entry(1, 3)],
+                           [m.Entry(2, 1), m.Entry(2, 2), m.Entry(2, 3)],
+                           [m.Entry(3, 1), m.Entry(3, 2), m.Entry(3, 3)]])
 
 
 cdef _convertToNumpyVec(const c_FGColumnVector3& v):
-    return numpy.mat([v.Entry(1), v.Entry(2), v.Entry(3)]).T
+    return numpy.asmatrix([v.Entry(1), v.Entry(2), v.Entry(3)]).T
 
 
 cdef class FGPropagate:

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -80,13 +80,13 @@ def _append_xml(name: str) -> str:
 
 
 cdef _convertToNumpyMat(const c_FGMatrix33& m):
-    return numpy.asmatrix([[m.Entry(1, 1), m.Entry(1, 2), m.Entry(1, 3)],
-                           [m.Entry(2, 1), m.Entry(2, 2), m.Entry(2, 3)],
-                           [m.Entry(3, 1), m.Entry(3, 2), m.Entry(3, 3)]])
+    return numpy.matrix([[m.Entry(1, 1), m.Entry(1, 2), m.Entry(1, 3)],
+                         [m.Entry(2, 1), m.Entry(2, 2), m.Entry(2, 3)],
+                         [m.Entry(3, 1), m.Entry(3, 2), m.Entry(3, 3)]])
 
 
 cdef _convertToNumpyVec(const c_FGColumnVector3& v):
-    return numpy.asmatrix([v.Entry(1), v.Entry(2), v.Entry(3)]).T
+    return numpy.matrix([v.Entry(1), v.Entry(2), v.Entry(3)]).T
 
 
 cdef class FGPropagate:

--- a/tests/TestAeroFuncFrame.py
+++ b/tests/TestAeroFuncFrame.py
@@ -34,7 +34,7 @@ class TestAeroFuncFrame(JSBSimTestCase):
                                                             'x153.xml')
         self.tree, self.aircraft_name, b = CopyAircraftDef(self.script_path, self.sandbox)
 
-        self.aero2wind = np.mat(np.identity(3));
+        self.aero2wind = np.matrix(np.identity(3));
         self.aero2wind[0,0] *= -1.0
         self.aero2wind[2,2] *= -1.0
         self.auxilliary = self.fdm.get_auxiliary()
@@ -47,18 +47,18 @@ class TestAeroFuncFrame(JSBSimTestCase):
         alpha = self.fdm['aero/alpha-rad']
         ca = math.cos(alpha)
         sa = math.sin(alpha)
-        Ts2b = np.mat([[ca, 0., -sa],
-                       [0., 1., 0.],
-                       [sa, 0., ca]])
+        Ts2b = np.matrix([[ca, 0., -sa],
+                          [0., 1., 0.],
+                          [sa, 0., ca]])
         return Ts2b
 
     def checkForcesAndMoments(self, getForces, getMoment, aeroFunc):
         self.fdm.load_script(self.script_path)
         self.fdm.run_ic()
 
-        rp = np.mat([self.fdm['metrics/aero-rp-x-in'],
-                     -self.fdm['metrics/aero-rp-y-in'],
-                     self.fdm['metrics/aero-rp-z-in']])
+        rp = np.matrix([self.fdm['metrics/aero-rp-x-in'],
+                        -self.fdm['metrics/aero-rp-y-in'],
+                        self.fdm['metrics/aero-rp-z-in']])
         result = {}
 
         while self.fdm.run():
@@ -73,9 +73,9 @@ class TestAeroFuncFrame(JSBSimTestCase):
             Fs = self.aero2wind * (Tb2s * Fb)
 
             Mb_MRC = getMoment(result)
-            cg = np.mat([self.fdm['inertia/cg-x-in'],
-                         -self.fdm['inertia/cg-y-in'],
-                         self.fdm['inertia/cg-z-in']])
+            cg = np.matrix([self.fdm['inertia/cg-x-in'],
+                            -self.fdm['inertia/cg-y-in'],
+                            self.fdm['inertia/cg-z-in']])
             arm_ft = (cg - rp)/12.0 # Convert from inches to ft
             Mb = Mb_MRC + np.cross(arm_ft, Fb.T)
             Tb2w = self.auxilliary.get_Tb2w()
@@ -134,13 +134,13 @@ class TestAeroFuncFrame(JSBSimTestCase):
 
         def getForces(result):
             Tb2w = self.auxilliary.get_Tb2w()
-            Fb = np.mat([result['X'], result['Y'], result['Z']]).T
+            Fb = np.matrix([result['X'], result['Y'], result['Z']]).T
             Fw = Tb2w * Fb
             Fa = self.aero2wind * Fw
             return Fa, Fb
 
         def getMoment(result):
-            return np.mat([result['ROLL'], result['PITCH'], result['YAW']])
+            return np.matrix([result['ROLL'], result['PITCH'], result['YAW']])
 
         self.checkAerodynamicsFrame(newAxisName, getForces, getMoment, '')
 
@@ -156,14 +156,14 @@ class TestAeroFuncFrame(JSBSimTestCase):
 
         def getForces(result):
             Tb2w = self.auxilliary.get_Tb2w()
-            Fnative = np.mat([result['AXIAL'], result['SIDE'], result['NORMAL']]).T
+            Fnative = np.matrix([result['AXIAL'], result['SIDE'], result['NORMAL']]).T
             Fb = self.aero2wind * Fnative
             Fw = Tb2w * Fb
             Fa = self.aero2wind * Fw
             return Fa, Fb
 
         def getMoment(result):
-            return np.mat([result['ROLL'], result['PITCH'], result['YAW']])
+            return np.matrix([result['ROLL'], result['PITCH'], result['YAW']])
 
         self.checkAerodynamicsFrame(newAxisName, getForces, getMoment, '')
 
@@ -173,14 +173,14 @@ class TestAeroFuncFrame(JSBSimTestCase):
 
         def getForces(result):
             Tw2b = self.auxilliary.get_Tw2b()
-            Fa = np.mat([result['X'], result['Y'], result['Z']]).T
+            Fa = np.matrix([result['X'], result['Y'], result['Z']]).T
             Fw = self.aero2wind * Fa
             Fb = Tw2b * Fw
             return Fa, Fb
 
         def getMoment(result):
             Tw2b = self.auxilliary.get_Tw2b()
-            Mw = np.mat([result['ROLL'], result['PITCH'], result['YAW']]).T
+            Mw = np.matrix([result['ROLL'], result['PITCH'], result['YAW']]).T
             Mb = Tw2b*Mw
             return Mb.T
 
@@ -198,13 +198,13 @@ class TestAeroFuncFrame(JSBSimTestCase):
 
         def getForces(result):
             Tw2b = self.auxilliary.get_Tw2b()
-            Fa = np.mat([result['DRAG'], result['SIDE'], result['LIFT']]).T
+            Fa = np.matrix([result['DRAG'], result['SIDE'], result['LIFT']]).T
             Fw = self.aero2wind * Fa
             Fb = Tw2b * Fw
             return Fa, Fb
 
         def getMoment(result):
-            return np.mat([result['ROLL'], result['PITCH'], result['YAW']])
+            return np.matrix([result['ROLL'], result['PITCH'], result['YAW']])
 
         self.checkForcesAndMoments(getForces, getMoment, aeroFunc)
 
@@ -215,7 +215,7 @@ class TestAeroFuncFrame(JSBSimTestCase):
         def getForces(result):
             Tb2w = self.auxilliary.get_Tb2w()
             Ts2b = self.getTs2b()
-            Fs = np.mat([result['X'], result['Y'], result['Z']]).T
+            Fs = np.matrix([result['X'], result['Y'], result['Z']]).T
             Fb = Ts2b * (self.aero2wind * Fs)
             Fw = Tb2w * Fb
             Fa = self.aero2wind * Fw
@@ -223,7 +223,7 @@ class TestAeroFuncFrame(JSBSimTestCase):
 
         def getMoment(result):
             Ts2b = self.getTs2b()
-            Ms = np.mat([result['ROLL'], result['PITCH'], result['YAW']]).T
+            Ms = np.matrix([result['ROLL'], result['PITCH'], result['YAW']]).T
             Mb = Ts2b*Ms
             return Mb.T
 

--- a/tests/TestExternalReactions.py
+++ b/tests/TestExternalReactions.py
@@ -64,7 +64,7 @@ class TestExternalReactions(JSBSimTestCase):
         while fdm.run():
             Tw2b = fdm.get_auxiliary().get_Tw2b()
             mag = fdm['aero/qbar-psf'] * fdm['fcs/parachute_reef_pos_norm']*parachute_area
-            f = Tw2b * np.mat([-1.0, 0.0, 0.0]).T * mag
+            f = Tw2b * np.matrix([-1.0, 0.0, 0.0]).T * mag
             self.assertAlmostEqual(fdm['forces/fbx-external-lbs'], f[0, 0])
             self.assertAlmostEqual(fdm['forces/fby-external-lbs'], f[1, 0])
             self.assertAlmostEqual(fdm['forces/fbz-external-lbs'], f[2, 0])
@@ -103,7 +103,7 @@ class TestExternalReactions(JSBSimTestCase):
         dz = 0.01
         fhook = np.array([dx, 0.0, dz])
         fhook /= np.linalg.norm(fhook)
-        
+
         self.assertAlmostEqual(fdm['external_reactions/hook/x'], fhook[0])
         self.assertAlmostEqual(fdm['external_reactions/hook/y'], fhook[1])
         self.assertAlmostEqual(fdm['external_reactions/hook/z'], fhook[2])
@@ -241,12 +241,12 @@ class TestExternalReactions(JSBSimTestCase):
         while fdm.run():
             Tw2b = fdm.get_auxiliary().get_Tw2b()
             mag = fdm['aero/qbar-psf'] * fdm['fcs/parachute_reef_pos_norm']*parachute_area
-            f = Tw2b * np.mat([-1.0, 0.0, 0.0]).T * mag
+            f = Tw2b * np.matrix([-1.0, 0.0, 0.0]).T * mag
             self.assertAlmostEqual(fdm['forces/fbx-external-lbs'], f[0, 0])
             self.assertAlmostEqual(fdm['forces/fby-external-lbs'], f[1, 0])
             self.assertAlmostEqual(fdm['forces/fbz-external-lbs'], f[2, 0])
 
-            m = -3.5 * Tw2b * np.mat(mDir).T
+            m = -3.5 * Tw2b * np.matrix(mDir).T
             fm = np.cross(self.getLeverArm(fdm,'parachute'),
                           np.array([f[0,0], f[1,0], f[2, 0]]))
             self.assertAlmostEqual(fdm['moments/l-external-lbsft'], m[0, 0] + fm[0])


### PR DESCRIPTION
Following the release of Numpy 2.0, the function `numpy.mat` has been deprecated. It is recommended by the [Numpy 2.0 migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#changes-to-namespaces) to replace `numpy.mat` by `numpy.asmatrix`. However:
* We want to support Numpy 1.xx and [it is unclear in the documentation](https://numpy.org/doc/stable/reference/generated/numpy.asmatrix.html#numpy-asmatrix) when the function `np.asmatrix` has been introduced. In particular, it might not be supported for older versions of Numpy.
* We have been using `np.matrix` for the last 6 years (see below) and NumPy 1.xx never complained.

https://github.com/JSBSim-Team/jsbsim/blob/e33e184f512449b8120769825b20e4d35df8ee51/tests/TestGndReactions.py#L90-L95
https://github.com/JSBSim-Team/jsbsim/blob/e33e184f512449b8120769825b20e4d35df8ee51/tests/TestFunctions.py#L272-L280

As our CI workflow installs NumPy 2.0 by default on the MacOSX ARM64 platform, the current PR replaces all occurrences of `numpy.mat` by `numpy.matrix` to support Numpy 1.xx and 2.0.