### PR TITLE
Add JSBSIM_API decoration to new logging classes

### DIFF
--- a/JSBSimForUnreal.vcxproj
+++ b/JSBSimForUnreal.vcxproj
@@ -159,6 +159,7 @@ exit/B %errlev%</Command>
     <ClInclude Include="src\initialization\FGLinearization.h" />
     <ClInclude Include="src\input_output\FGInputSocket.h" />
     <ClInclude Include="src\input_output\FGInputType.h" />
+    <ClInclude Include="src\input_output\FGLog.h" />
     <ClInclude Include="src\input_output\fgmodelloader.h" />
     <ClInclude Include="src\input_output\fgoutputfg.h" />
     <ClInclude Include="src\input_output\fgoutputfile.h" />
@@ -283,6 +284,7 @@ exit/B %errlev%</Command>
     <ClCompile Include="src\initialization\FGLinearization.cpp" />
     <ClCompile Include="src\input_output\FGInputSocket.cpp" />
     <ClCompile Include="src\input_output\FGInputType.cpp" />
+    <ClCompile Include="src\input_output\FGLog.cpp" />
     <ClCompile Include="src\input_output\FGModelLoader.cpp" />
     <ClCompile Include="src\input_output\FGOutputFG.cpp" />
     <ClCompile Include="src\input_output\FGOutputFile.cpp" />

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -89,7 +89,7 @@ CLASS DOCUMENTATION
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class FGLogger
+class JSBSIM_API FGLogger
 {
 public:
   virtual ~FGLogger() {}
@@ -104,7 +104,7 @@ protected:
   LogLevel min_level = LogLevel::INFO;
 };
 
-class FGLogging
+class JSBSIM_API FGLogging
 {
 public:
   FGLogging(std::shared_ptr<FGLogger> logger, LogLevel level)
@@ -126,13 +126,13 @@ protected:
   std::ostringstream buffer;
 };
 
-class FGXMLLogging : public FGLogging
+class JSBSIM_API FGXMLLogging : public FGLogging
 {
 public:
   FGXMLLogging(std::shared_ptr<FGLogger> logger, Element* el, LogLevel level);
 };
 
-class FGLogConsole : public FGLogger
+class JSBSIM_API FGLogConsole : public FGLogger
 {
 public:
   FGLogConsole() : out(std::cout.rdbuf()) {}


### PR DESCRIPTION
 Needed in order to export/import from DLL version of JSBSim library.