### PR TITLE
Logging redesign (cont'd)

### DIFF
--- a/src/input_output/FGLog.cpp
+++ b/src/input_output/FGLog.cpp
@@ -48,18 +48,28 @@ CLASS IMPLEMENTATION
 
 void FGLogging::Flush(void)
 {
-  logger->Message(buffer.str());
-  buffer.str("");
-  logger->Format(LogFormat::RESET);
-  logger->Flush();
+  std::string message = buffer.str();
+
+  if (!message.empty()) {
+    logger->Message(message);
+    buffer.str("");
+    logger->Format(LogFormat::RESET);
+    logger->Flush();
+  }
+
   buffer.clear();
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 FGLogging& FGLogging::operator<<(LogFormat format) {
-  logger->Message(buffer.str());
-  buffer.str("");
+  std::string message = buffer.str();
+
+  if (!message.empty()) {
+    logger->Message(message);
+    buffer.str("");
+  }
+
   logger->Format(format);
   return *this;
 }

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -59,7 +59,10 @@ class Element;
 // The return type of these functions is unspecified by the C++ standard so we
 // need some C++ magic to be able to overload the operator<< for these functions.
 using setprecision_t = decltype(std::setprecision(0));
+// For MSVC set_precision_t and setw_t are the same type
+#ifndef _MSC_VER
 using setw_t = decltype(std::setw(0));
+#endif
 
 enum class LogLevel {
   BULK,  // For frequent messages
@@ -121,7 +124,11 @@ public:
   FGLogging& operator<<(std::ostream& (*manipulator)(std::ostream&)) { buffer << manipulator; return *this; }
   FGLogging& operator<<(std::ios_base& (*manipulator)(std::ios_base&)) { buffer << manipulator; return *this; }
   FGLogging& operator<<(setprecision_t value) { buffer << value; return *this; }
+  // Avoid duplicate definition for MSVC for which set_precision_t and setw_t
+  // are the same type
+#ifndef _MSC_VER
   FGLogging& operator<<(setw_t value) { buffer << value; return *this; }
+#endif
   FGLogging& operator<<(const SGPath& path) { buffer << path; return *this; }
   FGLogging& operator<<(const FGColumnVector3& vec) { buffer << vec; return *this; }
   FGLogging& operator<<(LogFormat format);

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -46,6 +46,7 @@ INCLUDES
 
 #include "simgear/misc/sg_path.hxx"
 #include "FGJSBBase.h"
+#include "math/FGColumnVector3.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 FORWARD DECLARATIONS
@@ -116,8 +117,10 @@ public:
   FGLogging& operator<<(const std::string& message) { buffer << message ; return *this; }
   FGLogging& operator<<(unsigned int value) { buffer << value; return *this; }
   FGLogging& operator<<(std::ostream& (*manipulator)(std::ostream&)) { buffer << manipulator; return *this; }
+  FGLogging& operator<<(std::ios_base& (*manipulator)(std::ios_base&)) { buffer << manipulator; return *this; }
   FGLogging& operator<<(setprecision_t value) { buffer << value; return *this; }
   FGLogging& operator<<(const SGPath& path) { buffer << path; return *this; }
+  FGLogging& operator<<(const FGColumnVector3& vec) { buffer << vec; return *this; }
   FGLogging& operator<<(LogFormat format);
   std::string str(void) const { return buffer.str(); }
   void Flush(void);

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -56,9 +56,10 @@ namespace JSBSim {
 
 class Element;
 
-// The return type of std::setprecision is unspecified by the C++ standard so we
-// need some C++ magic to be able to overload the operator<< for std::setprecision
+// The return type of these functions is unspecified by the C++ standard so we
+// need some C++ magic to be able to overload the operator<< for these functions.
 using setprecision_t = decltype(std::setprecision(0));
+using setw_t = decltype(std::setw(0));
 
 enum class LogLevel {
   BULK,  // For frequent messages
@@ -115,10 +116,12 @@ public:
   virtual ~FGLogging() { Flush(); }
   FGLogging& operator<<(const char* message) { buffer << message ; return *this; }
   FGLogging& operator<<(const std::string& message) { buffer << message ; return *this; }
-  FGLogging& operator<<(unsigned int value) { buffer << value; return *this; }
+  template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+    FGLogging& operator<<(T value) { buffer << value; return *this; }
   FGLogging& operator<<(std::ostream& (*manipulator)(std::ostream&)) { buffer << manipulator; return *this; }
   FGLogging& operator<<(std::ios_base& (*manipulator)(std::ios_base&)) { buffer << manipulator; return *this; }
   FGLogging& operator<<(setprecision_t value) { buffer << value; return *this; }
+  FGLogging& operator<<(setw_t value) { buffer << value; return *this; }
   FGLogging& operator<<(const SGPath& path) { buffer << path; return *this; }
   FGLogging& operator<<(const FGColumnVector3& vec) { buffer << vec; return *this; }
   FGLogging& operator<<(LogFormat format);

--- a/src/input_output/FGModelLoader.cpp
+++ b/src/input_output/FGModelLoader.cpp
@@ -37,10 +37,11 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include "FGJSBBase.h"
+#include "FGFDMExec.h"
 #include "FGModelLoader.h"
 #include "FGXMLFileRead.h"
 #include "models/FGModel.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -67,8 +68,8 @@ Element_ptr FGModelLoader::Open(Element *el)
     else {
       document = XMLFileRead.LoadXMLDocument(path);
       if (document == 0L) {
-        cerr << endl << el->ReadFrom()
-             << "Could not open file: " << fname << endl;
+        FGXMLLogging log(model->GetExec()->GetLogger(), el, LogLevel::ERROR);
+        log << "Could not open file: " << fname << endl;
         return NULL;
       }
       CachedFiles[path.utf8Str()] = document;
@@ -82,6 +83,8 @@ Element_ptr FGModelLoader::Open(Element *el)
 
   return document;
 }
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 SGPath CheckPathName(const SGPath& path, const SGPath& filename) {
   SGPath fullName = path/filename.utf8Str();

--- a/src/input_output/FGfdmSocket.h
+++ b/src/input_output/FGfdmSocket.h
@@ -44,6 +44,7 @@ INCLUDES
 #if defined(_MSC_VER) || defined(__MINGW32__)
   #include <winsock.h>
   #include <io.h>
+  #undef ERROR
 #else
   #include <netdb.h>
 #endif

--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -44,6 +44,7 @@ INCLUDES
 
 #include "FGFDMExec.h"
 #include "FGAtmosphere.h"
+#include "input_output/FGLog.h"
 
 namespace JSBSim {
 
@@ -104,8 +105,9 @@ double FGAtmosphere::ValidatePressure(double p, const string& msg, bool quiet) c
   const double MinPressure = ConvertToPSF(1E-15, ePascals);
   if (p < MinPressure) {
     if (!quiet) {
-      cerr << msg << " " << p << " is too low." << endl
-           << msg << " is capped to " << MinPressure << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::WARN);
+      log << msg << " " << p << " is too low." << endl
+          << msg << " will be capped to " << MinPressure << endl;
     }
     return MinPressure;
   }
@@ -124,8 +126,9 @@ double FGAtmosphere::ValidateTemperature(double t, const string& msg, bool quiet
 
   if (t < minUniverseTemperature) {
     if (!quiet) {
-      cerr << msg << " " << t << " is too low." << endl
-           << msg << " is capped to " << minUniverseTemperature << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::WARN);
+      log << msg << " " << t << " is too low." << endl
+          << msg << " will be capped to " << minUniverseTemperature << endl;
     }
     return minUniverseTemperature;
   }
@@ -354,8 +357,9 @@ void FGAtmosphere::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) std::cout << "Instantiated: FGAtmosphere" << std::endl;
-    if (from == 1) std::cout << "Destroyed:    FGAtmosphere" << std::endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGAtmosphere" << std::endl;
+    if (from == 1) log << "Destroyed:    FGAtmosphere" << std::endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -48,6 +48,7 @@ INCLUDES
 #include "input_output/FGPropertyManager.h"
 #include "FGInertial.h"
 #include "FGAtmosphere.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -444,7 +445,9 @@ void FGAuxiliary::bind(void)
 
 double FGAuxiliary::BadUnits(void) const
 {
-  cerr << "Bad units" << endl; return 0.0;
+  FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+  log << "Bad units" << endl;
+  return 0.0;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -476,18 +479,20 @@ void FGAuxiliary::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGAuxiliary" << endl;
-    if (from == 1) cout << "Destroyed:    FGAuxiliary" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGAuxiliary" << endl;
+    if (from == 1) log << "Destroyed:    FGAuxiliary" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }
   if (debug_lvl & 8 ) { // Runtime state variables
   }
   if (debug_lvl & 16) { // Sanity checking
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
     if (Mach > 100 || Mach < 0.00)
-      cout << "FGPropagate::Mach is out of bounds: " << Mach << endl;
+      log << "FGPropagate::Mach is out of bounds: " << Mach << endl;
     if (qbar > 1e6 || qbar < 0.00)
-      cout << "FGPropagate::qbar is out of bounds: " << qbar << endl;
+      log << "FGPropagate::qbar is out of bounds: " << qbar << endl;
   }
   if (debug_lvl & 64) {
     if (from == 0) { // Constructor

--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -1,6 +1,6 @@
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
- Module:       FGFCS.cpp 
+ Module:       FGFCS.cpp
  Author:       Jon Berndt
  Date started: 12/12/98
  Purpose:      Model the flight controls
@@ -82,7 +82,7 @@ FGFCS::FGFCS(FGFDMExec* fdm) : FGModel(fdm), ChannelRate(1)
   PTrimCmd = YTrimCmd = RTrimCmd = 0.0;
   GearCmd = GearPos = 1; // default to gear down
   BrakePos.resize(FGLGear::bgNumBrakeGroups);
-  TailhookPos = WingFoldPos = 0.0; 
+  TailhookPos = WingFoldPos = 0.0;
 
   bind();
   for (i=0;i<NForms;i++) {
@@ -501,14 +501,14 @@ bool FGFCS::Load(Element* document)
   Debug(2);
 
   Element* channel_element = document->FindElement("channel");
-  
+
   while (channel_element) {
-  
+
     FGFCSChannel* newChannel = 0;
 
     string sOnOffProperty = channel_element->GetAttributeValue("execute");
     string sChannelName = channel_element->GetAttributeValue("name");
-    
+
     if (!channel_element->GetAttributeValue("execrate").empty())
       ChannelRate = channel_element->GetAttributeValueAsNumber("execrate");
     else
@@ -522,7 +522,7 @@ bool FGFCS::Load(Element* document)
             << "The On/Off property, " << sOnOffProperty << " specified for channel "
             << channel_element->GetAttributeValue("name") << " is undefined or not "
             << "understood. The simulation will abort" << LogFormat::RESET << endl;
-        throw("Bad system definition");
+        throw BaseException(log.str());
       } else
         newChannel = new FGFCSChannel(this, sChannelName, ChannelRate,
                                       OnOffPropertyNode);
@@ -536,7 +536,7 @@ bool FGFCS::Load(Element* document)
       log << endl << LogFormat::BOLD << LogFormat::BLUE << "    Channel "
           << LogFormat::NORMAL << channel_element->GetAttributeValue("name") << LogFormat::RESET << endl;
     }
-  
+
     Element* component_element = channel_element->GetElement();
     while (component_element) {
       try {
@@ -567,8 +567,10 @@ bool FGFCS::Load(Element* document)
           // <integrator> is equivalent to <pid type="trap">
           Element* c1_el = component_element->FindElement("c1");
           if (!c1_el) {
-            throw("INTEGRATOR component " + component_element->GetAttributeValue("name")
-                  + " does not provide the parameter <c1>");
+            FGXMLLogging log(FDMExec->GetLogger(), component_element, LogLevel::FATAL);
+            log << "INTEGRATOR component " << component_element->GetAttributeValue("name")
+                << " does not provide the parameter <c1>" << endl;
+            throw BaseException(log.str());
           }
           c1_el->ChangeName("ki");
           if (!c1_el->HasAttribute("type"))

--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -42,6 +42,7 @@ INCLUDES
 
 #include "FGFCS.h"
 #include "input_output/FGModelLoader.h"
+#include "input_output/FGLog.h"
 
 #include "models/flight_control/FGFilter.h"
 #include "models/flight_control/FGDeadBand.h"
@@ -167,7 +168,10 @@ bool FGFCS::Run(bool Holding)
 
   // Execute system channels in order
   for (i=0; i<SystemChannels.size(); i++) {
-    if (debug_lvl & 4) cout << "    Executing System Channel: " << SystemChannels[i]->GetName() << endl;
+    if (debug_lvl & 4) {
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      log << "    Executing System Channel: " << SystemChannels[i]->GetName() << endl;
+    }
     ChannelRate = SystemChannels[i]->GetRate();
     SystemChannels[i]->Execute();
   }
@@ -323,9 +327,10 @@ void FGFCS::SetThrottleCmd(int engineNum, double setting)
       ThrottleCmd[engineNum] = setting;
     }
   } else {
-    cerr << "Throttle " << engineNum << " does not exist! " << ThrottleCmd.size()
-         << " engines exist, but attempted throttle command is for engine "
-         << engineNum << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+    log << "Throttle " << engineNum << " does not exist! " << ThrottleCmd.size()
+        << " engines exist, but attempted throttle command is for engine "
+        << engineNum << endl;
   }
 }
 
@@ -341,9 +346,10 @@ void FGFCS::SetThrottlePos(int engineNum, double setting)
       ThrottlePos[engineNum] = setting;
     }
   } else {
-    cerr << "Throttle " << engineNum << " does not exist! " << ThrottlePos.size()
-         << " engines exist, but attempted throttle position setting is for engine "
-         << engineNum << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+    log << "Throttle " << engineNum << " does not exist! " << ThrottlePos.size()
+        << " engines exist, but attempted throttle position setting is for engine "
+        << engineNum << endl;
   }
 }
 
@@ -353,14 +359,16 @@ double FGFCS::GetThrottleCmd(int engineNum) const
 {
   if (engineNum < (int)ThrottlePos.size()) {
     if (engineNum < 0) {
-       cerr << "Cannot get throttle value for ALL engines" << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+      log << "Cannot get throttle value for ALL engines" << endl;
     } else {
       return ThrottleCmd[engineNum];
     }
   } else {
-    cerr << "Throttle " << engineNum << " does not exist! " << ThrottleCmd.size()
-         << " engines exist, but throttle setting for engine " << engineNum
-         << " is selected" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+    log << "Throttle " << engineNum << " does not exist! " << ThrottleCmd.size()
+        << " engines exist, but throttle setting for engine " << engineNum
+        << " is selected" << endl;
   }
   return 0.0;
 }
@@ -371,14 +379,16 @@ double FGFCS::GetThrottlePos(int engineNum) const
 {
   if (engineNum < (int)ThrottlePos.size()) {
     if (engineNum < 0) {
-       cerr << "Cannot get throttle value for ALL engines" << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+      log << "Cannot get throttle value for ALL engines" << endl;
     } else {
       return ThrottlePos[engineNum];
     }
   } else {
-    cerr << "Throttle " << engineNum << " does not exist! " << ThrottlePos.size()
-         << " engines exist, but attempted throttle position setting is for engine "
-         << engineNum << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+    log << "Throttle " << engineNum << " does not exist! " << ThrottlePos.size()
+        << " engines exist, but attempted throttle position setting is for engine "
+        << engineNum << endl;
   }
   return 0.0;
 }
@@ -506,11 +516,12 @@ bool FGFCS::Load(Element* document)
 
     if (sOnOffProperty.length() > 0) {
       FGPropertyNode* OnOffPropertyNode = PropertyManager->GetNode(sOnOffProperty);
-      if (OnOffPropertyNode == 0) {
-        cerr << channel_element->ReadFrom() << highint << fgred
-             << "The On/Off property, " << sOnOffProperty << " specified for channel "
-             << channel_element->GetAttributeValue("name") << " is undefined or not "
-             << "understood. The simulation will abort" << reset << endl;
+      if (OnOffPropertyNode == nullptr) {
+        FGXMLLogging log(FDMExec->GetLogger(), channel_element, LogLevel::FATAL);
+        log << LogFormat::BOLD << LogFormat::RED
+            << "The On/Off property, " << sOnOffProperty << " specified for channel "
+            << channel_element->GetAttributeValue("name") << " is undefined or not "
+            << "understood. The simulation will abort" << LogFormat::RESET << endl;
         throw("Bad system definition");
       } else
         newChannel = new FGFCSChannel(this, sChannelName, ChannelRate,
@@ -520,9 +531,11 @@ bool FGFCS::Load(Element* document)
 
     SystemChannels.push_back(newChannel);
 
-    if (debug_lvl > 0)
-      cout << endl << highint << fgblue << "    Channel " 
-         << normint << channel_element->GetAttributeValue("name") << reset << endl;
+    if (debug_lvl > 0) {
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      log << endl << LogFormat::BOLD << LogFormat::BLUE << "    Channel "
+          << LogFormat::NORMAL << channel_element->GetAttributeValue("name") << LogFormat::RESET << endl;
+    }
   
     Element* component_element = channel_element->GetElement();
     while (component_element) {
@@ -554,7 +567,6 @@ bool FGFCS::Load(Element* document)
           // <integrator> is equivalent to <pid type="trap">
           Element* c1_el = component_element->FindElement("c1");
           if (!c1_el) {
-            cerr << component_element->ReadFrom();
             throw("INTEGRATOR component " + component_element->GetAttributeValue("name")
                   + " does not provide the parameter <c1>");
           }
@@ -583,11 +595,13 @@ bool FGFCS::Load(Element* document)
         } else if (component_element->GetName() == string("linear_actuator")) {
           newChannel->Add(new FGLinearActuator(this, component_element));
         } else {
-          cerr << "Unknown FCS component: " << component_element->GetName() << endl;
+          FGXMLLogging log(FDMExec->GetLogger(), component_element, LogLevel::ERROR);
+          log << "Unknown FCS component: " << component_element->GetName() << endl;
         }
       } catch(string& s) {
-        cerr << highint << fgred << endl << "  " << s << endl;
-        cerr << reset << endl;
+        FGXMLLogging log(FDMExec->GetLogger(), component_element, LogLevel::ERROR);
+        log << LogFormat::BOLD << LogFormat::RED << endl << "  " << s << endl;
+        log << LogFormat::RESET << endl;
         return false;
       }
       component_element = channel_element->GetNextElement();
@@ -817,13 +831,15 @@ void FGFCS::Debug(int from)
   if (debug_lvl <= 0) return;
 
   if (debug_lvl & 1) { // Standard console startup message output
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
     if (from == 2) { // Loader
-      cout << endl << "  " << Name << endl;
+      log << endl << "  " << Name << endl;
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGFCS" << endl;
-    if (from == 1) cout << "Destroyed:    FGFCS" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGFCS" << endl;
+    if (from == 1) log << "Destroyed:    FGFCS" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGInertial.cpp
+++ b/src/models/FGInertial.cpp
@@ -35,8 +35,10 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+#include "FGFDMExec.h"
 #include "FGInertial.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/FGLog.h"
 #include "GeographicLib/Geodesic.hpp"
 
 using namespace std;
@@ -119,10 +121,11 @@ bool FGInertial::Load(Element* el)
 
   // Messages to warn the user about possible inconsistencies.
   if (debug_lvl > 0) {
+    FGLogging log(FDMExec->GetLogger(), LogLevel::WARN);
     if (a != b && J2 == 0.0)
-      cout << "Gravitational constant J2 is null for a non-spherical planet." << endl;
+      log << "Gravitational constant J2 is null for a non-spherical planet." << endl;
     if (a == b && J2 != 0.0)
-      cout << "Gravitational constant J2 is non-zero for a spherical planet." << endl;
+      log << "Gravitational constant J2 is non-zero for a spherical planet." << endl;
   }
 
   Debug(2);
@@ -239,15 +242,16 @@ void FGInertial::SetAltitudeAGL(FGLocation& location, double altitudeAGL)
 void FGInertial::SetGravityType(int gt)
 {
   // Messages to warn the user about possible inconsistencies.
+  FGLogging log(FDMExec->GetLogger(), LogLevel::WARN);
   switch (gt)
   {
   case eGravType::gtStandard:
     if (a != b)
-      cout << "Warning: Standard gravity model has been set for a non-spherical planet" << endl;
+      log << "Standard gravity model has been set for a non-spherical planet" << endl;
     break;
   case eGravType::gtWGS84:
     if (J2 == 0.0)
-      cout << "Warning: WGS84 gravity model has been set without specifying the J2 gravitational constant." << endl;
+      log << "WGS84 gravity model has been set without specifying the J2 gravitational constant." << endl;
   }
 
   gravType = gt;
@@ -287,19 +291,21 @@ void FGInertial::Debug(int from)
   if (debug_lvl <= 0) return;
 
   if (debug_lvl & 1) { // Standard console startup message output
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
     if (from == 0) {} // Constructor
     if (from == 2) { // Loading
-      cout << endl << "  Planet " << Name << endl;
-      cout << "    Semi major axis: " << a << endl;
-      cout << "    Semi minor axis: " << b << endl;
-      cout << "    Rotation rate  : " << scientific << vOmegaPlanet(eZ) << endl;
-      cout << "    GM             : " << GM << endl;
-      cout << "    J2             : " << J2 << endl << defaultfloat << endl;
+      log << endl << "  Planet " << Name << endl
+          << "    Semi major axis: " << a << endl
+          << "    Semi minor axis: " << b << endl
+          << "    Rotation rate  : " << scientific << vOmegaPlanet(eZ) << endl
+          << "    GM             : " << GM << endl
+          << "    J2             : " << J2 << endl << defaultfloat << endl;
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGInertial" << endl;
-    if (from == 1) cout << "Destroyed:    FGInertial" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGInertial" << endl;
+    if (from == 1) log << "Destroyed:    FGInertial" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGInput.cpp
+++ b/src/models/FGInput.cpp
@@ -157,9 +157,9 @@ bool FGInput::SetDirectivesFile(const SGPath& fname)
   FGXMLFileRead XMLFile;
   Element* document = XMLFile.LoadXMLDocument(fname);
   if (!document) {
-    stringstream s;
-    s << "Could not read directive file: " << fname;
-    throw BaseException(s.str());
+    FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
+    log << "Could not read directive file: " << fname << endl;
+    throw BaseException(log.str());
   }
   bool result = Load(document);
 

--- a/src/models/FGInput.cpp
+++ b/src/models/FGInput.cpp
@@ -43,6 +43,7 @@ INCLUDES
 #include "input_output/FGUDPInputSocket.h"
 #include "input_output/FGXMLFileRead.h"
 #include "input_output/FGModelLoader.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -91,7 +92,10 @@ bool FGInput::Load(Element* el)
   string type = element->GetAttributeValue("type");
   FGInputType* Input = 0;
 
-  if (debug_lvl > 0) cout << endl << "  Input data set: " << idx << "  " << endl;
+  if (debug_lvl > 0) {
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    log << endl << "  Input data set: " << idx << "  " << endl;
+  }
 
   type = to_upper(type);
 
@@ -100,8 +104,8 @@ bool FGInput::Load(Element* el)
   } else if (type == "QTJSBSIM") {
     Input = new FGUDPInputSocket(FDMExec);
   } else if (type != string("NONE")) {
-    cerr << element->ReadFrom()
-         << "Unknown type of input specified in config file" << endl;
+    FGXMLLogging log(FDMExec->GetLogger(), element, LogLevel::ERROR);
+    log << "Unknown type of input specified in config file" << endl;
   }
 
   if (!Input) return false;
@@ -159,8 +163,10 @@ bool FGInput::SetDirectivesFile(const SGPath& fname)
   }
   bool result = Load(document);
 
-  if (!result)
-    cerr << endl << "Aircraft input element has problems in file " << fname << endl;
+  if (!result) {
+    FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+    log << endl << "Aircraft input element has problems in file " << fname << endl;
+  }
 
   return result;
 }
@@ -229,8 +235,9 @@ void FGInput::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGInput" << endl;
-    if (from == 1) cout << "Destroyed:    FGInput" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGInput" << endl;
+    if (from == 1) log << "Destroyed:    FGInput" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -43,6 +43,7 @@ INCLUDES
 #include "FGMassBalance.h"
 #include "FGFDMExec.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -268,11 +269,9 @@ void FGMassBalance::AddPointMass(Element* el)
   Element* loc_element = el->FindElement("location");
   string pointmass_name = el->GetAttributeValue("name");
   if (!loc_element) {
-    stringstream s;
-    s << el->ReadFrom() << "Pointmass " << pointmass_name
-         << " has no location.";
-    cerr << endl << s.str() << endl;
-    throw BaseException(s.str());
+    FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::FATAL);
+    log << "Pointmass " << pointmass_name << " has no location." << endl;
+    throw BaseException(log.str());
   }
 
   double w = el->FindElementValueAsNumberConvertTo("weight", "LBS");
@@ -451,45 +450,44 @@ void FGMassBalance::PointMass::bind(FGPropertyManager* PropertyManager,
 
 void FGMassBalance::GetMassPropertiesReport(int i)
 {
-  cout << endl << fgblue << highint
-       << "  Mass Properties Report (English units: lbf, in, slug-ft^2)"
-       << reset << endl;
-  cout << "                                  " << underon << "    Weight    CG-X    CG-Y"
-       << "    CG-Z         Ixx         Iyy         Izz"
-       << "         Ixy         Ixz         Iyz" << underoff << endl;
-  cout.precision(1);
-  cout << highint << setw(34) << left << "    Base Vehicle " << normint
-       << right << setw(12) << EmptyWeight
-       << setw(8) << vbaseXYZcg(eX) << setw(8) << vbaseXYZcg(eY) << setw(8) << vbaseXYZcg(eZ)
-       << setw(12) << baseJ(1,1) << setw(12) << baseJ(2,2) << setw(12) << baseJ(3,3)
-       << setw(12) << baseJ(1,2) << setw(12) << baseJ(1,3) << setw(12) << baseJ(2,3) << endl;
+  FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
+  log << endl << LogFormat::BLUE << LogFormat::BOLD
+      << "  Mass Properties Report (English units: lbf, in, slug-ft^2)"
+      << LogFormat::RESET << endl;
+  log << "                                  " << underon << "    Weight    CG-X    CG-Y"
+      << "    CG-Z         Ixx         Iyy         Izz"
+      << "         Ixy         Ixz         Iyz" << underoff << endl;
+  log << setprecision(1);
+  log << LogFormat::BOLD << setw(34) << left << "    Base Vehicle " << normint
+      << right << setw(12) << EmptyWeight
+      << setw(8) << vbaseXYZcg(eX) << setw(8) << vbaseXYZcg(eY) << setw(8) << vbaseXYZcg(eZ)
+      << setw(12) << baseJ(1,1) << setw(12) << baseJ(2,2) << setw(12) << baseJ(3,3)
+      << setw(12) << baseJ(1,2) << setw(12) << baseJ(1,3) << setw(12) << baseJ(2,3) << endl;
 
   for (unsigned int i=0;i<PointMasses.size();i++) {
     PointMass* pm = PointMasses[i];
     double pmweight = pm->GetPointMassWeight();
-    cout << highint << left << setw(4) << i << setw(30) << pm->GetName() << normint
-         << right << setw(12) << pmweight << setw(8) << pm->GetLocation()(eX)
-         << setw(8) << pm->GetLocation()(eY) << setw(8) << pm->GetLocation()(eZ)
-         << setw(12) << pm->GetPointMassMoI(1,1) << setw(12) << pm->GetPointMassMoI(2,2) << setw(12) << pm->GetPointMassMoI(3,3)
-         << setw(12) << pm->GetPointMassMoI(1,2) << setw(12) << pm->GetPointMassMoI(1,3) << setw(12) << pm->GetPointMassMoI(2,3) << endl;
+    log << LogFormat::BOLD << left << setw(4) << i << setw(30) << pm->GetName() << normint
+        << right << setw(12) << pmweight << setw(8) << pm->GetLocation()(eX)
+        << setw(8) << pm->GetLocation()(eY) << setw(8) << pm->GetLocation()(eZ)
+        << setw(12) << pm->GetPointMassMoI(1,1) << setw(12) << pm->GetPointMassMoI(2,2) << setw(12) << pm->GetPointMassMoI(3,3)
+        << setw(12) << pm->GetPointMassMoI(1,2) << setw(12) << pm->GetPointMassMoI(1,3) << setw(12) << pm->GetPointMassMoI(2,3) << endl;
   }
 
-  cout << FDMExec->GetPropulsionTankReport();
+  log << FDMExec->GetPropulsionTankReport();
 
-  cout << "    " << underon << setw(136) << " " << underoff << endl;
-  cout << highint << left << setw(30) << "    Total: " << right << setw(14) << Weight
-       << setw(8) << vXYZcg(eX)
-       << setw(8) << vXYZcg(eY)
-       << setw(8) << vXYZcg(eZ)
-       << setw(12) << mJ(1,1)
-       << setw(12) << mJ(2,2)
-       << setw(12) << mJ(3,3)
-       << setw(12) << mJ(1,2)
-       << setw(12) << mJ(1,3)
-       << setw(12) << mJ(2,3)
-       << normint << endl;
-
-  cout.setf(ios_base::fixed);
+  log << "    " << underon << setw(136) << " " << underoff << endl;
+  log << LogFormat::BOLD << left << setw(30) << "    Total: " << right << setw(14) << Weight
+      << setw(8) << vXYZcg(eX)
+      << setw(8) << vXYZcg(eY)
+      << setw(8) << vXYZcg(eZ)
+      << setw(12) << mJ(1,1)
+      << setw(12) << mJ(2,2)
+      << setw(12) << mJ(3,3)
+      << setw(12) << mJ(1,2)
+      << setw(12) << mJ(1,3)
+      << setw(12) << mJ(2,3)
+      << LogFormat::NORMAL << endl;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -517,18 +515,19 @@ void FGMassBalance::Debug(int from)
 
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 2) { // Loading
-      cout << endl << "  Mass and Balance:" << endl;
-      cout << "    baseIxx: " << baseJ(1,1) << " slug-ft2" << endl;
-      cout << "    baseIyy: " << baseJ(2,2) << " slug-ft2" << endl;
-      cout << "    baseIzz: " << baseJ(3,3) << " slug-ft2" << endl;
-      cout << "    baseIxy: " << baseJ(1,2) << " slug-ft2" << endl;
-      cout << "    baseIxz: " << baseJ(1,3) << " slug-ft2" << endl;
-      cout << "    baseIyz: " << baseJ(2,3) << " slug-ft2" << endl;
-      cout << "    Empty Weight: " << EmptyWeight << " lbm" << endl;
-      cout << "    CG (x, y, z): " << vbaseXYZcg << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      log << endl << "  Mass and Balance:" << endl;
+      log << "    baseIxx: " << baseJ(1,1) << " slug-ft2" << endl;
+      log << "    baseIyy: " << baseJ(2,2) << " slug-ft2" << endl;
+      log << "    baseIzz: " << baseJ(3,3) << " slug-ft2" << endl;
+      log << "    baseIxy: " << baseJ(1,2) << " slug-ft2" << endl;
+      log << "    baseIxz: " << baseJ(1,3) << " slug-ft2" << endl;
+      log << "    baseIyz: " << baseJ(2,3) << " slug-ft2" << endl;
+      log << "    Empty Weight: " << EmptyWeight << " lbm" << endl;
+      log << "    CG (x, y, z): " << vbaseXYZcg << endl;
       // ToDo: Need to add point mass outputs here
       for (unsigned int i=0; i<PointMasses.size(); i++) {
-        cout << "    Point Mass Object: " << PointMasses[i]->Weight << " lbs. at "
+        log << "    Point Mass Object: " << PointMasses[i]->Weight << " lbs. at "
                    << "X, Y, Z (in.): " << PointMasses[i]->Location(eX) << "  "
                    << PointMasses[i]->Location(eY) << "  "
                    << PointMasses[i]->Location(eZ) << endl;
@@ -536,8 +535,9 @@ void FGMassBalance::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGMassBalance" << endl;
-    if (from == 1) cout << "Destroyed:    FGMassBalance" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGMassBalance" << endl;
+    if (from == 1) log << "Destroyed:    FGMassBalance" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }
@@ -545,12 +545,13 @@ void FGMassBalance::Debug(int from)
   }
   if (debug_lvl & 16) { // Sanity checking
     if (from == 2) {
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
       if (EmptyWeight <= 0.0 || EmptyWeight > 1e9)
-        cout << "MassBalance::EmptyWeight out of bounds: " << EmptyWeight << endl;
+        log << "MassBalance::EmptyWeight out of bounds: " << EmptyWeight << endl;
       if (Weight <= 0.0 || Weight > 1e9)
-        cout << "MassBalance::Weight out of bounds: " << Weight << endl;
+        log << "MassBalance::Weight out of bounds: " << Weight << endl;
       if (Mass <= 0.0 || Mass > 1e9)
-        cout << "MassBalance::Mass out of bounds: " << Mass << endl;
+        log << "MassBalance::Mass out of bounds: " << Mass << endl;
     }
   }
   if (debug_lvl & 64) {

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -454,9 +454,9 @@ void FGMassBalance::GetMassPropertiesReport(int i)
   log << endl << LogFormat::BLUE << LogFormat::BOLD
       << "  Mass Properties Report (English units: lbf, in, slug-ft^2)"
       << LogFormat::RESET << endl;
-  log << "                                  " << underon << "    Weight    CG-X    CG-Y"
+  log << "                                  " << LogFormat::UNDERLINE_ON << "    Weight    CG-X    CG-Y"
       << "    CG-Z         Ixx         Iyy         Izz"
-      << "         Ixy         Ixz         Iyz" << underoff << endl;
+      << "         Ixy         Ixz         Iyz" << LogFormat::UNDERLINE_OFF << endl;
   log << setprecision(1);
   log << LogFormat::BOLD << setw(34) << left << "    Base Vehicle " << normint
       << right << setw(12) << EmptyWeight
@@ -476,7 +476,7 @@ void FGMassBalance::GetMassPropertiesReport(int i)
 
   log << FDMExec->GetPropulsionTankReport();
 
-  log << "    " << underon << setw(136) << " " << underoff << endl;
+  log << "    " << LogFormat::UNDERLINE_ON << setw(136) << " " << LogFormat::UNDERLINE_OFF << endl;
   log << LogFormat::BOLD << left << setw(30) << "    Total: " << right << setw(14) << Weight
       << setw(8) << vXYZcg(eX)
       << setw(8) << vXYZcg(eY)

--- a/src/models/FGModel.cpp
+++ b/src/models/FGModel.cpp
@@ -41,6 +41,7 @@ INCLUDES
 #include "FGModel.h"
 #include "FGFDMExec.h"
 #include "input_output/FGModelLoader.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -66,14 +67,14 @@ FGModel::FGModel(FGFDMExec* fdmex)
   exe_ctr     = 1;
   rate        = 1;
 
-  if (debug_lvl & 2) cout << "              FGModel Base Class" << endl;
+  Debug(0);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 FGModel::~FGModel()
 {
-  if (debug_lvl & 2) cout << "Destroyed:    FGModel" << endl;
+  Debug(1);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -88,14 +89,14 @@ bool FGModel::InitModel(void)
 
 bool FGModel::Run(bool Holding)
 {
-  if (debug_lvl & 4) cout << "Entering Run() for model " << Name << endl;
-
   if (rate == 1) return false; // Fast exit if nothing to do
 
   if (exe_ctr >= rate) exe_ctr = 0;
 
   if (exe_ctr++ == 1) return false;
   else              return true;
+
+  Debug(2);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -115,9 +116,9 @@ bool FGModel::Upload(Element* el, bool preLoad)
   if (!document) return false;
 
   if (document->GetName() != el->GetName()) {
-    cerr << el->ReadFrom()
-         << " Read model '" << document->GetName()
-         << "' while expecting model '" << el->GetName() << "'" << endl;
+    FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::ERROR);
+    log << " Read model '" << document->GetName()
+        << "' while expecting model '" << el->GetName() << "'" << endl;
     return false;
   }
 
@@ -177,10 +178,13 @@ void FGModel::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGModel" << endl;
-    if (from == 1) cout << "Destroyed:    FGModel" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGModel" << endl;
+    if (from == 1) log << "Destroyed:    FGModel" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    log << "Entering Run() for model " << Name << endl;
   }
   if (debug_lvl & 8 ) { // Runtime state variables
   }

--- a/src/models/FGModel.h
+++ b/src/models/FGModel.h
@@ -90,12 +90,12 @@ public:
   /// Set the ouput rate for the model in frames
   void SetRate(unsigned int tt) {rate = tt;}
   /// Get the output rate for the model in frames
-  unsigned int GetRate(void)   {return rate;}
-  FGFDMExec* GetExec(void)     {return FDMExec;}
+  unsigned int GetRate(void) const { return rate; }
+  FGFDMExec* GetExec(void) const { return FDMExec; }
 
   void SetPropertyManager(std::shared_ptr<FGPropertyManager> fgpm) { PropertyManager=fgpm;}
   virtual SGPath FindFullPathName(const SGPath& path) const;
-  const std::string& GetName(void) { return Name; }
+  const std::string& GetName(void) const { return Name; }
   virtual bool Load(Element* el) { return true; }
 
 protected:

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -70,327 +70,328 @@ INCLUDES
 #include "FGFDMExec.h"
 #include "simgear/io/iostreams/sgstream.hxx"
 #include "FGInertial.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
 namespace JSBSim {
 
-/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-CLASS IMPLEMENTATION
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+  /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  CLASS IMPLEMENTATION
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGPropagate::FGPropagate(FGFDMExec* fdmex)
-  : FGModel(fdmex)
-{
-  Debug(0);
-  Name = "FGPropagate";
+  FGPropagate::FGPropagate(FGFDMExec* fdmex)
+    : FGModel(fdmex)
+  {
+    Debug(0);
+    Name = "FGPropagate";
 
-  Inertial = FDMExec->GetInertial();
+    Inertial = FDMExec->GetInertial();
 
-  /// These define the indices use to select the various integrators.
-  // eNone = 0, eRectEuler, eTrapezoidal, eAdamsBashforth2, eAdamsBashforth3, eAdamsBashforth4};
+    /// These define the indices use to select the various integrators.
+    // eNone = 0, eRectEuler, eTrapezoidal, eAdamsBashforth2, eAdamsBashforth3, eAdamsBashforth4};
 
-  integrator_rotational_rate = eRectEuler;
-  integrator_translational_rate = eAdamsBashforth2;
-  integrator_rotational_position = eRectEuler;
-  integrator_translational_position = eAdamsBashforth3;
+    integrator_rotational_rate = eRectEuler;
+    integrator_translational_rate = eAdamsBashforth2;
+    integrator_rotational_position = eRectEuler;
+    integrator_translational_position = eAdamsBashforth3;
 
   VState.dqPQRidot.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqUVWidot.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqInertialVelocity.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqQtrndot.resize(5, FGQuaternion(0.0,0.0,0.0));
 
-  epa = 0.0;
+    epa = 0.0;
 
-  bind();
-  Debug(0);
-}
+    bind();
+    Debug(0);
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-FGPropagate::~FGPropagate(void)
-{
-  Debug(1);
-}
+  FGPropagate::~FGPropagate(void)
+  {
+    Debug(1);
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-bool FGPropagate::InitModel(void)
-{
-  if (!FGModel::InitModel()) return false;
+  bool FGPropagate::InitModel(void)
+  {
+    if (!FGModel::InitModel()) return false;
 
-  // For initialization ONLY:
-  VState.vLocation.SetEllipse(in.SemiMajor, in.SemiMinor);
-  Inertial->SetAltitudeAGL(VState.vLocation, 4.0);
+    // For initialization ONLY:
+    VState.vLocation.SetEllipse(in.SemiMajor, in.SemiMinor);
+    Inertial->SetAltitudeAGL(VState.vLocation, 4.0);
 
   VState.dqPQRidot.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqUVWidot.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqInertialVelocity.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqQtrndot.resize(5, FGColumnVector3(0.0,0.0,0.0));
 
-  integrator_rotational_rate = eRectEuler;
-  integrator_translational_rate = eAdamsBashforth2;
-  integrator_rotational_position = eRectEuler;
-  integrator_translational_position = eAdamsBashforth3;
+    integrator_rotational_rate = eRectEuler;
+    integrator_translational_rate = eAdamsBashforth2;
+    integrator_rotational_position = eRectEuler;
+    integrator_translational_position = eAdamsBashforth3;
 
-  epa = 0.0;
+    epa = 0.0;
 
-  return true;
-}
+    return true;
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetInitialState(const FGInitialCondition* FGIC)
-{
-  // Initialize the State Vector elements and the transformation matrices
+  void FGPropagate::SetInitialState(const FGInitialCondition* FGIC)
+  {
+    // Initialize the State Vector elements and the transformation matrices
 
-  // Set the position lat/lon/radius
-  VState.vLocation = FGIC->GetPosition();
+    // Set the position lat/lon/radius
+    VState.vLocation = FGIC->GetPosition();
 
-  epa = FGIC->GetEarthPositionAngleIC();
-  Ti2ec = { cos(epa), sin(epa), 0.0,
-            -sin(epa), cos(epa), 0.0,
-            0.0, 0.0, 1.0 };
-  Tec2i = Ti2ec.Transposed();          // ECEF to ECI frame transform
+    epa = FGIC->GetEarthPositionAngleIC();
+    Ti2ec = { cos(epa), sin(epa), 0.0,
+              -sin(epa), cos(epa), 0.0,
+              0.0, 0.0, 1.0 };
+    Tec2i = Ti2ec.Transposed();          // ECEF to ECI frame transform
 
-  VState.vInertialPosition = Tec2i * VState.vLocation;
+    VState.vInertialPosition = Tec2i * VState.vLocation;
 
-  UpdateLocationMatrices();
+    UpdateLocationMatrices();
 
-  // Set the orientation from the euler angles (is normalized within the
-  // constructor). The Euler angles represent the orientation of the body
-  // frame relative to the local frame.
-  VState.qAttitudeLocal = FGIC->GetOrientation();
+    // Set the orientation from the euler angles (is normalized within the
+    // constructor). The Euler angles represent the orientation of the body
+    // frame relative to the local frame.
+    VState.qAttitudeLocal = FGIC->GetOrientation();
 
   VState.qAttitudeECI = Ti2l.GetQuaternion()*VState.qAttitudeLocal;
-  UpdateBodyMatrices();
+    UpdateBodyMatrices();
 
-  // Set the velocities in the instantaneus body frame
-  VState.vUVW = FGIC->GetUVWFpsIC();
+    // Set the velocities in the instantaneus body frame
+    VState.vUVW = FGIC->GetUVWFpsIC();
 
-  // Compute the local frame ECEF velocity
-  vVel = Tb2l * VState.vUVW;
+    // Compute the local frame ECEF velocity
+    vVel = Tb2l * VState.vUVW;
 
-  // Compute local terrain velocity
-  RecomputeLocalTerrainVelocity();
+    // Compute local terrain velocity
+    RecomputeLocalTerrainVelocity();
 
-  // Set the angular velocities of the body frame relative to the ECEF frame,
-  // expressed in the body frame.
-  VState.vPQR = FGIC->GetPQRRadpsIC();
+    // Set the angular velocities of the body frame relative to the ECEF frame,
+    // expressed in the body frame.
+    VState.vPQR = FGIC->GetPQRRadpsIC();
 
-  VState.vPQRi = VState.vPQR + Ti2b * in.vOmegaPlanet;
+    VState.vPQRi = VState.vPQR + Ti2b * in.vOmegaPlanet;
 
-  CalculateInertialVelocity(); // Translational position derivative
-  CalculateQuatdot();  // Angular orientation derivative
-}
+    CalculateInertialVelocity(); // Translational position derivative
+    CalculateQuatdot();  // Angular orientation derivative
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-// Initialize the past value deques
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  // Initialize the past value deques
 
-void FGPropagate::InitializeDerivatives()
-{
-  VState.dqPQRidot.assign(5, in.vPQRidot);
-  VState.dqUVWidot.assign(5, in.vUVWidot);
-  VState.dqInertialVelocity.assign(5, VState.vInertialVelocity);
-  VState.dqQtrndot.assign(5, VState.vQtrndot);
-}
+  void FGPropagate::InitializeDerivatives()
+  {
+    VState.dqPQRidot.assign(5, in.vPQRidot);
+    VState.dqUVWidot.assign(5, in.vUVWidot);
+    VState.dqInertialVelocity.assign(5, VState.vInertialVelocity);
+    VState.dqQtrndot.assign(5, VState.vQtrndot);
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-/*
-Purpose: Called on a schedule to perform EOM integration
-Notes:   [JB] Run in standalone mode, SeaLevelRadius will be reference radius.
-         In FGFS, SeaLevelRadius is stuffed from FGJSBSim in JSBSim.cxx each pass.
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  /*
+  Purpose: Called on a schedule to perform EOM integration
+  Notes:   [JB] Run in standalone mode, SeaLevelRadius will be reference radius.
+           In FGFS, SeaLevelRadius is stuffed from FGJSBSim in JSBSim.cxx each pass.
 
-At the top of this Run() function, see several "shortcuts" (or, aliases) being
-set up for use later, rather than using the longer class->function() notation.
+  At the top of this Run() function, see several "shortcuts" (or, aliases) being
+  set up for use later, rather than using the longer class->function() notation.
 
-This propagation is done using the current state values
-and current derivatives. Based on these values we compute an approximation to the
-state values for (now + dt).
+  This propagation is done using the current state values
+  and current derivatives. Based on these values we compute an approximation to the
+  state values for (now + dt).
 
-In the code below, variables named beginning with a small "v" refer to a
-a column vector, variables named beginning with a "T" refer to a transformation
-matrix. ECEF refers to Earth Centered Earth Fixed. ECI refers to Earth Centered
-Inertial.
+  In the code below, variables named beginning with a small "v" refer to a
+  a column vector, variables named beginning with a "T" refer to a transformation
+  matrix. ECEF refers to Earth Centered Earth Fixed. ECI refers to Earth Centered
+  Inertial.
 
-*/
+  */
 
-bool FGPropagate::Run(bool Holding)
-{
-  if (FGModel::Run(Holding)) return true;  // Fast return if we have nothing to do ...
-  if (Holding) return false;
+  bool FGPropagate::Run(bool Holding)
+  {
+    if (FGModel::Run(Holding)) return true;  // Fast return if we have nothing to do ...
+    if (Holding) return false;
 
-  double dt = in.DeltaT * rate;  // The 'stepsize'
+    double dt = in.DeltaT * rate;  // The 'stepsize'
 
-  // Propagate rotational / translational velocity, angular /translational position, respectively.
+    // Propagate rotational / translational velocity, angular /translational position, respectively.
 
-  if (!FDMExec->IntegrationSuspended()) {
+    if (!FDMExec->IntegrationSuspended()) {
     Integrate(VState.qAttitudeECI,      VState.vQtrndot,      VState.dqQtrndot,          dt, integrator_rotational_position);
     Integrate(VState.vPQRi,             in.vPQRidot,          VState.dqPQRidot,          dt, integrator_rotational_rate);
-    Integrate(VState.vInertialPosition, VState.vInertialVelocity, VState.dqInertialVelocity, dt, integrator_translational_position);
+      Integrate(VState.vInertialPosition, VState.vInertialVelocity, VState.dqInertialVelocity, dt, integrator_translational_position);
     Integrate(VState.vInertialVelocity, in.vUVWidot,          VState.dqUVWidot,          dt, integrator_translational_rate);
-  }
+    }
 
-  // CAUTION : the order of the operations below is very important to get
-  // transformation matrices that are consistent with the new state of the
-  // vehicle
+    // CAUTION : the order of the operations below is very important to get
+    // transformation matrices that are consistent with the new state of the
+    // vehicle
 
-  // 1. Update the Earth position angle (EPA)
+    // 1. Update the Earth position angle (EPA)
   epa += in.vOmegaPlanet(eZ)*dt;
 
-  // 2. Update the Ti2ec and Tec2i transforms from the updated EPA
-  double cos_epa = cos(epa);
-  double sin_epa = sin(epa);
-  Ti2ec = { cos_epa, sin_epa, 0.0,
-            -sin_epa, cos_epa, 0.0,
-            0.0, 0.0, 1.0 };
-  Tec2i = Ti2ec.Transposed();          // ECEF to ECI frame transform
+    // 2. Update the Ti2ec and Tec2i transforms from the updated EPA
+    double cos_epa = cos(epa);
+    double sin_epa = sin(epa);
+    Ti2ec = { cos_epa, sin_epa, 0.0,
+              -sin_epa, cos_epa, 0.0,
+              0.0, 0.0, 1.0 };
+    Tec2i = Ti2ec.Transposed();          // ECEF to ECI frame transform
 
-  // 3. Update the location from the updated Ti2ec and inertial position
+    // 3. Update the location from the updated Ti2ec and inertial position
   VState.vLocation = Ti2ec*VState.vInertialPosition;
 
-  // 4. Update the other "Location-based" transformation matrices from the
-  //    updated vLocation vector.
-  UpdateLocationMatrices();
+    // 4. Update the other "Location-based" transformation matrices from the
+    //    updated vLocation vector.
+    UpdateLocationMatrices();
 
-  // 5. Update the "Orientation-based" transformation matrices from the updated
-  //    orientation quaternion and vLocation vector.
-  UpdateBodyMatrices();
+    // 5. Update the "Orientation-based" transformation matrices from the updated
+    //    orientation quaternion and vLocation vector.
+    UpdateBodyMatrices();
 
-  // Translational position derivative (velocities are integrated in the
-  // inertial frame)
-  CalculateUVW();
+    // Translational position derivative (velocities are integrated in the
+    // inertial frame)
+    CalculateUVW();
 
-  // Set auxilliary state variables
-  RecomputeLocalTerrainVelocity();
+    // Set auxilliary state variables
+    RecomputeLocalTerrainVelocity();
 
-  VState.vPQR = VState.vPQRi - Ti2b * in.vOmegaPlanet;
+    VState.vPQR = VState.vPQRi - Ti2b * in.vOmegaPlanet;
 
-  // Angular orientation derivative
-  CalculateQuatdot();
-
-  VState.qAttitudeLocal = Tl2b.GetQuaternion();
-
-  // Compute vehicle velocity wrt ECEF frame, expressed in Local horizontal
-  // frame.
-  vVel = Tb2l * VState.vUVW;
-
-  // Compute orbital parameters in the inertial frame
-  ComputeOrbitalParameters();
-
-  Debug(2);
-  return false;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void FGPropagate::SetHoldDown(bool hd)
-{
-  if (hd) {
-    VState.vUVW.InitMatrix();
-    CalculateInertialVelocity();
-    VState.vPQR.InitMatrix();
-    VState.vPQRi = Ti2b * in.vOmegaPlanet;
+    // Angular orientation derivative
     CalculateQuatdot();
-    InitializeDerivatives();
+
+    VState.qAttitudeLocal = Tl2b.GetQuaternion();
+
+    // Compute vehicle velocity wrt ECEF frame, expressed in Local horizontal
+    // frame.
+    vVel = Tb2l * VState.vUVW;
+
+    // Compute orbital parameters in the inertial frame
+    ComputeOrbitalParameters();
+
+    Debug(2);
+    return false;
   }
-}
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-// Compute the quaternion orientation derivative
-//
-// vQtrndot is the quaternion derivative.
-// Reference: See Stevens and Lewis, "Aircraft Control and Simulation",
-//            Second edition (2004), eqn 1.5-16b (page 50)
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::CalculateQuatdot(void)
-{
-  // Compute quaternion orientation derivative on current body rates
-  VState.vQtrndot = VState.qAttitudeECI.GetQDot(VState.vPQRi);
-}
+  void FGPropagate::SetHoldDown(bool hd)
+  {
+    if (hd) {
+      VState.vUVW.InitMatrix();
+      CalculateInertialVelocity();
+      VState.vPQR.InitMatrix();
+      VState.vPQRi = Ti2b * in.vOmegaPlanet;
+      CalculateQuatdot();
+      InitializeDerivatives();
+    }
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  // Transform the velocity vector of the body relative to the origin (Earth
-  // center) to be expressed in the inertial frame, and add the vehicle velocity
-  // contribution due to the rotation of the planet.
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  // Compute the quaternion orientation derivative
+  //
+  // vQtrndot is the quaternion derivative.
   // Reference: See Stevens and Lewis, "Aircraft Control and Simulation",
-  //            Second edition (2004), eqn 1.5-16c (page 50)
+  //            Second edition (2004), eqn 1.5-16b (page 50)
 
-void FGPropagate::CalculateInertialVelocity(void)
-{
-  VState.vInertialVelocity = Tb2i * VState.vUVW + (in.vOmegaPlanet * VState.vInertialPosition);
-}
+  void FGPropagate::CalculateQuatdot(void)
+  {
+    // Compute quaternion orientation derivative on current body rates
+    VState.vQtrndot = VState.qAttitudeECI.GetQDot(VState.vPQRi);
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  // Transform the velocity vector of the inertial frame to be expressed in the
-  // body frame relative to the origin (Earth center), and substract the vehicle
-  // velocity contribution due to the rotation of the planet.
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    // Transform the velocity vector of the body relative to the origin (Earth
+    // center) to be expressed in the inertial frame, and add the vehicle velocity
+    // contribution due to the rotation of the planet.
+    // Reference: See Stevens and Lewis, "Aircraft Control and Simulation",
+    //            Second edition (2004), eqn 1.5-16c (page 50)
 
-void FGPropagate::CalculateUVW(void)
-{
-  VState.vUVW = Ti2b * (VState.vInertialVelocity - (in.vOmegaPlanet * VState.vInertialPosition));
-}
+  void FGPropagate::CalculateInertialVelocity(void)
+  {
+    VState.vInertialVelocity = Tb2i * VState.vUVW + (in.vOmegaPlanet * VState.vInertialPosition);
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    // Transform the velocity vector of the inertial frame to be expressed in the
+    // body frame relative to the origin (Earth center), and substract the vehicle
+    // velocity contribution due to the rotation of the planet.
+
+  void FGPropagate::CalculateUVW(void)
+  {
+    VState.vUVW = Ti2b * (VState.vInertialVelocity - (in.vOmegaPlanet * VState.vInertialPosition));
+  }
+
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGPropagate::Integrate( FGColumnVector3& Integrand,
-                             FGColumnVector3& Val,
-                             deque <FGColumnVector3>& ValDot,
-                             double dt,
-                             eIntegrateType integration_type)
-{
-  ValDot.push_front(Val);
-  ValDot.pop_back();
+    FGColumnVector3& Val,
+    deque <FGColumnVector3>& ValDot,
+    double dt,
+    eIntegrateType integration_type)
+  {
+    ValDot.push_front(Val);
+    ValDot.pop_back();
 
   switch(integration_type) {
   case eRectEuler:       Integrand += dt*ValDot[0];
-    break;
+      break;
   case eTrapezoidal:     Integrand += 0.5*dt*(ValDot[0] + ValDot[1]);
-    break;
+      break;
   case eAdamsBashforth2: Integrand += dt*(1.5*ValDot[0] - 0.5*ValDot[1]);
-    break;
+      break;
   case eAdamsBashforth3: Integrand += (1/12.0)*dt*(23.0*ValDot[0] - 16.0*ValDot[1] + 5.0*ValDot[2]);
-    break;
+      break;
   case eAdamsBashforth4: Integrand += (1/24.0)*dt*(55.0*ValDot[0] - 59.0*ValDot[1] + 37.0*ValDot[2] - 9.0*ValDot[3]);
-    break;
+      break;
   case eAdamsBashforth5: Integrand += dt*((1901./720.)*ValDot[0] - (1387./360.)*ValDot[1] + (109./30.)*ValDot[2] - (637./360.)*ValDot[3] + (251./720.)*ValDot[4]);
-    break;
-  case eNone: // do nothing, freeze translational rate
-    break;
-  case eBuss1:
-  case eBuss2:
-  case eLocalLinearization:
-    throw("Can only use Buss (1 & 2) or local linearization integration methods in for rotational position!");
-  default:
-    break;
+      break;
+    case eNone: // do nothing, freeze translational rate
+      break;
+    case eBuss1:
+    case eBuss2:
+    case eLocalLinearization:
+      throw("Can only use Buss (1 & 2) or local linearization integration methods in for rotational position!");
+    default:
+      break;
+    }
   }
-}
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGPropagate::Integrate( FGQuaternion& Integrand,
-                             FGQuaternion& Val,
-                             deque <FGQuaternion>& ValDot,
-                             double dt,
-                             eIntegrateType integration_type)
-{
-  ValDot.push_front(Val);
-  ValDot.pop_back();
+    FGQuaternion& Val,
+    deque <FGQuaternion>& ValDot,
+    double dt,
+    eIntegrateType integration_type)
+  {
+    ValDot.push_front(Val);
+    ValDot.pop_back();
 
   switch(integration_type) {
   case eRectEuler:       Integrand += dt*ValDot[0];
-    break;
+      break;
   case eTrapezoidal:     Integrand += 0.5*dt*(ValDot[0] + ValDot[1]);
-    break;
+      break;
   case eAdamsBashforth2: Integrand += dt*(1.5*ValDot[0] - 0.5*ValDot[1]);
-    break;
+      break;
   case eAdamsBashforth3: Integrand += (1/12.0)*dt*(23.0*ValDot[0] - 16.0*ValDot[1] + 5.0*ValDot[2]);
-    break;
+      break;
   case eAdamsBashforth4: Integrand += (1/24.0)*dt*(55.0*ValDot[0] - 59.0*ValDot[1] + 37.0*ValDot[2] - 9.0*ValDot[3]);
-    break;
+      break;
   case eAdamsBashforth5: Integrand += dt*((1901./720.)*ValDot[0] - (1387./360.)*ValDot[1] + (109./30.)*ValDot[2] - (637./360.)*ValDot[3] + (251./720.)*ValDot[4]);
-    break;
-  case eBuss1:
+      break;
+    case eBuss1:
     {
       // This is the first order method as described in Samuel R. Buss paper[6].
       // The formula from Buss' paper is transposed below to quaternions and is
@@ -399,7 +400,7 @@ void FGPropagate::Integrate( FGQuaternion& Integrand,
       Integrand = Integrand * QExp(0.5 * dt * VState.vPQRi);
     }
     return; // No need to normalize since the quaternion exponential is always normal
-  case eBuss2:
+    case eBuss2:
     {
       // This is the 'augmented second-order method' from S.R. Buss paper [6].
       // Unlike Runge-Kutta or Adams-Bashforth, it is a one-pass second-order
@@ -410,7 +411,7 @@ void FGPropagate::Integrate( FGQuaternion& Integrand,
       Integrand = Integrand * QExp(0.5 * dt * omega);
     }
     return; // No need to normalize since the quaternion exponential is always normal
-  case eLocalLinearization:
+    case eLocalLinearization:
     {
       // This is the local linearization algorithm of Barker et al. (see ref. [7])
       // It is also a one-pass second-order method. The code below is based on the
@@ -461,598 +462,601 @@ void FGPropagate::Integrate( FGQuaternion& Integrand,
       cout << "FORTRAN: " << H << " , " << K << " , " << J << " , " << -G << endl;*/
     }
     break; // The quaternion q is not normal so the normalization needs to be done.
-  case eNone: // do nothing, freeze rotational rate
-    break;
-  default:
-    break;
+    case eNone: // do nothing, freeze rotational rate
+      break;
+    default:
+      break;
+    }
+
+    Integrand.Normalize();
   }
 
-  Integrand.Normalize();
-}
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void FGPropagate::UpdateLocationMatrices(void)
-{
-  Tl2ec = VState.vLocation.GetTl2ec(); // local to ECEF transform
-  Tec2l = Tl2ec.Transposed();          // ECEF to local frame transform
+  void FGPropagate::UpdateLocationMatrices(void)
+  {
+    Tl2ec = VState.vLocation.GetTl2ec(); // local to ECEF transform
+    Tec2l = Tl2ec.Transposed();          // ECEF to local frame transform
   Ti2l  = Tec2l * Ti2ec;               // ECI to local frame transform
   Tl2i  = Ti2l.Transposed();           // local to ECI transform
-}
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::UpdateBodyMatrices(void)
-{
+  void FGPropagate::UpdateBodyMatrices(void)
+  {
   Ti2b  = VState.qAttitudeECI.GetT(); // ECI to body frame transform
   Tb2i  = Ti2b.Transposed();          // body to ECI frame transform
   Tl2b  = Ti2b * Tl2i;                // local to body frame transform
   Tb2l  = Tl2b.Transposed();          // body to local frame transform
-  Tec2b = Ti2b * Tec2i;               // ECEF to body frame transform
-  Tb2ec = Tec2b.Transposed();         // body to ECEF frame tranform
+    Tec2b = Ti2b * Tec2i;               // ECEF to body frame transform
+    Tb2ec = Tec2b.Transposed();         // body to ECEF frame tranform
 
-  Qec2b = Tec2b.GetQuaternion();
-}
+    Qec2b = Tec2b.GetQuaternion();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::ComputeOrbitalParameters(void)
-{
-  const FGColumnVector3 Z{0., 0., 1.};
-  FGColumnVector3 R = VState.vInertialPosition;
-  FGColumnVector3 angularMomentum = R * VState.vInertialVelocity;
-  h = angularMomentum.Magnitude();
-  Inclination = acos(angularMomentum(eZ)/h)*radtodeg;
-  FGColumnVector3 N;
-  if (abs(Inclination) > 1E-8) {
-    N = Z * angularMomentum;
-    RightAscension = atan2(N(eY), N(eX))*radtodeg;
-    N.Normalize();
-  }
-  else {
-    RightAscension = 0.0;
-    N = {1., 0., 0.};
-    PerigeeArgument = 0.0;
-  }
-  R.Normalize();
-  double vr = DotProduct(R, VState.vInertialVelocity);
-  FGColumnVector3 eVector = (VState.vInertialVelocity*angularMomentum/in.GM - R);
-  Eccentricity = eVector.Magnitude();
-  if (Eccentricity > 1E-8) {
-    eVector /= Eccentricity;
-    if (abs(Inclination) > 1E-8) {
-      PerigeeArgument = acos(DotProduct(N, eVector)) * radtodeg;
-      if (eVector(eZ) < 0) PerigeeArgument = 360. - PerigeeArgument;
-    }
-  }
-  else
+  void FGPropagate::ComputeOrbitalParameters(void)
   {
+  const FGColumnVector3 Z{0., 0., 1.};
+    FGColumnVector3 R = VState.vInertialPosition;
+    FGColumnVector3 angularMomentum = R * VState.vInertialVelocity;
+    h = angularMomentum.Magnitude();
+  Inclination = acos(angularMomentum(eZ)/h)*radtodeg;
+    FGColumnVector3 N;
+    if (abs(Inclination) > 1E-8) {
+      N = Z * angularMomentum;
+    RightAscension = atan2(N(eY), N(eX))*radtodeg;
+      N.Normalize();
+    }
+    else {
+      RightAscension = 0.0;
+    N = {1., 0., 0.};
+      PerigeeArgument = 0.0;
+    }
+    R.Normalize();
+    double vr = DotProduct(R, VState.vInertialVelocity);
+  FGColumnVector3 eVector = (VState.vInertialVelocity*angularMomentum/in.GM - R);
+    Eccentricity = eVector.Magnitude();
+    if (Eccentricity > 1E-8) {
+      eVector /= Eccentricity;
+      if (abs(Inclination) > 1E-8) {
+        PerigeeArgument = acos(DotProduct(N, eVector)) * radtodeg;
+        if (eVector(eZ) < 0) PerigeeArgument = 360. - PerigeeArgument;
+      }
+    }
+    else
+    {
     eVector = {1., 0., 0.};
-    PerigeeArgument = 0.0;
-  }
+      PerigeeArgument = 0.0;
+    }
 
-  TrueAnomaly = acos(Constrain(-1.0, DotProduct(eVector, R), 1.0)) * radtodeg;
-  if (vr < 0.0) TrueAnomaly = 360. - TrueAnomaly;
+    TrueAnomaly = acos(Constrain(-1.0, DotProduct(eVector, R), 1.0)) * radtodeg;
+    if (vr < 0.0) TrueAnomaly = 360. - TrueAnomaly;
   ApoapsisRadius = h*h / (in.GM * (1-Eccentricity));
   PeriapsisRadius = h*h / (in.GM * (1+Eccentricity));
 
-  if (Eccentricity < 1.0) {
+    if (Eccentricity < 1.0) {
     double semimajor = 0.5*(ApoapsisRadius + PeriapsisRadius);
     OrbitalPeriod = 2.*M_PI*pow(semimajor, 1.5)/sqrt(in.GM);
+    }
+    else
+      OrbitalPeriod = 0.0;
   }
-  else
-    OrbitalPeriod = 0.0;
-}
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetInertialOrientation(const FGQuaternion& Qi)
-{
-  VState.qAttitudeECI = Qi;
-  VState.qAttitudeECI.Normalize();
-  UpdateBodyMatrices();
-  VState.qAttitudeLocal = Tl2b.GetQuaternion();
-  CalculateQuatdot();
-}
+  void FGPropagate::SetInertialOrientation(const FGQuaternion& Qi)
+  {
+    VState.qAttitudeECI = Qi;
+    VState.qAttitudeECI.Normalize();
+    UpdateBodyMatrices();
+    VState.qAttitudeLocal = Tl2b.GetQuaternion();
+    CalculateQuatdot();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetInertialVelocity(const FGColumnVector3& Vi) {
-  VState.vInertialVelocity = Vi;
-  CalculateUVW();
-  vVel = Tb2l * VState.vUVW;
-}
+  void FGPropagate::SetInertialVelocity(const FGColumnVector3& Vi) {
+    VState.vInertialVelocity = Vi;
+    CalculateUVW();
+    vVel = Tb2l * VState.vUVW;
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetInertialRates(const FGColumnVector3& vRates) {
-  VState.vPQRi = Ti2b * vRates;
-  VState.vPQR = VState.vPQRi - Ti2b * in.vOmegaPlanet;
-  CalculateQuatdot();
-}
+  void FGPropagate::SetInertialRates(const FGColumnVector3& vRates) {
+    VState.vPQRi = Ti2b * vRates;
+    VState.vPQR = VState.vPQRi - Ti2b * in.vOmegaPlanet;
+    CalculateQuatdot();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-double FGPropagate::GetAltitudeASL() const
-{
-  return VState.vLocation.GetRadius() - VState.vLocation.GetSeaLevelRadius();
-}
+  double FGPropagate::GetAltitudeASL() const
+  {
+    return VState.vLocation.GetRadius() - VState.vLocation.GetSeaLevelRadius();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetAltitudeASL(double altASL)
-{
-  double slr = VState.vLocation.GetSeaLevelRadius();
-  VState.vLocation.SetRadius(slr + altASL);
-  UpdateVehicleState();
-}
+  void FGPropagate::SetAltitudeASL(double altASL)
+  {
+    double slr = VState.vLocation.GetSeaLevelRadius();
+    VState.vLocation.SetRadius(slr + altASL);
+    UpdateVehicleState();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::RecomputeLocalTerrainVelocity()
-{
-  FGLocation contact;
-  FGColumnVector3 normal;
-  Inertial->GetContactPoint(VState.vLocation, contact, normal,
-                            LocalTerrainVelocity, LocalTerrainAngularVelocity);
-}
+  void FGPropagate::RecomputeLocalTerrainVelocity()
+  {
+    FGLocation contact;
+    FGColumnVector3 normal;
+    Inertial->GetContactPoint(VState.vLocation, contact, normal,
+      LocalTerrainVelocity, LocalTerrainAngularVelocity);
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-double FGPropagate::GetTerrainElevation(void) const
-{
-  FGColumnVector3 vDummy;
-  FGLocation contact;
-  contact.SetEllipse(in.SemiMajor, in.SemiMinor);
-  Inertial->GetContactPoint(VState.vLocation, contact, vDummy, vDummy, vDummy);
-  return contact.GetGeodAltitude();
-}
+  double FGPropagate::GetTerrainElevation(void) const
+  {
+    FGColumnVector3 vDummy;
+    FGLocation contact;
+    contact.SetEllipse(in.SemiMajor, in.SemiMinor);
+    Inertial->GetContactPoint(VState.vLocation, contact, vDummy, vDummy, vDummy);
+    return contact.GetGeodAltitude();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetTerrainElevation(double terrainElev)
-{
-  Inertial->SetTerrainElevation(terrainElev);
-}
+  void FGPropagate::SetTerrainElevation(double terrainElev)
+  {
+    Inertial->SetTerrainElevation(terrainElev);
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-double FGPropagate::GetLocalTerrainRadius(void) const
-{
-  FGLocation contact;
-  FGColumnVector3 vDummy;
-  Inertial->GetContactPoint(VState.vLocation, contact, vDummy, vDummy, vDummy);
-  return contact.GetRadius();
-}
+  double FGPropagate::GetLocalTerrainRadius(void) const
+  {
+    FGLocation contact;
+    FGColumnVector3 vDummy;
+    Inertial->GetContactPoint(VState.vLocation, contact, vDummy, vDummy, vDummy);
+    return contact.GetRadius();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-double FGPropagate::GetDistanceAGL(void) const
-{
-  return Inertial->GetAltitudeAGL(VState.vLocation);
-}
+  double FGPropagate::GetDistanceAGL(void) const
+  {
+    return Inertial->GetAltitudeAGL(VState.vLocation);
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-double FGPropagate::GetDistanceAGLKm(void) const
-{
+  double FGPropagate::GetDistanceAGLKm(void) const
+  {
   return GetDistanceAGL()*0.0003048;
-}
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetDistanceAGL(double tt)
-{
-  Inertial->SetAltitudeAGL(VState.vLocation, tt);
-  UpdateVehicleState();
-}
+  void FGPropagate::SetDistanceAGL(double tt)
+  {
+    Inertial->SetAltitudeAGL(VState.vLocation, tt);
+    UpdateVehicleState();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetDistanceAGLKm(double tt)
-{
+  void FGPropagate::SetDistanceAGLKm(double tt)
+  {
   SetDistanceAGL(tt*3280.8399);
-}
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetVState(const VehicleState& vstate)
-{
-  //ToDo: Shouldn't all of these be set from the vstate vector passed in?
-  VState.vLocation = vstate.vLocation;
-  UpdateLocationMatrices();
-  SetInertialOrientation(vstate.qAttitudeECI);
-  RecomputeLocalTerrainVelocity();
-  VState.vUVW = vstate.vUVW;
-  vVel = Tb2l * VState.vUVW;
-  VState.vPQR = vstate.vPQR;
-  VState.vPQRi = VState.vPQR + Ti2b * in.vOmegaPlanet;
-  VState.vInertialPosition = vstate.vInertialPosition;
-  CalculateQuatdot();
-}
+  void FGPropagate::SetVState(const VehicleState& vstate)
+  {
+    //ToDo: Shouldn't all of these be set from the vstate vector passed in?
+    VState.vLocation = vstate.vLocation;
+    UpdateLocationMatrices();
+    SetInertialOrientation(vstate.qAttitudeECI);
+    RecomputeLocalTerrainVelocity();
+    VState.vUVW = vstate.vUVW;
+    vVel = Tb2l * VState.vUVW;
+    VState.vPQR = vstate.vPQR;
+    VState.vPQRi = VState.vPQR + Ti2b * in.vOmegaPlanet;
+    VState.vInertialPosition = vstate.vInertialPosition;
+    CalculateQuatdot();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::UpdateVehicleState(void)
-{
-  RecomputeLocalTerrainVelocity();
-  VState.vInertialPosition = Tec2i * VState.vLocation;
-  UpdateLocationMatrices();
-  UpdateBodyMatrices();
-  vVel = Tb2l * VState.vUVW;
-  VState.qAttitudeLocal = Tl2b.GetQuaternion();
-}
+  void FGPropagate::UpdateVehicleState(void)
+  {
+    RecomputeLocalTerrainVelocity();
+    VState.vInertialPosition = Tec2i * VState.vLocation;
+    UpdateLocationMatrices();
+    UpdateBodyMatrices();
+    vVel = Tb2l * VState.vUVW;
+    VState.qAttitudeLocal = Tl2b.GetQuaternion();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::SetLocation(const FGLocation& l)
-{
-  VState.vLocation = l;
-  UpdateVehicleState();
-}
+  void FGPropagate::SetLocation(const FGLocation& l)
+  {
+    VState.vLocation = l;
+    UpdateVehicleState();
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-FGColumnVector3 FGPropagate::GetEulerDeg(void) const
-{
-  return VState.qAttitudeLocal.GetEuler() * radtodeg;
-}
+  FGColumnVector3 FGPropagate::GetEulerDeg(void) const
+  {
+    return VState.qAttitudeLocal.GetEuler() * radtodeg;
+  }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::DumpState(void)
-{
-  cout << endl;
-  cout << fgblue
-       << "------------------------------------------------------------------" << reset << endl;
-  cout << highint
-       << "State Report at sim time: " << FDMExec->GetSimTime() << " seconds" << reset << endl;
-  cout << "  " << underon
-       <<   "Position" << underoff << endl;
-  cout << "    ECI:   " << VState.vInertialPosition.Dump(", ") << " (x,y,z, in ft)" << endl;
-  cout << "    ECEF:  " << VState.vLocation << " (x,y,z, in ft)"  << endl;
-  cout << "    Local: " << VState.vLocation.GetGeodLatitudeDeg()
-                        << ", " << VState.vLocation.GetLongitudeDeg()
-                        << ", " << GetAltitudeASL() << " (geodetic lat, lon, alt ASL in deg and ft)" << endl;
+  void FGPropagate::DumpState(void)
+  {
+    FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
+    log << endl;
+    log << LogFormat::BLUE
+        << "------------------------------------------------------------------" << LogFormat::RESET << endl;
+    log << LogFormat::BOLD
+        << "State Report at sim time: " << FDMExec->GetSimTime() << " seconds" << LogFormat::RESET << endl;
+    log << "  " << LogFormat::UNDERLINE_ON
+        << "Position" << LogFormat::UNDERLINE_OFF << endl;
+    log << "    ECI:   " << VState.vInertialPosition.Dump(", ") << " (x,y,z, in ft)" << endl;
+    log << "    ECEF:  " << VState.vLocation << " (x,y,z, in ft)" << endl;
+    log << "    Local: " << VState.vLocation.GetGeodLatitudeDeg()
+        << ", " << VState.vLocation.GetLongitudeDeg()
+        << ", " << GetAltitudeASL() << " (geodetic lat, lon, alt ASL in deg and ft)" << endl;
 
-  cout << endl << "  " << underon
-       <<   "Orientation" << underoff << endl;
-  cout << "    ECI:   " << VState.qAttitudeECI.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
-  cout << "    Local: " << VState.qAttitudeLocal.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
+    log << endl << "  " << LogFormat::UNDERLINE_ON
+        << "Orientation" << LogFormat::UNDERLINE_OFF << endl;
+    log << "    ECI:   " << VState.qAttitudeECI.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
+    log << "    Local: " << VState.qAttitudeLocal.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
 
-  cout << endl << "  " << underon
-       <<   "Velocity" << underoff << endl;
-  cout << "    ECI:   " << VState.vInertialVelocity.Dump(", ") << " (x,y,z in ft/s)" << endl;
-  cout << "    ECEF:  " << (Tb2ec * VState.vUVW).Dump(", ")  << " (x,y,z in ft/s)"  << endl;
-  cout << "    Local: " << GetVel() << " (n,e,d in ft/sec)" << endl;
-  cout << "    Body:  " << GetUVW() << " (u,v,w in ft/sec)" << endl;
+    log << endl << "  " << LogFormat::UNDERLINE_ON
+        << "Velocity" << LogFormat::UNDERLINE_OFF << endl;
+    log << "    ECI:   " << VState.vInertialVelocity.Dump(", ") << " (x,y,z in ft/s)" << endl;
+    log << "    ECEF:  " << (Tb2ec * VState.vUVW).Dump(", ") << " (x,y,z in ft/s)" << endl;
+    log << "    Local: " << GetVel() << " (n,e,d in ft/sec)" << endl;
+    log << "    Body:  " << GetUVW() << " (u,v,w in ft/sec)" << endl;
 
-  cout << endl << "  " << underon
-       <<   "Body Rates (relative to given frame, expressed in body frame)" << underoff << endl;
-  cout << "    ECI:   " << (VState.vPQRi*radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
-  cout << "    ECEF:  " << (VState.vPQR*radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
-}
+    log << endl << "  " << LogFormat::UNDERLINE_ON
+        << "Body Rates (relative to given frame, expressed in body frame)" << LogFormat::UNDERLINE_OFF << endl;
+    log << "    ECI:   " << (VState.vPQRi * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
+    log << "    ECEF:  " << (VState.vPQR * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
+  }
 
-//******************************************************************************
+  //******************************************************************************
 
-void FGPropagate::WriteStateFile(int num)
-{
-  sg_ofstream outfile;
+  void FGPropagate::WriteStateFile(int num)
+  {
+    sg_ofstream outfile;
 
-  if (num == 0) return;
+    if (num == 0) return;
 
-  SGPath path = FDMExec->GetOutputPath();
+    SGPath path = FDMExec->GetOutputPath();
 
-  if (path.isNull()) path = SGPath("initfile.");
-  else               path.append("initfile.");
+    if (path.isNull()) path = SGPath("initfile.");
+    else               path.append("initfile.");
 
-  // Append sim time to the filename since there may be more than one created during a simulation run
+    // Append sim time to the filename since there may be more than one created during a simulation run
   path.concat(to_string((double)FDMExec->GetSimTime())+".xml");
 
   switch(num) {
-  case 1:
-    outfile.open(path);
-    if (outfile.is_open()) {
-      outfile << "<?xml version=\"1.0\"?>" << endl;
-      outfile << "<initialize name=\"reset00\">" << endl;
-      outfile << "  <ubody unit=\"FT/SEC\"> " << VState.vUVW(eU) << " </ubody> " << endl;
-      outfile << "  <vbody unit=\"FT/SEC\"> " << VState.vUVW(eV) << " </vbody> " << endl;
-      outfile << "  <wbody unit=\"FT/SEC\"> " << VState.vUVW(eW) << " </wbody> " << endl;
-      outfile << "  <phi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePhi)*radtodeg << " </phi>" << endl;
-      outfile << "  <theta unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(eTht)*radtodeg << " </theta>" << endl;
-      outfile << "  <psi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePsi)*radtodeg << " </psi>" << endl;
-      outfile << "  <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
-      outfile << "  <latitude unit=\"DEG\"> " << VState.vLocation.GetLatitudeDeg() << " </latitude>" << endl;
-      outfile << "  <altitude unit=\"FT\"> " << GetDistanceAGL() << " </altitude>" << endl;
-      outfile << "</initialize>" << endl;
-      outfile.close();
-    } else {
-      cerr << "Could not open and/or write the state to the initial conditions file: "
-           << path << endl;
+    case 1:
+      outfile.open(path);
+      if (outfile.is_open()) {
+        outfile << "<?xml version=\"1.0\"?>" << endl;
+        outfile << "<initialize name=\"reset00\">" << endl;
+        outfile << "  <ubody unit=\"FT/SEC\"> " << VState.vUVW(eU) << " </ubody> " << endl;
+        outfile << "  <vbody unit=\"FT/SEC\"> " << VState.vUVW(eV) << " </vbody> " << endl;
+        outfile << "  <wbody unit=\"FT/SEC\"> " << VState.vUVW(eW) << " </wbody> " << endl;
+        outfile << "  <phi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePhi)*radtodeg << " </phi>" << endl;
+        outfile << "  <theta unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(eTht)*radtodeg << " </theta>" << endl;
+        outfile << "  <psi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePsi)*radtodeg << " </psi>" << endl;
+        outfile << "  <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
+        outfile << "  <latitude unit=\"DEG\"> " << VState.vLocation.GetLatitudeDeg() << " </latitude>" << endl;
+        outfile << "  <altitude unit=\"FT\"> " << GetDistanceAGL() << " </altitude>" << endl;
+        outfile << "</initialize>" << endl;
+        outfile.close();
+      } else {
+        FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+        log << "Could not open and/or write the state to the initial conditions file: "
+            << path << endl;
+      }
+      break;
+    case 2:
+      outfile.open(path);
+      if (outfile.is_open()) {
+        outfile << "<?xml version=\"1.0\"?>" << endl;
+        outfile << "<initialize name=\"IC File\" version=\"2.0\">" << endl;
+        outfile << "" << endl;
+        outfile << "  <position frame=\"ECEF\">" << endl;
+        outfile << "    <latitude unit=\"DEG\" type=\"geodetic\"> " << VState.vLocation.GetGeodLatitudeDeg() << " </latitude>" << endl;
+        outfile << "    <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
+        outfile << "    <altitudeMSL unit=\"FT\"> " << GetAltitudeASL() << " </altitudeMSL>" << endl;
+        outfile << "  </position>" << endl;
+        outfile << "" << endl;
+        outfile << "  <orientation unit=\"DEG\" frame=\"LOCAL\">" << endl;
+        outfile << "    <yaw> " << VState.qAttitudeLocal.GetEulerDeg(eYaw) << " </yaw>" << endl;
+        outfile << "    <pitch> " << VState.qAttitudeLocal.GetEulerDeg(ePitch) << " </pitch>" << endl;
+        outfile << "    <roll> " << VState.qAttitudeLocal.GetEulerDeg(eRoll) << " </roll>" << endl;
+        outfile << "  </orientation>" << endl;
+        outfile << "" << endl;
+        outfile << "  <velocity unit=\"FT/SEC\" frame=\"LOCAL\">" << endl;
+        outfile << "    <x> " << GetVel(eNorth) << " </x>" << endl;
+        outfile << "    <y> " << GetVel(eEast) << " </y>" << endl;
+        outfile << "    <z> " << GetVel(eDown) << " </z>" << endl;
+        outfile << "  </velocity>" << endl;
+        outfile << "" << endl;
+        outfile << "  <attitude_rate unit=\"DEG/SEC\" frame=\"BODY\">" << endl;
+        outfile << "    <roll> " << (VState.vPQR*radtodeg)(eRoll) << " </roll>" << endl;
+        outfile << "    <pitch> " << (VState.vPQR*radtodeg)(ePitch) << " </pitch>" << endl;
+        outfile << "    <yaw> " << (VState.vPQR*radtodeg)(eYaw) << " </yaw>" << endl;
+        outfile << "  </attitude_rate>" << endl;
+        outfile << "" << endl;
+        outfile << "</initialize>" << endl;
+        outfile.close();
+      } else {
+        FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+        log << "Could not open and/or write the state to the initial conditions file: "
+            << path << endl;
+      }
+      break;
+    default:
+      FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+      log << "When writing a state file, the supplied value must be 1 or 2 for the version number of the resulting IC file" << endl;
     }
-    break;
-  case 2:
-    outfile.open(path);
-    if (outfile.is_open()) {
-      outfile << "<?xml version=\"1.0\"?>" << endl;
-      outfile << "<initialize name=\"IC File\" version=\"2.0\">" << endl;
-      outfile << "" << endl;
-      outfile << "  <position frame=\"ECEF\">" << endl;
-      outfile << "    <latitude unit=\"DEG\" type=\"geodetic\"> " << VState.vLocation.GetGeodLatitudeDeg() << " </latitude>" << endl;
-      outfile << "    <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
-      outfile << "    <altitudeMSL unit=\"FT\"> " << GetAltitudeASL() << " </altitudeMSL>" << endl;
-      outfile << "  </position>" << endl;
-      outfile << "" << endl;
-      outfile << "  <orientation unit=\"DEG\" frame=\"LOCAL\">" << endl;
-      outfile << "    <yaw> " << VState.qAttitudeLocal.GetEulerDeg(eYaw) << " </yaw>" << endl;
-      outfile << "    <pitch> " << VState.qAttitudeLocal.GetEulerDeg(ePitch) << " </pitch>" << endl;
-      outfile << "    <roll> " << VState.qAttitudeLocal.GetEulerDeg(eRoll) << " </roll>" << endl;
-      outfile << "  </orientation>" << endl;
-      outfile << "" << endl;
-      outfile << "  <velocity unit=\"FT/SEC\" frame=\"LOCAL\">" << endl;
-      outfile << "    <x> " << GetVel(eNorth) << " </x>" << endl;
-      outfile << "    <y> " << GetVel(eEast) << " </y>" << endl;
-      outfile << "    <z> " << GetVel(eDown) << " </z>" << endl;
-      outfile << "  </velocity>" << endl;
-      outfile << "" << endl;
-      outfile << "  <attitude_rate unit=\"DEG/SEC\" frame=\"BODY\">" << endl;
-      outfile << "    <roll> " << (VState.vPQR*radtodeg)(eRoll) << " </roll>" << endl;
-      outfile << "    <pitch> " << (VState.vPQR*radtodeg)(ePitch) << " </pitch>" << endl;
-      outfile << "    <yaw> " << (VState.vPQR*radtodeg)(eYaw) << " </yaw>" << endl;
-      outfile << "  </attitude_rate>" << endl;
-      outfile << "" << endl;
-      outfile << "</initialize>" << endl;
-      outfile.close();
-    } else {
-      cerr << "Could not open and/or write the state to the initial conditions file: "
-           << path << endl;
-    }
-    break;
-  default:
-    cerr << "When writing a state file, the supplied value must be 1 or 2 for the version number of the resulting IC file" << endl;
   }
-}
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGPropagate::bind(void)
-{
+  void FGPropagate::bind(void)
+  {
   typedef double (FGPropagate::*PMF)(int) const;
   typedef int (FGPropagate::*iPMF)(void) const;
 
-  PropertyManager->Tie("velocities/h-dot-fps", this, &FGPropagate::Gethdot);
+    PropertyManager->Tie("velocities/h-dot-fps", this, &FGPropagate::Gethdot);
 
-  PropertyManager->Tie("velocities/v-north-fps", this, eNorth, (PMF)&FGPropagate::GetVel);
-  PropertyManager->Tie("velocities/v-east-fps", this, eEast, (PMF)&FGPropagate::GetVel);
-  PropertyManager->Tie("velocities/v-down-fps", this, eDown, (PMF)&FGPropagate::GetVel);
+    PropertyManager->Tie("velocities/v-north-fps", this, eNorth, (PMF)&FGPropagate::GetVel);
+    PropertyManager->Tie("velocities/v-east-fps", this, eEast, (PMF)&FGPropagate::GetVel);
+    PropertyManager->Tie("velocities/v-down-fps", this, eDown, (PMF)&FGPropagate::GetVel);
 
-  PropertyManager->Tie("velocities/u-fps", this, eU, (PMF)&FGPropagate::GetUVW);
-  PropertyManager->Tie("velocities/v-fps", this, eV, (PMF)&FGPropagate::GetUVW);
-  PropertyManager->Tie("velocities/w-fps", this, eW, (PMF)&FGPropagate::GetUVW);
+    PropertyManager->Tie("velocities/u-fps", this, eU, (PMF)&FGPropagate::GetUVW);
+    PropertyManager->Tie("velocities/v-fps", this, eV, (PMF)&FGPropagate::GetUVW);
+    PropertyManager->Tie("velocities/w-fps", this, eW, (PMF)&FGPropagate::GetUVW);
 
-  PropertyManager->Tie("velocities/p-rad_sec", this, eP, (PMF)&FGPropagate::GetPQR);
-  PropertyManager->Tie("velocities/q-rad_sec", this, eQ, (PMF)&FGPropagate::GetPQR);
-  PropertyManager->Tie("velocities/r-rad_sec", this, eR, (PMF)&FGPropagate::GetPQR);
+    PropertyManager->Tie("velocities/p-rad_sec", this, eP, (PMF)&FGPropagate::GetPQR);
+    PropertyManager->Tie("velocities/q-rad_sec", this, eQ, (PMF)&FGPropagate::GetPQR);
+    PropertyManager->Tie("velocities/r-rad_sec", this, eR, (PMF)&FGPropagate::GetPQR);
 
-  PropertyManager->Tie("velocities/pi-rad_sec", this, eP, (PMF)&FGPropagate::GetPQRi);
-  PropertyManager->Tie("velocities/qi-rad_sec", this, eQ, (PMF)&FGPropagate::GetPQRi);
-  PropertyManager->Tie("velocities/ri-rad_sec", this, eR, (PMF)&FGPropagate::GetPQRi);
+    PropertyManager->Tie("velocities/pi-rad_sec", this, eP, (PMF)&FGPropagate::GetPQRi);
+    PropertyManager->Tie("velocities/qi-rad_sec", this, eQ, (PMF)&FGPropagate::GetPQRi);
+    PropertyManager->Tie("velocities/ri-rad_sec", this, eR, (PMF)&FGPropagate::GetPQRi);
 
-  PropertyManager->Tie("velocities/eci-x-fps", this, eX, (PMF)&FGPropagate::GetInertialVelocity);
-  PropertyManager->Tie("velocities/eci-y-fps", this, eY, (PMF)&FGPropagate::GetInertialVelocity);
-  PropertyManager->Tie("velocities/eci-z-fps", this, eZ, (PMF)&FGPropagate::GetInertialVelocity);
+    PropertyManager->Tie("velocities/eci-x-fps", this, eX, (PMF)&FGPropagate::GetInertialVelocity);
+    PropertyManager->Tie("velocities/eci-y-fps", this, eY, (PMF)&FGPropagate::GetInertialVelocity);
+    PropertyManager->Tie("velocities/eci-z-fps", this, eZ, (PMF)&FGPropagate::GetInertialVelocity);
 
-  PropertyManager->Tie("velocities/eci-velocity-mag-fps", this, &FGPropagate::GetInertialVelocityMagnitude);
-  PropertyManager->Tie("velocities/ned-velocity-mag-fps", this, &FGPropagate::GetNEDVelocityMagnitude);
+    PropertyManager->Tie("velocities/eci-velocity-mag-fps", this, &FGPropagate::GetInertialVelocityMagnitude);
+    PropertyManager->Tie("velocities/ned-velocity-mag-fps", this, &FGPropagate::GetNEDVelocityMagnitude);
 
-  PropertyManager->Tie("position/h-sl-ft", this, &FGPropagate::GetAltitudeASL, &FGPropagate::SetAltitudeASL);
-  PropertyManager->Tie("position/h-sl-meters", this, &FGPropagate::GetAltitudeASLmeters, &FGPropagate::SetAltitudeASLmeters);
-  PropertyManager->Tie("position/lat-gc-rad", this, &FGPropagate::GetLatitude, &FGPropagate::SetLatitude);
-  PropertyManager->Tie("position/long-gc-rad", this, &FGPropagate::GetLongitude, &FGPropagate::SetLongitude);
-  PropertyManager->Tie("position/lat-gc-deg", this, &FGPropagate::GetLatitudeDeg, &FGPropagate::SetLatitudeDeg);
-  PropertyManager->Tie("position/long-gc-deg", this, &FGPropagate::GetLongitudeDeg, &FGPropagate::SetLongitudeDeg);
-  PropertyManager->Tie("position/lat-geod-rad", this, &FGPropagate::GetGeodLatitudeRad);
-  PropertyManager->Tie("position/lat-geod-deg", this, &FGPropagate::GetGeodLatitudeDeg);
-  PropertyManager->Tie("position/geod-alt-ft", this, &FGPropagate::GetGeodeticAltitude);
+    PropertyManager->Tie("position/h-sl-ft", this, &FGPropagate::GetAltitudeASL, &FGPropagate::SetAltitudeASL);
+    PropertyManager->Tie("position/h-sl-meters", this, &FGPropagate::GetAltitudeASLmeters, &FGPropagate::SetAltitudeASLmeters);
+    PropertyManager->Tie("position/lat-gc-rad", this, &FGPropagate::GetLatitude, &FGPropagate::SetLatitude);
+    PropertyManager->Tie("position/long-gc-rad", this, &FGPropagate::GetLongitude, &FGPropagate::SetLongitude);
+    PropertyManager->Tie("position/lat-gc-deg", this, &FGPropagate::GetLatitudeDeg, &FGPropagate::SetLatitudeDeg);
+    PropertyManager->Tie("position/long-gc-deg", this, &FGPropagate::GetLongitudeDeg, &FGPropagate::SetLongitudeDeg);
+    PropertyManager->Tie("position/lat-geod-rad", this, &FGPropagate::GetGeodLatitudeRad);
+    PropertyManager->Tie("position/lat-geod-deg", this, &FGPropagate::GetGeodLatitudeDeg);
+    PropertyManager->Tie("position/geod-alt-ft", this, &FGPropagate::GetGeodeticAltitude);
   PropertyManager->Tie("position/h-agl-ft", this,  &FGPropagate::GetDistanceAGL, &FGPropagate::SetDistanceAGL);
-  PropertyManager->Tie("position/geod-alt-km", this, &FGPropagate::GetGeodeticAltitudeKm);
+    PropertyManager->Tie("position/geod-alt-km", this, &FGPropagate::GetGeodeticAltitudeKm);
   PropertyManager->Tie("position/h-agl-km", this,  &FGPropagate::GetDistanceAGLKm, &FGPropagate::SetDistanceAGLKm);
-  PropertyManager->Tie("position/radius-to-vehicle-ft", this, &FGPropagate::GetRadius);
-  PropertyManager->Tie("position/terrain-elevation-asl-ft", this,
-                          &FGPropagate::GetTerrainElevation,
-                          &FGPropagate::SetTerrainElevation);
+    PropertyManager->Tie("position/radius-to-vehicle-ft", this, &FGPropagate::GetRadius);
+    PropertyManager->Tie("position/terrain-elevation-asl-ft", this,
+      &FGPropagate::GetTerrainElevation,
+      &FGPropagate::SetTerrainElevation);
 
-  PropertyManager->Tie("position/eci-x-ft", this, eX, (PMF)&FGPropagate::GetInertialPosition);
-  PropertyManager->Tie("position/eci-y-ft", this, eY, (PMF)&FGPropagate::GetInertialPosition);
-  PropertyManager->Tie("position/eci-z-ft", this, eZ, (PMF)&FGPropagate::GetInertialPosition);
+    PropertyManager->Tie("position/eci-x-ft", this, eX, (PMF)&FGPropagate::GetInertialPosition);
+    PropertyManager->Tie("position/eci-y-ft", this, eY, (PMF)&FGPropagate::GetInertialPosition);
+    PropertyManager->Tie("position/eci-z-ft", this, eZ, (PMF)&FGPropagate::GetInertialPosition);
 
-  PropertyManager->Tie("position/ecef-x-ft", this, eX, (PMF)&FGPropagate::GetLocation);
-  PropertyManager->Tie("position/ecef-y-ft", this, eY, (PMF)&FGPropagate::GetLocation);
-  PropertyManager->Tie("position/ecef-z-ft", this, eZ, (PMF)&FGPropagate::GetLocation);
+    PropertyManager->Tie("position/ecef-x-ft", this, eX, (PMF)&FGPropagate::GetLocation);
+    PropertyManager->Tie("position/ecef-y-ft", this, eY, (PMF)&FGPropagate::GetLocation);
+    PropertyManager->Tie("position/ecef-z-ft", this, eZ, (PMF)&FGPropagate::GetLocation);
 
-  PropertyManager->Tie("position/epa-rad", this, &FGPropagate::GetEarthPositionAngle);
-  PropertyManager->Tie("metrics/terrain-radius", this, &FGPropagate::GetLocalTerrainRadius);
+    PropertyManager->Tie("position/epa-rad", this, &FGPropagate::GetEarthPositionAngle);
+    PropertyManager->Tie("metrics/terrain-radius", this, &FGPropagate::GetLocalTerrainRadius);
 
-  PropertyManager->Tie("attitude/phi-rad", this, (int)ePhi, (PMF)&FGPropagate::GetEuler);
-  PropertyManager->Tie("attitude/theta-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
-  PropertyManager->Tie("attitude/psi-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
+    PropertyManager->Tie("attitude/phi-rad", this, (int)ePhi, (PMF)&FGPropagate::GetEuler);
+    PropertyManager->Tie("attitude/theta-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
+    PropertyManager->Tie("attitude/psi-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
 
-  PropertyManager->Tie("attitude/phi-deg", this, (int)ePhi, (PMF)&FGPropagate::GetEulerDeg);
-  PropertyManager->Tie("attitude/theta-deg", this, (int)eTht, (PMF)&FGPropagate::GetEulerDeg);
-  PropertyManager->Tie("attitude/psi-deg", this, (int)ePsi, (PMF)&FGPropagate::GetEulerDeg);
+    PropertyManager->Tie("attitude/phi-deg", this, (int)ePhi, (PMF)&FGPropagate::GetEulerDeg);
+    PropertyManager->Tie("attitude/theta-deg", this, (int)eTht, (PMF)&FGPropagate::GetEulerDeg);
+    PropertyManager->Tie("attitude/psi-deg", this, (int)ePsi, (PMF)&FGPropagate::GetEulerDeg);
 
-  PropertyManager->Tie("attitude/roll-rad", this, (int)ePhi, (PMF)&FGPropagate::GetEuler);
-  PropertyManager->Tie("attitude/pitch-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
-  PropertyManager->Tie("attitude/heading-true-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
+    PropertyManager->Tie("attitude/roll-rad", this, (int)ePhi, (PMF)&FGPropagate::GetEuler);
+    PropertyManager->Tie("attitude/pitch-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
+    PropertyManager->Tie("attitude/heading-true-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
 
-  PropertyManager->Tie("orbital/specific-angular-momentum-ft2_sec", &h);
-  PropertyManager->Tie("orbital/inclination-deg", &Inclination);
-  PropertyManager->Tie("orbital/right-ascension-deg", &RightAscension);
-  PropertyManager->Tie("orbital/eccentricity", &Eccentricity);
-  PropertyManager->Tie("orbital/argument-of-perigee-deg", &PerigeeArgument);
-  PropertyManager->Tie("orbital/true-anomaly-deg", &TrueAnomaly);
-  PropertyManager->Tie("orbital/apoapsis-radius-ft", &ApoapsisRadius);
-  PropertyManager->Tie("orbital/periapsis-radius-ft", &PeriapsisRadius);
-  PropertyManager->Tie("orbital/period-sec", &OrbitalPeriod);
+    PropertyManager->Tie("orbital/specific-angular-momentum-ft2_sec", &h);
+    PropertyManager->Tie("orbital/inclination-deg", &Inclination);
+    PropertyManager->Tie("orbital/right-ascension-deg", &RightAscension);
+    PropertyManager->Tie("orbital/eccentricity", &Eccentricity);
+    PropertyManager->Tie("orbital/argument-of-perigee-deg", &PerigeeArgument);
+    PropertyManager->Tie("orbital/true-anomaly-deg", &TrueAnomaly);
+    PropertyManager->Tie("orbital/apoapsis-radius-ft", &ApoapsisRadius);
+    PropertyManager->Tie("orbital/periapsis-radius-ft", &PeriapsisRadius);
+    PropertyManager->Tie("orbital/period-sec", &OrbitalPeriod);
 
-  PropertyManager->Tie("simulation/integrator/rate/rotational", (int*)&integrator_rotational_rate);
-  PropertyManager->Tie("simulation/integrator/rate/translational", (int*)&integrator_translational_rate);
-  PropertyManager->Tie("simulation/integrator/position/rotational", (int*)&integrator_rotational_position);
-  PropertyManager->Tie("simulation/integrator/position/translational", (int*)&integrator_translational_position);
+    PropertyManager->Tie("simulation/integrator/rate/rotational", (int*)&integrator_rotational_rate);
+    PropertyManager->Tie("simulation/integrator/rate/translational", (int*)&integrator_translational_rate);
+    PropertyManager->Tie("simulation/integrator/position/rotational", (int*)&integrator_rotational_position);
+    PropertyManager->Tie("simulation/integrator/position/translational", (int*)&integrator_translational_position);
 
-  PropertyManager->Tie("simulation/write-state-file", this, (iPMF)0, &FGPropagate::WriteStateFile);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-//    The bitmasked value choices are as follows:
-//    unset: In this case (the default) JSBSim would only print
-//       out the normally expected messages, essentially echoing
-//       the config files as they are read. If the environment
-//       variable is not set, debug_lvl is set to 1 internally
-//    0: This requests JSBSim not to output any messages
-//       whatsoever.
-//    1: This value explicity requests the normal JSBSim
-//       startup messages
-//    2: This value asks for a message to be printed out when
-//       a class is instantiated
-//    4: When this value is set, a message is displayed when a
-//       FGModel object executes its Run() method
-//    8: When this value is set, various runtime state variables
-//       are printed out periodically
-//    16: When set various parameters are sanity checked and
-//       a message is printed out when they go out of bounds
-
-void FGPropagate::Debug(int from)
-{
-  if (debug_lvl <= 0) return;
-
-  if (debug_lvl & 1) { // Standard console startup message output
-    if (from == 0) { // Constructor
-
-    }
+    PropertyManager->Tie("simulation/write-state-file", this, (iPMF)0, &FGPropagate::WriteStateFile);
   }
+
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  //    The bitmasked value choices are as follows:
+  //    unset: In this case (the default) JSBSim would only print
+  //       out the normally expected messages, essentially echoing
+  //       the config files as they are read. If the environment
+  //       variable is not set, debug_lvl is set to 1 internally
+  //    0: This requests JSBSim not to output any messages
+  //       whatsoever.
+  //    1: This value explicity requests the normal JSBSim
+  //       startup messages
+  //    2: This value asks for a message to be printed out when
+  //       a class is instantiated
+  //    4: When this value is set, a message is displayed when a
+  //       FGModel object executes its Run() method
+  //    8: When this value is set, various runtime state variables
+  //       are printed out periodically
+  //    16: When set various parameters are sanity checked and
+  //       a message is printed out when they go out of bounds
+
+  void FGPropagate::Debug(int from)
+  {
+    if (debug_lvl <= 0) return;
+
+    if (debug_lvl & 1) { // Standard console startup message output
+      if (from == 0) { // Constructor
+
+      }
+    }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGPropagate" << endl;
-    if (from == 1) cout << "Destroyed:    FGPropagate" << endl;
-  }
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      if (from == 0) log << "Instantiated: FGPropagate" << endl;
+      if (from == 1) log << "Destroyed:    FGPropagate" << endl;
+    }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
-  }
-  if (debug_lvl & 8 && from == 2) { // Runtime state variables
-    cout << endl << fgblue << highint << left
-         << "  Propagation Report (English units: ft, degrees) at simulation time " << FDMExec->GetSimTime() << " seconds"
-         << reset << endl;
-    cout << endl;
-    cout << highint << "  Earth Position Angle (deg): " << setw(8) << setprecision(3) << reset
-         << GetEarthPositionAngleDeg() << endl;
-    cout << endl;
-    cout << highint << "  Body velocity (ft/sec): " << setw(8) << setprecision(3) << reset << VState.vUVW << endl;
-    cout << highint << "  Local velocity (ft/sec): " << setw(8) << setprecision(3) << reset << vVel << endl;
-    cout << highint << "  Inertial velocity (ft/sec): " << setw(8) << setprecision(3) << reset << VState.vInertialVelocity << endl;
-    cout << highint << "  Inertial Position (ft): " << setw(10) << setprecision(3) << reset << VState.vInertialPosition << endl;
-    cout << highint << "  Latitude (deg): " << setw(8) << setprecision(3) << reset << VState.vLocation.GetLatitudeDeg() << endl;
-    cout << highint << "  Longitude (deg): " << setw(8) << setprecision(3) << reset << VState.vLocation.GetLongitudeDeg() << endl;
-    cout << highint << "  Altitude ASL (ft): " << setw(8) << setprecision(3) << reset << GetAltitudeASL() << endl;
-//    cout << highint << "  Acceleration (NED, ft/sec^2): " << setw(8) << setprecision(3) << reset << Tb2l*GetUVWdot() << endl;
-    cout << endl;
-    cout << highint << "  Matrix ECEF to Body (Orientation of Body with respect to ECEF): "
-                    << reset << endl << Tec2b.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Tec2b.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+    }
+    if (debug_lvl & 8 && from == 2) { // Runtime state variables
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      log << endl << LogFormat::BLUE << LogFormat::BOLD << left
+          << "  Propagation Report (English units: ft, degrees) at simulation time " << FDMExec->GetSimTime() << " seconds"
+          << LogFormat::RESET << endl;
+      log << endl;
+      log << LogFormat::BOLD << "  Earth Position Angle (deg): " << setw(8) << setprecision(3) << LogFormat::RESET
+          << GetEarthPositionAngleDeg() << endl;
+      log << endl;
+      log << LogFormat::BOLD << "  Body velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vUVW << endl;
+      log << LogFormat::BOLD << "  Local velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << vVel << endl;
+      log << LogFormat::BOLD << "  Inertial velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vInertialVelocity << endl;
+      log << LogFormat::BOLD << "  Inertial Position (ft): " << setw(10) << setprecision(3) << LogFormat::RESET << VState.vInertialPosition << endl;
+      log << LogFormat::BOLD << "  Latitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLatitudeDeg() << endl;
+      log << LogFormat::BOLD << "  Longitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLongitudeDeg() << endl;
+      log << LogFormat::BOLD << "  Altitude ASL (ft): " << setw(8) << setprecision(3) << LogFormat::RESET << GetAltitudeASL() << endl;
+      //    log << LogFormat::BOLD << "  Acceleration (NED, ft/sec^2): " << setw(8) << setprecision(3) << LogFormat::RESET << Tb2l*GetUVWdot() << endl;
+      log << endl;
+      log << LogFormat::BOLD << "  Matrix ECEF to Body (Orientation of Body with respect to ECEF): "
+          << LogFormat::RESET << endl << Tec2b.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Tec2b.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix Body to ECEF (Orientation of ECEF with respect to Body):"
-                    << reset << endl << Tb2ec.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Tb2ec.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix Body to ECEF (Orientation of ECEF with respect to Body):"
+          << LogFormat::RESET << endl << Tb2ec.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Tb2ec.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix Local to Body (Orientation of Body with respect to Local):"
-                    << reset << endl << Tl2b.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Tl2b.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix Local to Body (Orientation of Body with respect to Local):"
+          << LogFormat::RESET << endl << Tl2b.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Tl2b.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix Body to Local (Orientation of Local with respect to Body):"
-                    << reset << endl << Tb2l.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Tb2l.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix Body to Local (Orientation of Local with respect to Body):"
+          << LogFormat::RESET << endl << Tb2l.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Tb2l.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix Local to ECEF (Orientation of ECEF with respect to Local):"
-                    << reset << endl << Tl2ec.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Tl2ec.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix Local to ECEF (Orientation of ECEF with respect to Local):"
+          << LogFormat::RESET << endl << Tl2ec.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Tl2ec.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix ECEF to Local (Orientation of Local with respect to ECEF):"
-                    << reset << endl << Tec2l.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Tec2l.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix ECEF to Local (Orientation of Local with respect to ECEF):"
+          << LogFormat::RESET << endl << Tec2l.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Tec2l.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix ECEF to Inertial (Orientation of Inertial with respect to ECEF):"
-                    << reset << endl << Tec2i.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Tec2i.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix ECEF to Inertial (Orientation of Inertial with respect to ECEF):"
+          << LogFormat::RESET << endl << Tec2i.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Tec2i.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix Inertial to ECEF (Orientation of ECEF with respect to Inertial):"
-                    << reset << endl << Ti2ec.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Ti2ec.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix Inertial to ECEF (Orientation of ECEF with respect to Inertial):"
+          << LogFormat::RESET << endl << Ti2ec.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Ti2ec.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix Inertial to Body (Orientation of Body with respect to Inertial):"
-                    << reset << endl << Ti2b.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Ti2b.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix Inertial to Body (Orientation of Body with respect to Inertial):"
+          << LogFormat::RESET << endl << Ti2b.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Ti2b.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix Body to Inertial (Orientation of Inertial with respect to Body):"
-                    << reset << endl << Tb2i.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Tb2i.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix Body to Inertial (Orientation of Inertial with respect to Body):"
+          << LogFormat::RESET << endl << Tb2i.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Tb2i.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix Inertial to Local (Orientation of Local with respect to Inertial):"
-                    << reset << endl << Ti2l.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Ti2l.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix Inertial to Local (Orientation of Local with respect to Inertial):"
+          << LogFormat::RESET << endl << Ti2l.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Ti2l.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << highint << "  Matrix Local to Inertial (Orientation of Inertial with respect to Local):"
-                    << reset << endl << Tl2i.Dump("\t", "    ") << endl;
-    cout << highint << "    Associated Euler angles (deg): " << setw(8)
-                    << setprecision(3) << reset << (Tl2i.GetQuaternion().GetEuler()*radtodeg)
-                    << endl << endl;
+      log << LogFormat::BOLD << "  Matrix Local to Inertial (Orientation of Inertial with respect to Local):"
+          << LogFormat::RESET << endl << Tl2i.Dump("\t", "    ") << endl;
+      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+          << setprecision(3) << LogFormat::RESET << (Tl2i.GetQuaternion().GetEuler()*radtodeg)
+          << endl << endl;
 
-    cout << setprecision(6); // reset the output stream
-  }
-  if (debug_lvl & 16) { // Sanity checking
-    if (from == 2) { // State sanity checking
-      if (fabs(VState.vPQR.Magnitude()) > 1000.0) {
-        stringstream s;
-        s << "Vehicle rotation rate is excessive (>1000 rad/sec): " << VState.vPQR.Magnitude();
-        cerr << endl << s.str() << endl;
-        throw BaseException(s.str());
+      log << setprecision(6); // reset the output stream
+    }
+    if (debug_lvl & 16) { // Sanity checking
+      if (from == 2) { // State sanity checking
+        if (fabs(VState.vPQR.Magnitude()) > 1000.0) {
+          FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
+          log << "Vehicle rotation rate is excessive (>1000 rad/sec): " << VState.vPQR.Magnitude() << endl;
+          throw BaseException(log.str());
+        }
+        if (fabs(VState.vUVW.Magnitude()) > 1.0e10) {
+          FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
+          log << "Vehicle velocity is excessive (>1e10 ft/sec): " << VState.vUVW.Magnitude() << endl;
+          throw BaseException(log.str());
+        }
+        if (fabs(GetDistanceAGL()) > 1e10) {
+          FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
+          log << "Vehicle altitude is excessive (>1e10 ft): " << GetDistanceAGL() << endl;
+          throw BaseException(log.str());
+        }
       }
-      if (fabs(VState.vUVW.Magnitude()) > 1.0e10) {
-        stringstream s;
-        s << "Vehicle velocity is excessive (>1e10 ft/sec): " << VState.vUVW.Magnitude();
-        cerr << endl << s.str() << endl;
-        throw BaseException(s.str());
-      }
-      if (fabs(GetDistanceAGL()) > 1e10) {
-        stringstream s;
-        s << "Vehicle altitude is excessive (>1e10 ft): " << GetDistanceAGL();
-        cerr << endl << s.str() << endl;
-        throw BaseException(s.str());
+    }
+    if (debug_lvl & 64) {
+      if (from == 0) { // Constructor
       }
     }
   }
-  if (debug_lvl & 64) {
-    if (from == 0) { // Constructor
-    }
-  }
-}
 }

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -76,322 +76,322 @@ using namespace std;
 
 namespace JSBSim {
 
-  /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  CLASS IMPLEMENTATION
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+CLASS IMPLEMENTATION
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-  FGPropagate::FGPropagate(FGFDMExec* fdmex)
-    : FGModel(fdmex)
-  {
-    Debug(0);
-    Name = "FGPropagate";
+FGPropagate::FGPropagate(FGFDMExec* fdmex)
+  : FGModel(fdmex)
+{
+  Debug(0);
+  Name = "FGPropagate";
 
-    Inertial = FDMExec->GetInertial();
+  Inertial = FDMExec->GetInertial();
 
-    /// These define the indices use to select the various integrators.
-    // eNone = 0, eRectEuler, eTrapezoidal, eAdamsBashforth2, eAdamsBashforth3, eAdamsBashforth4};
+  /// These define the indices use to select the various integrators.
+  // eNone = 0, eRectEuler, eTrapezoidal, eAdamsBashforth2, eAdamsBashforth3, eAdamsBashforth4};
 
-    integrator_rotational_rate = eRectEuler;
-    integrator_translational_rate = eAdamsBashforth2;
-    integrator_rotational_position = eRectEuler;
-    integrator_translational_position = eAdamsBashforth3;
+  integrator_rotational_rate = eRectEuler;
+  integrator_translational_rate = eAdamsBashforth2;
+  integrator_rotational_position = eRectEuler;
+  integrator_translational_position = eAdamsBashforth3;
 
   VState.dqPQRidot.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqUVWidot.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqInertialVelocity.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqQtrndot.resize(5, FGQuaternion(0.0,0.0,0.0));
 
-    epa = 0.0;
+  epa = 0.0;
 
-    bind();
-    Debug(0);
-  }
+  bind();
+  Debug(0);
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  FGPropagate::~FGPropagate(void)
-  {
-    Debug(1);
-  }
+FGPropagate::~FGPropagate(void)
+{
+  Debug(1);
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  bool FGPropagate::InitModel(void)
-  {
-    if (!FGModel::InitModel()) return false;
+bool FGPropagate::InitModel(void)
+{
+  if (!FGModel::InitModel()) return false;
 
-    // For initialization ONLY:
-    VState.vLocation.SetEllipse(in.SemiMajor, in.SemiMinor);
-    Inertial->SetAltitudeAGL(VState.vLocation, 4.0);
+  // For initialization ONLY:
+  VState.vLocation.SetEllipse(in.SemiMajor, in.SemiMinor);
+  Inertial->SetAltitudeAGL(VState.vLocation, 4.0);
 
   VState.dqPQRidot.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqUVWidot.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqInertialVelocity.resize(5, FGColumnVector3(0.0,0.0,0.0));
   VState.dqQtrndot.resize(5, FGColumnVector3(0.0,0.0,0.0));
 
-    integrator_rotational_rate = eRectEuler;
-    integrator_translational_rate = eAdamsBashforth2;
-    integrator_rotational_position = eRectEuler;
-    integrator_translational_position = eAdamsBashforth3;
+  integrator_rotational_rate = eRectEuler;
+  integrator_translational_rate = eAdamsBashforth2;
+  integrator_rotational_position = eRectEuler;
+  integrator_translational_position = eAdamsBashforth3;
 
-    epa = 0.0;
+  epa = 0.0;
 
-    return true;
-  }
+  return true;
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetInitialState(const FGInitialCondition* FGIC)
-  {
-    // Initialize the State Vector elements and the transformation matrices
+void FGPropagate::SetInitialState(const FGInitialCondition* FGIC)
+{
+  // Initialize the State Vector elements and the transformation matrices
 
-    // Set the position lat/lon/radius
-    VState.vLocation = FGIC->GetPosition();
+  // Set the position lat/lon/radius
+  VState.vLocation = FGIC->GetPosition();
 
-    epa = FGIC->GetEarthPositionAngleIC();
-    Ti2ec = { cos(epa), sin(epa), 0.0,
-              -sin(epa), cos(epa), 0.0,
-              0.0, 0.0, 1.0 };
-    Tec2i = Ti2ec.Transposed();          // ECEF to ECI frame transform
+  epa = FGIC->GetEarthPositionAngleIC();
+  Ti2ec = { cos(epa), sin(epa), 0.0,
+            -sin(epa), cos(epa), 0.0,
+            0.0, 0.0, 1.0 };
+  Tec2i = Ti2ec.Transposed();          // ECEF to ECI frame transform
 
-    VState.vInertialPosition = Tec2i * VState.vLocation;
+  VState.vInertialPosition = Tec2i * VState.vLocation;
 
-    UpdateLocationMatrices();
+  UpdateLocationMatrices();
 
-    // Set the orientation from the euler angles (is normalized within the
-    // constructor). The Euler angles represent the orientation of the body
-    // frame relative to the local frame.
-    VState.qAttitudeLocal = FGIC->GetOrientation();
+  // Set the orientation from the euler angles (is normalized within the
+  // constructor). The Euler angles represent the orientation of the body
+  // frame relative to the local frame.
+  VState.qAttitudeLocal = FGIC->GetOrientation();
 
   VState.qAttitudeECI = Ti2l.GetQuaternion()*VState.qAttitudeLocal;
-    UpdateBodyMatrices();
+  UpdateBodyMatrices();
 
-    // Set the velocities in the instantaneus body frame
-    VState.vUVW = FGIC->GetUVWFpsIC();
+  // Set the velocities in the instantaneus body frame
+  VState.vUVW = FGIC->GetUVWFpsIC();
 
-    // Compute the local frame ECEF velocity
-    vVel = Tb2l * VState.vUVW;
+  // Compute the local frame ECEF velocity
+  vVel = Tb2l * VState.vUVW;
 
-    // Compute local terrain velocity
-    RecomputeLocalTerrainVelocity();
+  // Compute local terrain velocity
+  RecomputeLocalTerrainVelocity();
 
-    // Set the angular velocities of the body frame relative to the ECEF frame,
-    // expressed in the body frame.
-    VState.vPQR = FGIC->GetPQRRadpsIC();
+  // Set the angular velocities of the body frame relative to the ECEF frame,
+  // expressed in the body frame.
+  VState.vPQR = FGIC->GetPQRRadpsIC();
 
-    VState.vPQRi = VState.vPQR + Ti2b * in.vOmegaPlanet;
+  VState.vPQRi = VState.vPQR + Ti2b * in.vOmegaPlanet;
 
-    CalculateInertialVelocity(); // Translational position derivative
-    CalculateQuatdot();  // Angular orientation derivative
-  }
+  CalculateInertialVelocity(); // Translational position derivative
+  CalculateQuatdot();  // Angular orientation derivative
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  // Initialize the past value deques
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+// Initialize the past value deques
 
-  void FGPropagate::InitializeDerivatives()
-  {
-    VState.dqPQRidot.assign(5, in.vPQRidot);
-    VState.dqUVWidot.assign(5, in.vUVWidot);
-    VState.dqInertialVelocity.assign(5, VState.vInertialVelocity);
-    VState.dqQtrndot.assign(5, VState.vQtrndot);
-  }
+void FGPropagate::InitializeDerivatives()
+{
+  VState.dqPQRidot.assign(5, in.vPQRidot);
+  VState.dqUVWidot.assign(5, in.vUVWidot);
+  VState.dqInertialVelocity.assign(5, VState.vInertialVelocity);
+  VState.dqQtrndot.assign(5, VState.vQtrndot);
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  /*
-  Purpose: Called on a schedule to perform EOM integration
-  Notes:   [JB] Run in standalone mode, SeaLevelRadius will be reference radius.
-           In FGFS, SeaLevelRadius is stuffed from FGJSBSim in JSBSim.cxx each pass.
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+/*
+Purpose: Called on a schedule to perform EOM integration
+Notes:   [JB] Run in standalone mode, SeaLevelRadius will be reference radius.
+         In FGFS, SeaLevelRadius is stuffed from FGJSBSim in JSBSim.cxx each pass.
 
-  At the top of this Run() function, see several "shortcuts" (or, aliases) being
-  set up for use later, rather than using the longer class->function() notation.
+At the top of this Run() function, see several "shortcuts" (or, aliases) being
+set up for use later, rather than using the longer class->function() notation.
 
-  This propagation is done using the current state values
-  and current derivatives. Based on these values we compute an approximation to the
-  state values for (now + dt).
+This propagation is done using the current state values
+and current derivatives. Based on these values we compute an approximation to the
+state values for (now + dt).
 
-  In the code below, variables named beginning with a small "v" refer to a
-  a column vector, variables named beginning with a "T" refer to a transformation
-  matrix. ECEF refers to Earth Centered Earth Fixed. ECI refers to Earth Centered
-  Inertial.
+In the code below, variables named beginning with a small "v" refer to a
+a column vector, variables named beginning with a "T" refer to a transformation
+matrix. ECEF refers to Earth Centered Earth Fixed. ECI refers to Earth Centered
+Inertial.
 
-  */
+*/
 
-  bool FGPropagate::Run(bool Holding)
-  {
-    if (FGModel::Run(Holding)) return true;  // Fast return if we have nothing to do ...
-    if (Holding) return false;
+bool FGPropagate::Run(bool Holding)
+{
+  if (FGModel::Run(Holding)) return true;  // Fast return if we have nothing to do ...
+  if (Holding) return false;
 
-    double dt = in.DeltaT * rate;  // The 'stepsize'
+  double dt = in.DeltaT * rate;  // The 'stepsize'
 
-    // Propagate rotational / translational velocity, angular /translational position, respectively.
+  // Propagate rotational / translational velocity, angular /translational position, respectively.
 
-    if (!FDMExec->IntegrationSuspended()) {
+  if (!FDMExec->IntegrationSuspended()) {
     Integrate(VState.qAttitudeECI,      VState.vQtrndot,      VState.dqQtrndot,          dt, integrator_rotational_position);
     Integrate(VState.vPQRi,             in.vPQRidot,          VState.dqPQRidot,          dt, integrator_rotational_rate);
-      Integrate(VState.vInertialPosition, VState.vInertialVelocity, VState.dqInertialVelocity, dt, integrator_translational_position);
+    Integrate(VState.vInertialPosition, VState.vInertialVelocity, VState.dqInertialVelocity, dt, integrator_translational_position);
     Integrate(VState.vInertialVelocity, in.vUVWidot,          VState.dqUVWidot,          dt, integrator_translational_rate);
-    }
+  }
 
-    // CAUTION : the order of the operations below is very important to get
-    // transformation matrices that are consistent with the new state of the
-    // vehicle
+  // CAUTION : the order of the operations below is very important to get
+  // transformation matrices that are consistent with the new state of the
+  // vehicle
 
-    // 1. Update the Earth position angle (EPA)
+  // 1. Update the Earth position angle (EPA)
   epa += in.vOmegaPlanet(eZ)*dt;
 
-    // 2. Update the Ti2ec and Tec2i transforms from the updated EPA
-    double cos_epa = cos(epa);
-    double sin_epa = sin(epa);
-    Ti2ec = { cos_epa, sin_epa, 0.0,
-              -sin_epa, cos_epa, 0.0,
-              0.0, 0.0, 1.0 };
-    Tec2i = Ti2ec.Transposed();          // ECEF to ECI frame transform
+  // 2. Update the Ti2ec and Tec2i transforms from the updated EPA
+  double cos_epa = cos(epa);
+  double sin_epa = sin(epa);
+  Ti2ec = { cos_epa, sin_epa, 0.0,
+            -sin_epa, cos_epa, 0.0,
+            0.0, 0.0, 1.0 };
+  Tec2i = Ti2ec.Transposed();          // ECEF to ECI frame transform
 
-    // 3. Update the location from the updated Ti2ec and inertial position
+  // 3. Update the location from the updated Ti2ec and inertial position
   VState.vLocation = Ti2ec*VState.vInertialPosition;
 
-    // 4. Update the other "Location-based" transformation matrices from the
-    //    updated vLocation vector.
-    UpdateLocationMatrices();
+  // 4. Update the other "Location-based" transformation matrices from the
+  //    updated vLocation vector.
+  UpdateLocationMatrices();
 
-    // 5. Update the "Orientation-based" transformation matrices from the updated
-    //    orientation quaternion and vLocation vector.
-    UpdateBodyMatrices();
+  // 5. Update the "Orientation-based" transformation matrices from the updated
+  //    orientation quaternion and vLocation vector.
+  UpdateBodyMatrices();
 
-    // Translational position derivative (velocities are integrated in the
-    // inertial frame)
-    CalculateUVW();
+  // Translational position derivative (velocities are integrated in the
+  // inertial frame)
+  CalculateUVW();
 
-    // Set auxilliary state variables
-    RecomputeLocalTerrainVelocity();
+  // Set auxilliary state variables
+  RecomputeLocalTerrainVelocity();
 
-    VState.vPQR = VState.vPQRi - Ti2b * in.vOmegaPlanet;
+  VState.vPQR = VState.vPQRi - Ti2b * in.vOmegaPlanet;
 
-    // Angular orientation derivative
+  // Angular orientation derivative
+  CalculateQuatdot();
+
+  VState.qAttitudeLocal = Tl2b.GetQuaternion();
+
+  // Compute vehicle velocity wrt ECEF frame, expressed in Local horizontal
+  // frame.
+  vVel = Tb2l * VState.vUVW;
+
+  // Compute orbital parameters in the inertial frame
+  ComputeOrbitalParameters();
+
+  Debug(2);
+  return false;
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+void FGPropagate::SetHoldDown(bool hd)
+{
+  if (hd) {
+    VState.vUVW.InitMatrix();
+    CalculateInertialVelocity();
+    VState.vPQR.InitMatrix();
+    VState.vPQRi = Ti2b * in.vOmegaPlanet;
     CalculateQuatdot();
-
-    VState.qAttitudeLocal = Tl2b.GetQuaternion();
-
-    // Compute vehicle velocity wrt ECEF frame, expressed in Local horizontal
-    // frame.
-    vVel = Tb2l * VState.vUVW;
-
-    // Compute orbital parameters in the inertial frame
-    ComputeOrbitalParameters();
-
-    Debug(2);
-    return false;
+    InitializeDerivatives();
   }
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+// Compute the quaternion orientation derivative
+//
+// vQtrndot is the quaternion derivative.
+// Reference: See Stevens and Lewis, "Aircraft Control and Simulation",
+//            Second edition (2004), eqn 1.5-16b (page 50)
 
-  void FGPropagate::SetHoldDown(bool hd)
-  {
-    if (hd) {
-      VState.vUVW.InitMatrix();
-      CalculateInertialVelocity();
-      VState.vPQR.InitMatrix();
-      VState.vPQRi = Ti2b * in.vOmegaPlanet;
-      CalculateQuatdot();
-      InitializeDerivatives();
-    }
-  }
+void FGPropagate::CalculateQuatdot(void)
+{
+  // Compute quaternion orientation derivative on current body rates
+  VState.vQtrndot = VState.qAttitudeECI.GetQDot(VState.vPQRi);
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  // Compute the quaternion orientation derivative
-  //
-  // vQtrndot is the quaternion derivative.
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  // Transform the velocity vector of the body relative to the origin (Earth
+  // center) to be expressed in the inertial frame, and add the vehicle velocity
+  // contribution due to the rotation of the planet.
   // Reference: See Stevens and Lewis, "Aircraft Control and Simulation",
-  //            Second edition (2004), eqn 1.5-16b (page 50)
+  //            Second edition (2004), eqn 1.5-16c (page 50)
 
-  void FGPropagate::CalculateQuatdot(void)
-  {
-    // Compute quaternion orientation derivative on current body rates
-    VState.vQtrndot = VState.qAttitudeECI.GetQDot(VState.vPQRi);
-  }
+void FGPropagate::CalculateInertialVelocity(void)
+{
+  VState.vInertialVelocity = Tb2i * VState.vUVW + (in.vOmegaPlanet * VState.vInertialPosition);
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    // Transform the velocity vector of the body relative to the origin (Earth
-    // center) to be expressed in the inertial frame, and add the vehicle velocity
-    // contribution due to the rotation of the planet.
-    // Reference: See Stevens and Lewis, "Aircraft Control and Simulation",
-    //            Second edition (2004), eqn 1.5-16c (page 50)
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  // Transform the velocity vector of the inertial frame to be expressed in the
+  // body frame relative to the origin (Earth center), and substract the vehicle
+  // velocity contribution due to the rotation of the planet.
 
-  void FGPropagate::CalculateInertialVelocity(void)
-  {
-    VState.vInertialVelocity = Tb2i * VState.vUVW + (in.vOmegaPlanet * VState.vInertialPosition);
-  }
+void FGPropagate::CalculateUVW(void)
+{
+  VState.vUVW = Ti2b * (VState.vInertialVelocity - (in.vOmegaPlanet * VState.vInertialPosition));
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    // Transform the velocity vector of the inertial frame to be expressed in the
-    // body frame relative to the origin (Earth center), and substract the vehicle
-    // velocity contribution due to the rotation of the planet.
-
-  void FGPropagate::CalculateUVW(void)
-  {
-    VState.vUVW = Ti2b * (VState.vInertialVelocity - (in.vOmegaPlanet * VState.vInertialPosition));
-  }
-
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGPropagate::Integrate( FGColumnVector3& Integrand,
-    FGColumnVector3& Val,
-    deque <FGColumnVector3>& ValDot,
-    double dt,
-    eIntegrateType integration_type)
-  {
-    ValDot.push_front(Val);
-    ValDot.pop_back();
+                             FGColumnVector3& Val,
+                             deque <FGColumnVector3>& ValDot,
+                             double dt,
+                             eIntegrateType integration_type)
+{
+  ValDot.push_front(Val);
+  ValDot.pop_back();
 
   switch(integration_type) {
   case eRectEuler:       Integrand += dt*ValDot[0];
-      break;
+    break;
   case eTrapezoidal:     Integrand += 0.5*dt*(ValDot[0] + ValDot[1]);
-      break;
+    break;
   case eAdamsBashforth2: Integrand += dt*(1.5*ValDot[0] - 0.5*ValDot[1]);
-      break;
+    break;
   case eAdamsBashforth3: Integrand += (1/12.0)*dt*(23.0*ValDot[0] - 16.0*ValDot[1] + 5.0*ValDot[2]);
-      break;
+    break;
   case eAdamsBashforth4: Integrand += (1/24.0)*dt*(55.0*ValDot[0] - 59.0*ValDot[1] + 37.0*ValDot[2] - 9.0*ValDot[3]);
-      break;
+    break;
   case eAdamsBashforth5: Integrand += dt*((1901./720.)*ValDot[0] - (1387./360.)*ValDot[1] + (109./30.)*ValDot[2] - (637./360.)*ValDot[3] + (251./720.)*ValDot[4]);
-      break;
-    case eNone: // do nothing, freeze translational rate
-      break;
-    case eBuss1:
-    case eBuss2:
-    case eLocalLinearization:
-      throw("Can only use Buss (1 & 2) or local linearization integration methods in for rotational position!");
-    default:
-      break;
-    }
+    break;
+  case eNone: // do nothing, freeze translational rate
+    break;
+  case eBuss1:
+  case eBuss2:
+  case eLocalLinearization:
+    throw("Can only use Buss (1 & 2) or local linearization integration methods in for rotational position!");
+  default:
+    break;
   }
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGPropagate::Integrate( FGQuaternion& Integrand,
-    FGQuaternion& Val,
-    deque <FGQuaternion>& ValDot,
-    double dt,
-    eIntegrateType integration_type)
-  {
-    ValDot.push_front(Val);
-    ValDot.pop_back();
+                             FGQuaternion& Val,
+                             deque <FGQuaternion>& ValDot,
+                             double dt,
+                             eIntegrateType integration_type)
+{
+  ValDot.push_front(Val);
+  ValDot.pop_back();
 
   switch(integration_type) {
   case eRectEuler:       Integrand += dt*ValDot[0];
-      break;
+    break;
   case eTrapezoidal:     Integrand += 0.5*dt*(ValDot[0] + ValDot[1]);
-      break;
+    break;
   case eAdamsBashforth2: Integrand += dt*(1.5*ValDot[0] - 0.5*ValDot[1]);
-      break;
+    break;
   case eAdamsBashforth3: Integrand += (1/12.0)*dt*(23.0*ValDot[0] - 16.0*ValDot[1] + 5.0*ValDot[2]);
-      break;
+    break;
   case eAdamsBashforth4: Integrand += (1/24.0)*dt*(55.0*ValDot[0] - 59.0*ValDot[1] + 37.0*ValDot[2] - 9.0*ValDot[3]);
-      break;
+    break;
   case eAdamsBashforth5: Integrand += dt*((1901./720.)*ValDot[0] - (1387./360.)*ValDot[1] + (109./30.)*ValDot[2] - (637./360.)*ValDot[3] + (251./720.)*ValDot[4]);
-      break;
-    case eBuss1:
+    break;
+  case eBuss1:
     {
       // This is the first order method as described in Samuel R. Buss paper[6].
       // The formula from Buss' paper is transposed below to quaternions and is
@@ -400,7 +400,7 @@ void FGPropagate::Integrate( FGQuaternion& Integrand,
       Integrand = Integrand * QExp(0.5 * dt * VState.vPQRi);
     }
     return; // No need to normalize since the quaternion exponential is always normal
-    case eBuss2:
+  case eBuss2:
     {
       // This is the 'augmented second-order method' from S.R. Buss paper [6].
       // Unlike Runge-Kutta or Adams-Bashforth, it is a one-pass second-order
@@ -411,7 +411,7 @@ void FGPropagate::Integrate( FGQuaternion& Integrand,
       Integrand = Integrand * QExp(0.5 * dt * omega);
     }
     return; // No need to normalize since the quaternion exponential is always normal
-    case eLocalLinearization:
+  case eLocalLinearization:
     {
       // This is the local linearization algorithm of Barker et al. (see ref. [7])
       // It is also a one-pass second-order method. The code below is based on the
@@ -462,601 +462,601 @@ void FGPropagate::Integrate( FGQuaternion& Integrand,
       cout << "FORTRAN: " << H << " , " << K << " , " << J << " , " << -G << endl;*/
     }
     break; // The quaternion q is not normal so the normalization needs to be done.
-    case eNone: // do nothing, freeze rotational rate
-      break;
-    default:
-      break;
-    }
-
-    Integrand.Normalize();
+  case eNone: // do nothing, freeze rotational rate
+    break;
+  default:
+    break;
   }
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  Integrand.Normalize();
+}
 
-  void FGPropagate::UpdateLocationMatrices(void)
-  {
-    Tl2ec = VState.vLocation.GetTl2ec(); // local to ECEF transform
-    Tec2l = Tl2ec.Transposed();          // ECEF to local frame transform
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+void FGPropagate::UpdateLocationMatrices(void)
+{
+  Tl2ec = VState.vLocation.GetTl2ec(); // local to ECEF transform
+  Tec2l = Tl2ec.Transposed();          // ECEF to local frame transform
   Ti2l  = Tec2l * Ti2ec;               // ECI to local frame transform
   Tl2i  = Ti2l.Transposed();           // local to ECI transform
-  }
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::UpdateBodyMatrices(void)
-  {
+void FGPropagate::UpdateBodyMatrices(void)
+{
   Ti2b  = VState.qAttitudeECI.GetT(); // ECI to body frame transform
   Tb2i  = Ti2b.Transposed();          // body to ECI frame transform
   Tl2b  = Ti2b * Tl2i;                // local to body frame transform
   Tb2l  = Tl2b.Transposed();          // body to local frame transform
-    Tec2b = Ti2b * Tec2i;               // ECEF to body frame transform
-    Tb2ec = Tec2b.Transposed();         // body to ECEF frame tranform
+  Tec2b = Ti2b * Tec2i;               // ECEF to body frame transform
+  Tb2ec = Tec2b.Transposed();         // body to ECEF frame tranform
 
-    Qec2b = Tec2b.GetQuaternion();
+  Qec2b = Tec2b.GetQuaternion();
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+void FGPropagate::ComputeOrbitalParameters(void)
+{
+  const FGColumnVector3 Z{0., 0., 1.};
+  FGColumnVector3 R = VState.vInertialPosition;
+  FGColumnVector3 angularMomentum = R * VState.vInertialVelocity;
+  h = angularMomentum.Magnitude();
+  Inclination = acos(angularMomentum(eZ)/h)*radtodeg;
+  FGColumnVector3 N;
+  if (abs(Inclination) > 1E-8) {
+    N = Z * angularMomentum;
+    RightAscension = atan2(N(eY), N(eX))*radtodeg;
+    N.Normalize();
+  }
+  else {
+    RightAscension = 0.0;
+    N = {1., 0., 0.};
+    PerigeeArgument = 0.0;
+  }
+  R.Normalize();
+  double vr = DotProduct(R, VState.vInertialVelocity);
+  FGColumnVector3 eVector = (VState.vInertialVelocity*angularMomentum/in.GM - R);
+  Eccentricity = eVector.Magnitude();
+  if (Eccentricity > 1E-8) {
+    eVector /= Eccentricity;
+    if (abs(Inclination) > 1E-8) {
+      PerigeeArgument = acos(DotProduct(N, eVector)) * radtodeg;
+      if (eVector(eZ) < 0) PerigeeArgument = 360. - PerigeeArgument;
+    }
+  }
+  else
+  {
+    eVector = {1., 0., 0.};
+    PerigeeArgument = 0.0;
   }
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-  void FGPropagate::ComputeOrbitalParameters(void)
-  {
-  const FGColumnVector3 Z{0., 0., 1.};
-    FGColumnVector3 R = VState.vInertialPosition;
-    FGColumnVector3 angularMomentum = R * VState.vInertialVelocity;
-    h = angularMomentum.Magnitude();
-  Inclination = acos(angularMomentum(eZ)/h)*radtodeg;
-    FGColumnVector3 N;
-    if (abs(Inclination) > 1E-8) {
-      N = Z * angularMomentum;
-    RightAscension = atan2(N(eY), N(eX))*radtodeg;
-      N.Normalize();
-    }
-    else {
-      RightAscension = 0.0;
-    N = {1., 0., 0.};
-      PerigeeArgument = 0.0;
-    }
-    R.Normalize();
-    double vr = DotProduct(R, VState.vInertialVelocity);
-  FGColumnVector3 eVector = (VState.vInertialVelocity*angularMomentum/in.GM - R);
-    Eccentricity = eVector.Magnitude();
-    if (Eccentricity > 1E-8) {
-      eVector /= Eccentricity;
-      if (abs(Inclination) > 1E-8) {
-        PerigeeArgument = acos(DotProduct(N, eVector)) * radtodeg;
-        if (eVector(eZ) < 0) PerigeeArgument = 360. - PerigeeArgument;
-      }
-    }
-    else
-    {
-    eVector = {1., 0., 0.};
-      PerigeeArgument = 0.0;
-    }
-
-    TrueAnomaly = acos(Constrain(-1.0, DotProduct(eVector, R), 1.0)) * radtodeg;
-    if (vr < 0.0) TrueAnomaly = 360. - TrueAnomaly;
+  TrueAnomaly = acos(Constrain(-1.0, DotProduct(eVector, R), 1.0)) * radtodeg;
+  if (vr < 0.0) TrueAnomaly = 360. - TrueAnomaly;
   ApoapsisRadius = h*h / (in.GM * (1-Eccentricity));
   PeriapsisRadius = h*h / (in.GM * (1+Eccentricity));
 
-    if (Eccentricity < 1.0) {
+  if (Eccentricity < 1.0) {
     double semimajor = 0.5*(ApoapsisRadius + PeriapsisRadius);
     OrbitalPeriod = 2.*M_PI*pow(semimajor, 1.5)/sqrt(in.GM);
-    }
-    else
-      OrbitalPeriod = 0.0;
   }
+  else
+    OrbitalPeriod = 0.0;
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetInertialOrientation(const FGQuaternion& Qi)
-  {
-    VState.qAttitudeECI = Qi;
-    VState.qAttitudeECI.Normalize();
-    UpdateBodyMatrices();
-    VState.qAttitudeLocal = Tl2b.GetQuaternion();
-    CalculateQuatdot();
-  }
+void FGPropagate::SetInertialOrientation(const FGQuaternion& Qi)
+{
+  VState.qAttitudeECI = Qi;
+  VState.qAttitudeECI.Normalize();
+  UpdateBodyMatrices();
+  VState.qAttitudeLocal = Tl2b.GetQuaternion();
+  CalculateQuatdot();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetInertialVelocity(const FGColumnVector3& Vi) {
-    VState.vInertialVelocity = Vi;
-    CalculateUVW();
-    vVel = Tb2l * VState.vUVW;
-  }
+void FGPropagate::SetInertialVelocity(const FGColumnVector3& Vi) {
+  VState.vInertialVelocity = Vi;
+  CalculateUVW();
+  vVel = Tb2l * VState.vUVW;
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetInertialRates(const FGColumnVector3& vRates) {
-    VState.vPQRi = Ti2b * vRates;
-    VState.vPQR = VState.vPQRi - Ti2b * in.vOmegaPlanet;
-    CalculateQuatdot();
-  }
+void FGPropagate::SetInertialRates(const FGColumnVector3& vRates) {
+  VState.vPQRi = Ti2b * vRates;
+  VState.vPQR = VState.vPQRi - Ti2b * in.vOmegaPlanet;
+  CalculateQuatdot();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  double FGPropagate::GetAltitudeASL() const
-  {
-    return VState.vLocation.GetRadius() - VState.vLocation.GetSeaLevelRadius();
-  }
+double FGPropagate::GetAltitudeASL() const
+{
+  return VState.vLocation.GetRadius() - VState.vLocation.GetSeaLevelRadius();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetAltitudeASL(double altASL)
-  {
-    double slr = VState.vLocation.GetSeaLevelRadius();
-    VState.vLocation.SetRadius(slr + altASL);
-    UpdateVehicleState();
-  }
+void FGPropagate::SetAltitudeASL(double altASL)
+{
+  double slr = VState.vLocation.GetSeaLevelRadius();
+  VState.vLocation.SetRadius(slr + altASL);
+  UpdateVehicleState();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::RecomputeLocalTerrainVelocity()
-  {
-    FGLocation contact;
-    FGColumnVector3 normal;
-    Inertial->GetContactPoint(VState.vLocation, contact, normal,
-      LocalTerrainVelocity, LocalTerrainAngularVelocity);
-  }
+void FGPropagate::RecomputeLocalTerrainVelocity()
+{
+  FGLocation contact;
+  FGColumnVector3 normal;
+  Inertial->GetContactPoint(VState.vLocation, contact, normal,
+                            LocalTerrainVelocity, LocalTerrainAngularVelocity);
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  double FGPropagate::GetTerrainElevation(void) const
-  {
-    FGColumnVector3 vDummy;
-    FGLocation contact;
-    contact.SetEllipse(in.SemiMajor, in.SemiMinor);
-    Inertial->GetContactPoint(VState.vLocation, contact, vDummy, vDummy, vDummy);
-    return contact.GetGeodAltitude();
-  }
+double FGPropagate::GetTerrainElevation(void) const
+{
+  FGColumnVector3 vDummy;
+  FGLocation contact;
+  contact.SetEllipse(in.SemiMajor, in.SemiMinor);
+  Inertial->GetContactPoint(VState.vLocation, contact, vDummy, vDummy, vDummy);
+  return contact.GetGeodAltitude();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetTerrainElevation(double terrainElev)
-  {
-    Inertial->SetTerrainElevation(terrainElev);
-  }
+void FGPropagate::SetTerrainElevation(double terrainElev)
+{
+  Inertial->SetTerrainElevation(terrainElev);
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  double FGPropagate::GetLocalTerrainRadius(void) const
-  {
-    FGLocation contact;
-    FGColumnVector3 vDummy;
-    Inertial->GetContactPoint(VState.vLocation, contact, vDummy, vDummy, vDummy);
-    return contact.GetRadius();
-  }
+double FGPropagate::GetLocalTerrainRadius(void) const
+{
+  FGLocation contact;
+  FGColumnVector3 vDummy;
+  Inertial->GetContactPoint(VState.vLocation, contact, vDummy, vDummy, vDummy);
+  return contact.GetRadius();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  double FGPropagate::GetDistanceAGL(void) const
-  {
-    return Inertial->GetAltitudeAGL(VState.vLocation);
-  }
+double FGPropagate::GetDistanceAGL(void) const
+{
+  return Inertial->GetAltitudeAGL(VState.vLocation);
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  double FGPropagate::GetDistanceAGLKm(void) const
-  {
+double FGPropagate::GetDistanceAGLKm(void) const
+{
   return GetDistanceAGL()*0.0003048;
-  }
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetDistanceAGL(double tt)
-  {
-    Inertial->SetAltitudeAGL(VState.vLocation, tt);
-    UpdateVehicleState();
-  }
+void FGPropagate::SetDistanceAGL(double tt)
+{
+  Inertial->SetAltitudeAGL(VState.vLocation, tt);
+  UpdateVehicleState();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetDistanceAGLKm(double tt)
-  {
+void FGPropagate::SetDistanceAGLKm(double tt)
+{
   SetDistanceAGL(tt*3280.8399);
-  }
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetVState(const VehicleState& vstate)
-  {
-    //ToDo: Shouldn't all of these be set from the vstate vector passed in?
-    VState.vLocation = vstate.vLocation;
-    UpdateLocationMatrices();
-    SetInertialOrientation(vstate.qAttitudeECI);
-    RecomputeLocalTerrainVelocity();
-    VState.vUVW = vstate.vUVW;
-    vVel = Tb2l * VState.vUVW;
-    VState.vPQR = vstate.vPQR;
-    VState.vPQRi = VState.vPQR + Ti2b * in.vOmegaPlanet;
-    VState.vInertialPosition = vstate.vInertialPosition;
-    CalculateQuatdot();
-  }
+void FGPropagate::SetVState(const VehicleState& vstate)
+{
+  //ToDo: Shouldn't all of these be set from the vstate vector passed in?
+  VState.vLocation = vstate.vLocation;
+  UpdateLocationMatrices();
+  SetInertialOrientation(vstate.qAttitudeECI);
+  RecomputeLocalTerrainVelocity();
+  VState.vUVW = vstate.vUVW;
+  vVel = Tb2l * VState.vUVW;
+  VState.vPQR = vstate.vPQR;
+  VState.vPQRi = VState.vPQR + Ti2b * in.vOmegaPlanet;
+  VState.vInertialPosition = vstate.vInertialPosition;
+  CalculateQuatdot();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::UpdateVehicleState(void)
-  {
-    RecomputeLocalTerrainVelocity();
-    VState.vInertialPosition = Tec2i * VState.vLocation;
-    UpdateLocationMatrices();
-    UpdateBodyMatrices();
-    vVel = Tb2l * VState.vUVW;
-    VState.qAttitudeLocal = Tl2b.GetQuaternion();
-  }
+void FGPropagate::UpdateVehicleState(void)
+{
+  RecomputeLocalTerrainVelocity();
+  VState.vInertialPosition = Tec2i * VState.vLocation;
+  UpdateLocationMatrices();
+  UpdateBodyMatrices();
+  vVel = Tb2l * VState.vUVW;
+  VState.qAttitudeLocal = Tl2b.GetQuaternion();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::SetLocation(const FGLocation& l)
-  {
-    VState.vLocation = l;
-    UpdateVehicleState();
-  }
+void FGPropagate::SetLocation(const FGLocation& l)
+{
+  VState.vLocation = l;
+  UpdateVehicleState();
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  FGColumnVector3 FGPropagate::GetEulerDeg(void) const
-  {
-    return VState.qAttitudeLocal.GetEuler() * radtodeg;
-  }
+FGColumnVector3 FGPropagate::GetEulerDeg(void) const
+{
+  return VState.qAttitudeLocal.GetEuler() * radtodeg;
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::DumpState(void)
-  {
-    FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
-    log << endl;
-    log << LogFormat::BLUE
-        << "------------------------------------------------------------------" << LogFormat::RESET << endl;
-    log << LogFormat::BOLD
-        << "State Report at sim time: " << FDMExec->GetSimTime() << " seconds" << LogFormat::RESET << endl;
-    log << "  " << LogFormat::UNDERLINE_ON
-        << "Position" << LogFormat::UNDERLINE_OFF << endl;
-    log << "    ECI:   " << VState.vInertialPosition.Dump(", ") << " (x,y,z, in ft)" << endl;
-    log << "    ECEF:  " << VState.vLocation << " (x,y,z, in ft)" << endl;
-    log << "    Local: " << VState.vLocation.GetGeodLatitudeDeg()
-        << ", " << VState.vLocation.GetLongitudeDeg()
-        << ", " << GetAltitudeASL() << " (geodetic lat, lon, alt ASL in deg and ft)" << endl;
+void FGPropagate::DumpState(void)
+{
+  FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
+  log << endl;
+  log << LogFormat::BLUE
+      << "------------------------------------------------------------------" << LogFormat::RESET << endl;
+  log << LogFormat::BOLD
+      << "State Report at sim time: " << FDMExec->GetSimTime() << " seconds" << LogFormat::RESET << endl;
+  log << "  " << LogFormat::UNDERLINE_ON
+      << "Position" << LogFormat::UNDERLINE_OFF << endl;
+  log << "    ECI:   " << VState.vInertialPosition.Dump(", ") << " (x,y,z, in ft)" << endl;
+  log << "    ECEF:  " << VState.vLocation << " (x,y,z, in ft)" << endl;
+  log << "    Local: " << VState.vLocation.GetGeodLatitudeDeg()
+                       << ", " << VState.vLocation.GetLongitudeDeg()
+                       << ", " << GetAltitudeASL() << " (geodetic lat, lon, alt ASL in deg and ft)" << endl;
 
-    log << endl << "  " << LogFormat::UNDERLINE_ON
-        << "Orientation" << LogFormat::UNDERLINE_OFF << endl;
-    log << "    ECI:   " << VState.qAttitudeECI.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
-    log << "    Local: " << VState.qAttitudeLocal.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
+  log << endl << "  " << LogFormat::UNDERLINE_ON
+      << "Orientation" << LogFormat::UNDERLINE_OFF << endl;
+  log << "    ECI:   " << VState.qAttitudeECI.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
+  log << "    Local: " << VState.qAttitudeLocal.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
 
-    log << endl << "  " << LogFormat::UNDERLINE_ON
-        << "Velocity" << LogFormat::UNDERLINE_OFF << endl;
-    log << "    ECI:   " << VState.vInertialVelocity.Dump(", ") << " (x,y,z in ft/s)" << endl;
-    log << "    ECEF:  " << (Tb2ec * VState.vUVW).Dump(", ") << " (x,y,z in ft/s)" << endl;
-    log << "    Local: " << GetVel() << " (n,e,d in ft/sec)" << endl;
-    log << "    Body:  " << GetUVW() << " (u,v,w in ft/sec)" << endl;
+  log << endl << "  " << LogFormat::UNDERLINE_ON
+      << "Velocity" << LogFormat::UNDERLINE_OFF << endl;
+  log << "    ECI:   " << VState.vInertialVelocity.Dump(", ") << " (x,y,z in ft/s)" << endl;
+  log << "    ECEF:  " << (Tb2ec * VState.vUVW).Dump(", ") << " (x,y,z in ft/s)" << endl;
+  log << "    Local: " << GetVel() << " (n,e,d in ft/sec)" << endl;
+  log << "    Body:  " << GetUVW() << " (u,v,w in ft/sec)" << endl;
 
-    log << endl << "  " << LogFormat::UNDERLINE_ON
-        << "Body Rates (relative to given frame, expressed in body frame)" << LogFormat::UNDERLINE_OFF << endl;
-    log << "    ECI:   " << (VState.vPQRi * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
-    log << "    ECEF:  " << (VState.vPQR * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
-  }
+  log << endl << "  " << LogFormat::UNDERLINE_ON
+      << "Body Rates (relative to given frame, expressed in body frame)" << LogFormat::UNDERLINE_OFF << endl;
+  log << "    ECI:   " << (VState.vPQRi * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
+  log << "    ECEF:  " << (VState.vPQR * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
+}
 
-  //******************************************************************************
+//******************************************************************************
 
-  void FGPropagate::WriteStateFile(int num)
-  {
-    sg_ofstream outfile;
+void FGPropagate::WriteStateFile(int num)
+{
+  sg_ofstream outfile;
 
-    if (num == 0) return;
+  if (num == 0) return;
 
-    SGPath path = FDMExec->GetOutputPath();
+  SGPath path = FDMExec->GetOutputPath();
 
-    if (path.isNull()) path = SGPath("initfile.");
-    else               path.append("initfile.");
+  if (path.isNull()) path = SGPath("initfile.");
+  else               path.append("initfile.");
 
-    // Append sim time to the filename since there may be more than one created during a simulation run
+  // Append sim time to the filename since there may be more than one created during a simulation run
   path.concat(to_string((double)FDMExec->GetSimTime())+".xml");
 
   switch(num) {
-    case 1:
-      outfile.open(path);
-      if (outfile.is_open()) {
-        outfile << "<?xml version=\"1.0\"?>" << endl;
-        outfile << "<initialize name=\"reset00\">" << endl;
-        outfile << "  <ubody unit=\"FT/SEC\"> " << VState.vUVW(eU) << " </ubody> " << endl;
-        outfile << "  <vbody unit=\"FT/SEC\"> " << VState.vUVW(eV) << " </vbody> " << endl;
-        outfile << "  <wbody unit=\"FT/SEC\"> " << VState.vUVW(eW) << " </wbody> " << endl;
-        outfile << "  <phi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePhi)*radtodeg << " </phi>" << endl;
-        outfile << "  <theta unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(eTht)*radtodeg << " </theta>" << endl;
-        outfile << "  <psi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePsi)*radtodeg << " </psi>" << endl;
-        outfile << "  <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
-        outfile << "  <latitude unit=\"DEG\"> " << VState.vLocation.GetLatitudeDeg() << " </latitude>" << endl;
-        outfile << "  <altitude unit=\"FT\"> " << GetDistanceAGL() << " </altitude>" << endl;
-        outfile << "</initialize>" << endl;
-        outfile.close();
-      } else {
-        FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
-        log << "Could not open and/or write the state to the initial conditions file: "
-            << path << endl;
-      }
-      break;
-    case 2:
-      outfile.open(path);
-      if (outfile.is_open()) {
-        outfile << "<?xml version=\"1.0\"?>" << endl;
-        outfile << "<initialize name=\"IC File\" version=\"2.0\">" << endl;
-        outfile << "" << endl;
-        outfile << "  <position frame=\"ECEF\">" << endl;
-        outfile << "    <latitude unit=\"DEG\" type=\"geodetic\"> " << VState.vLocation.GetGeodLatitudeDeg() << " </latitude>" << endl;
-        outfile << "    <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
-        outfile << "    <altitudeMSL unit=\"FT\"> " << GetAltitudeASL() << " </altitudeMSL>" << endl;
-        outfile << "  </position>" << endl;
-        outfile << "" << endl;
-        outfile << "  <orientation unit=\"DEG\" frame=\"LOCAL\">" << endl;
-        outfile << "    <yaw> " << VState.qAttitudeLocal.GetEulerDeg(eYaw) << " </yaw>" << endl;
-        outfile << "    <pitch> " << VState.qAttitudeLocal.GetEulerDeg(ePitch) << " </pitch>" << endl;
-        outfile << "    <roll> " << VState.qAttitudeLocal.GetEulerDeg(eRoll) << " </roll>" << endl;
-        outfile << "  </orientation>" << endl;
-        outfile << "" << endl;
-        outfile << "  <velocity unit=\"FT/SEC\" frame=\"LOCAL\">" << endl;
-        outfile << "    <x> " << GetVel(eNorth) << " </x>" << endl;
-        outfile << "    <y> " << GetVel(eEast) << " </y>" << endl;
-        outfile << "    <z> " << GetVel(eDown) << " </z>" << endl;
-        outfile << "  </velocity>" << endl;
-        outfile << "" << endl;
-        outfile << "  <attitude_rate unit=\"DEG/SEC\" frame=\"BODY\">" << endl;
-        outfile << "    <roll> " << (VState.vPQR*radtodeg)(eRoll) << " </roll>" << endl;
-        outfile << "    <pitch> " << (VState.vPQR*radtodeg)(ePitch) << " </pitch>" << endl;
-        outfile << "    <yaw> " << (VState.vPQR*radtodeg)(eYaw) << " </yaw>" << endl;
-        outfile << "  </attitude_rate>" << endl;
-        outfile << "" << endl;
-        outfile << "</initialize>" << endl;
-        outfile.close();
-      } else {
-        FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
-        log << "Could not open and/or write the state to the initial conditions file: "
-            << path << endl;
-      }
-      break;
-    default:
+  case 1:
+    outfile.open(path);
+    if (outfile.is_open()) {
+      outfile << "<?xml version=\"1.0\"?>" << endl;
+      outfile << "<initialize name=\"reset00\">" << endl;
+      outfile << "  <ubody unit=\"FT/SEC\"> " << VState.vUVW(eU) << " </ubody> " << endl;
+      outfile << "  <vbody unit=\"FT/SEC\"> " << VState.vUVW(eV) << " </vbody> " << endl;
+      outfile << "  <wbody unit=\"FT/SEC\"> " << VState.vUVW(eW) << " </wbody> " << endl;
+      outfile << "  <phi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePhi)*radtodeg << " </phi>" << endl;
+      outfile << "  <theta unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(eTht)*radtodeg << " </theta>" << endl;
+      outfile << "  <psi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePsi)*radtodeg << " </psi>" << endl;
+      outfile << "  <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
+      outfile << "  <latitude unit=\"DEG\"> " << VState.vLocation.GetLatitudeDeg() << " </latitude>" << endl;
+      outfile << "  <altitude unit=\"FT\"> " << GetDistanceAGL() << " </altitude>" << endl;
+      outfile << "</initialize>" << endl;
+      outfile.close();
+    } else {
       FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
-      log << "When writing a state file, the supplied value must be 1 or 2 for the version number of the resulting IC file" << endl;
+      log << "Could not open and/or write the state to the initial conditions file: "
+          << path << endl;
     }
+    break;
+  case 2:
+    outfile.open(path);
+    if (outfile.is_open()) {
+      outfile << "<?xml version=\"1.0\"?>" << endl;
+      outfile << "<initialize name=\"IC File\" version=\"2.0\">" << endl;
+      outfile << "" << endl;
+      outfile << "  <position frame=\"ECEF\">" << endl;
+      outfile << "    <latitude unit=\"DEG\" type=\"geodetic\"> " << VState.vLocation.GetGeodLatitudeDeg() << " </latitude>" << endl;
+      outfile << "    <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
+      outfile << "    <altitudeMSL unit=\"FT\"> " << GetAltitudeASL() << " </altitudeMSL>" << endl;
+      outfile << "  </position>" << endl;
+      outfile << "" << endl;
+      outfile << "  <orientation unit=\"DEG\" frame=\"LOCAL\">" << endl;
+      outfile << "    <yaw> " << VState.qAttitudeLocal.GetEulerDeg(eYaw) << " </yaw>" << endl;
+      outfile << "    <pitch> " << VState.qAttitudeLocal.GetEulerDeg(ePitch) << " </pitch>" << endl;
+      outfile << "    <roll> " << VState.qAttitudeLocal.GetEulerDeg(eRoll) << " </roll>" << endl;
+      outfile << "  </orientation>" << endl;
+      outfile << "" << endl;
+      outfile << "  <velocity unit=\"FT/SEC\" frame=\"LOCAL\">" << endl;
+      outfile << "    <x> " << GetVel(eNorth) << " </x>" << endl;
+      outfile << "    <y> " << GetVel(eEast) << " </y>" << endl;
+      outfile << "    <z> " << GetVel(eDown) << " </z>" << endl;
+      outfile << "  </velocity>" << endl;
+      outfile << "" << endl;
+      outfile << "  <attitude_rate unit=\"DEG/SEC\" frame=\"BODY\">" << endl;
+      outfile << "    <roll> " << (VState.vPQR*radtodeg)(eRoll) << " </roll>" << endl;
+      outfile << "    <pitch> " << (VState.vPQR*radtodeg)(ePitch) << " </pitch>" << endl;
+      outfile << "    <yaw> " << (VState.vPQR*radtodeg)(eYaw) << " </yaw>" << endl;
+      outfile << "  </attitude_rate>" << endl;
+      outfile << "" << endl;
+      outfile << "</initialize>" << endl;
+      outfile.close();
+    } else {
+      FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+      log << "Could not open and/or write the state to the initial conditions file: "
+          << path << endl;
+    }
+    break;
+  default:
+    FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+    log << "When writing a state file, the supplied value must be 1 or 2 for the version number of the resulting IC file" << endl;
   }
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  void FGPropagate::bind(void)
-  {
+void FGPropagate::bind(void)
+{
   typedef double (FGPropagate::*PMF)(int) const;
   typedef int (FGPropagate::*iPMF)(void) const;
 
-    PropertyManager->Tie("velocities/h-dot-fps", this, &FGPropagate::Gethdot);
+  PropertyManager->Tie("velocities/h-dot-fps", this, &FGPropagate::Gethdot);
 
-    PropertyManager->Tie("velocities/v-north-fps", this, eNorth, (PMF)&FGPropagate::GetVel);
-    PropertyManager->Tie("velocities/v-east-fps", this, eEast, (PMF)&FGPropagate::GetVel);
-    PropertyManager->Tie("velocities/v-down-fps", this, eDown, (PMF)&FGPropagate::GetVel);
+  PropertyManager->Tie("velocities/v-north-fps", this, eNorth, (PMF)&FGPropagate::GetVel);
+  PropertyManager->Tie("velocities/v-east-fps", this, eEast, (PMF)&FGPropagate::GetVel);
+  PropertyManager->Tie("velocities/v-down-fps", this, eDown, (PMF)&FGPropagate::GetVel);
 
-    PropertyManager->Tie("velocities/u-fps", this, eU, (PMF)&FGPropagate::GetUVW);
-    PropertyManager->Tie("velocities/v-fps", this, eV, (PMF)&FGPropagate::GetUVW);
-    PropertyManager->Tie("velocities/w-fps", this, eW, (PMF)&FGPropagate::GetUVW);
+  PropertyManager->Tie("velocities/u-fps", this, eU, (PMF)&FGPropagate::GetUVW);
+  PropertyManager->Tie("velocities/v-fps", this, eV, (PMF)&FGPropagate::GetUVW);
+  PropertyManager->Tie("velocities/w-fps", this, eW, (PMF)&FGPropagate::GetUVW);
 
-    PropertyManager->Tie("velocities/p-rad_sec", this, eP, (PMF)&FGPropagate::GetPQR);
-    PropertyManager->Tie("velocities/q-rad_sec", this, eQ, (PMF)&FGPropagate::GetPQR);
-    PropertyManager->Tie("velocities/r-rad_sec", this, eR, (PMF)&FGPropagate::GetPQR);
+  PropertyManager->Tie("velocities/p-rad_sec", this, eP, (PMF)&FGPropagate::GetPQR);
+  PropertyManager->Tie("velocities/q-rad_sec", this, eQ, (PMF)&FGPropagate::GetPQR);
+  PropertyManager->Tie("velocities/r-rad_sec", this, eR, (PMF)&FGPropagate::GetPQR);
 
-    PropertyManager->Tie("velocities/pi-rad_sec", this, eP, (PMF)&FGPropagate::GetPQRi);
-    PropertyManager->Tie("velocities/qi-rad_sec", this, eQ, (PMF)&FGPropagate::GetPQRi);
-    PropertyManager->Tie("velocities/ri-rad_sec", this, eR, (PMF)&FGPropagate::GetPQRi);
+  PropertyManager->Tie("velocities/pi-rad_sec", this, eP, (PMF)&FGPropagate::GetPQRi);
+  PropertyManager->Tie("velocities/qi-rad_sec", this, eQ, (PMF)&FGPropagate::GetPQRi);
+  PropertyManager->Tie("velocities/ri-rad_sec", this, eR, (PMF)&FGPropagate::GetPQRi);
 
-    PropertyManager->Tie("velocities/eci-x-fps", this, eX, (PMF)&FGPropagate::GetInertialVelocity);
-    PropertyManager->Tie("velocities/eci-y-fps", this, eY, (PMF)&FGPropagate::GetInertialVelocity);
-    PropertyManager->Tie("velocities/eci-z-fps", this, eZ, (PMF)&FGPropagate::GetInertialVelocity);
+  PropertyManager->Tie("velocities/eci-x-fps", this, eX, (PMF)&FGPropagate::GetInertialVelocity);
+  PropertyManager->Tie("velocities/eci-y-fps", this, eY, (PMF)&FGPropagate::GetInertialVelocity);
+  PropertyManager->Tie("velocities/eci-z-fps", this, eZ, (PMF)&FGPropagate::GetInertialVelocity);
 
-    PropertyManager->Tie("velocities/eci-velocity-mag-fps", this, &FGPropagate::GetInertialVelocityMagnitude);
-    PropertyManager->Tie("velocities/ned-velocity-mag-fps", this, &FGPropagate::GetNEDVelocityMagnitude);
+  PropertyManager->Tie("velocities/eci-velocity-mag-fps", this, &FGPropagate::GetInertialVelocityMagnitude);
+  PropertyManager->Tie("velocities/ned-velocity-mag-fps", this, &FGPropagate::GetNEDVelocityMagnitude);
 
-    PropertyManager->Tie("position/h-sl-ft", this, &FGPropagate::GetAltitudeASL, &FGPropagate::SetAltitudeASL);
-    PropertyManager->Tie("position/h-sl-meters", this, &FGPropagate::GetAltitudeASLmeters, &FGPropagate::SetAltitudeASLmeters);
-    PropertyManager->Tie("position/lat-gc-rad", this, &FGPropagate::GetLatitude, &FGPropagate::SetLatitude);
-    PropertyManager->Tie("position/long-gc-rad", this, &FGPropagate::GetLongitude, &FGPropagate::SetLongitude);
-    PropertyManager->Tie("position/lat-gc-deg", this, &FGPropagate::GetLatitudeDeg, &FGPropagate::SetLatitudeDeg);
-    PropertyManager->Tie("position/long-gc-deg", this, &FGPropagate::GetLongitudeDeg, &FGPropagate::SetLongitudeDeg);
-    PropertyManager->Tie("position/lat-geod-rad", this, &FGPropagate::GetGeodLatitudeRad);
-    PropertyManager->Tie("position/lat-geod-deg", this, &FGPropagate::GetGeodLatitudeDeg);
-    PropertyManager->Tie("position/geod-alt-ft", this, &FGPropagate::GetGeodeticAltitude);
+  PropertyManager->Tie("position/h-sl-ft", this, &FGPropagate::GetAltitudeASL, &FGPropagate::SetAltitudeASL);
+  PropertyManager->Tie("position/h-sl-meters", this, &FGPropagate::GetAltitudeASLmeters, &FGPropagate::SetAltitudeASLmeters);
+  PropertyManager->Tie("position/lat-gc-rad", this, &FGPropagate::GetLatitude, &FGPropagate::SetLatitude);
+  PropertyManager->Tie("position/long-gc-rad", this, &FGPropagate::GetLongitude, &FGPropagate::SetLongitude);
+  PropertyManager->Tie("position/lat-gc-deg", this, &FGPropagate::GetLatitudeDeg, &FGPropagate::SetLatitudeDeg);
+  PropertyManager->Tie("position/long-gc-deg", this, &FGPropagate::GetLongitudeDeg, &FGPropagate::SetLongitudeDeg);
+  PropertyManager->Tie("position/lat-geod-rad", this, &FGPropagate::GetGeodLatitudeRad);
+  PropertyManager->Tie("position/lat-geod-deg", this, &FGPropagate::GetGeodLatitudeDeg);
+  PropertyManager->Tie("position/geod-alt-ft", this, &FGPropagate::GetGeodeticAltitude);
   PropertyManager->Tie("position/h-agl-ft", this,  &FGPropagate::GetDistanceAGL, &FGPropagate::SetDistanceAGL);
-    PropertyManager->Tie("position/geod-alt-km", this, &FGPropagate::GetGeodeticAltitudeKm);
+  PropertyManager->Tie("position/geod-alt-km", this, &FGPropagate::GetGeodeticAltitudeKm);
   PropertyManager->Tie("position/h-agl-km", this,  &FGPropagate::GetDistanceAGLKm, &FGPropagate::SetDistanceAGLKm);
-    PropertyManager->Tie("position/radius-to-vehicle-ft", this, &FGPropagate::GetRadius);
-    PropertyManager->Tie("position/terrain-elevation-asl-ft", this,
-      &FGPropagate::GetTerrainElevation,
-      &FGPropagate::SetTerrainElevation);
+  PropertyManager->Tie("position/radius-to-vehicle-ft", this, &FGPropagate::GetRadius);
+  PropertyManager->Tie("position/terrain-elevation-asl-ft", this,
+                          &FGPropagate::GetTerrainElevation,
+                          &FGPropagate::SetTerrainElevation);
 
-    PropertyManager->Tie("position/eci-x-ft", this, eX, (PMF)&FGPropagate::GetInertialPosition);
-    PropertyManager->Tie("position/eci-y-ft", this, eY, (PMF)&FGPropagate::GetInertialPosition);
-    PropertyManager->Tie("position/eci-z-ft", this, eZ, (PMF)&FGPropagate::GetInertialPosition);
+  PropertyManager->Tie("position/eci-x-ft", this, eX, (PMF)&FGPropagate::GetInertialPosition);
+  PropertyManager->Tie("position/eci-y-ft", this, eY, (PMF)&FGPropagate::GetInertialPosition);
+  PropertyManager->Tie("position/eci-z-ft", this, eZ, (PMF)&FGPropagate::GetInertialPosition);
 
-    PropertyManager->Tie("position/ecef-x-ft", this, eX, (PMF)&FGPropagate::GetLocation);
-    PropertyManager->Tie("position/ecef-y-ft", this, eY, (PMF)&FGPropagate::GetLocation);
-    PropertyManager->Tie("position/ecef-z-ft", this, eZ, (PMF)&FGPropagate::GetLocation);
+  PropertyManager->Tie("position/ecef-x-ft", this, eX, (PMF)&FGPropagate::GetLocation);
+  PropertyManager->Tie("position/ecef-y-ft", this, eY, (PMF)&FGPropagate::GetLocation);
+  PropertyManager->Tie("position/ecef-z-ft", this, eZ, (PMF)&FGPropagate::GetLocation);
 
-    PropertyManager->Tie("position/epa-rad", this, &FGPropagate::GetEarthPositionAngle);
-    PropertyManager->Tie("metrics/terrain-radius", this, &FGPropagate::GetLocalTerrainRadius);
+  PropertyManager->Tie("position/epa-rad", this, &FGPropagate::GetEarthPositionAngle);
+  PropertyManager->Tie("metrics/terrain-radius", this, &FGPropagate::GetLocalTerrainRadius);
 
-    PropertyManager->Tie("attitude/phi-rad", this, (int)ePhi, (PMF)&FGPropagate::GetEuler);
-    PropertyManager->Tie("attitude/theta-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
-    PropertyManager->Tie("attitude/psi-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
+  PropertyManager->Tie("attitude/phi-rad", this, (int)ePhi, (PMF)&FGPropagate::GetEuler);
+  PropertyManager->Tie("attitude/theta-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
+  PropertyManager->Tie("attitude/psi-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
 
-    PropertyManager->Tie("attitude/phi-deg", this, (int)ePhi, (PMF)&FGPropagate::GetEulerDeg);
-    PropertyManager->Tie("attitude/theta-deg", this, (int)eTht, (PMF)&FGPropagate::GetEulerDeg);
-    PropertyManager->Tie("attitude/psi-deg", this, (int)ePsi, (PMF)&FGPropagate::GetEulerDeg);
+  PropertyManager->Tie("attitude/phi-deg", this, (int)ePhi, (PMF)&FGPropagate::GetEulerDeg);
+  PropertyManager->Tie("attitude/theta-deg", this, (int)eTht, (PMF)&FGPropagate::GetEulerDeg);
+  PropertyManager->Tie("attitude/psi-deg", this, (int)ePsi, (PMF)&FGPropagate::GetEulerDeg);
 
-    PropertyManager->Tie("attitude/roll-rad", this, (int)ePhi, (PMF)&FGPropagate::GetEuler);
-    PropertyManager->Tie("attitude/pitch-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
-    PropertyManager->Tie("attitude/heading-true-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
+  PropertyManager->Tie("attitude/roll-rad", this, (int)ePhi, (PMF)&FGPropagate::GetEuler);
+  PropertyManager->Tie("attitude/pitch-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
+  PropertyManager->Tie("attitude/heading-true-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
 
-    PropertyManager->Tie("orbital/specific-angular-momentum-ft2_sec", &h);
-    PropertyManager->Tie("orbital/inclination-deg", &Inclination);
-    PropertyManager->Tie("orbital/right-ascension-deg", &RightAscension);
-    PropertyManager->Tie("orbital/eccentricity", &Eccentricity);
-    PropertyManager->Tie("orbital/argument-of-perigee-deg", &PerigeeArgument);
-    PropertyManager->Tie("orbital/true-anomaly-deg", &TrueAnomaly);
-    PropertyManager->Tie("orbital/apoapsis-radius-ft", &ApoapsisRadius);
-    PropertyManager->Tie("orbital/periapsis-radius-ft", &PeriapsisRadius);
-    PropertyManager->Tie("orbital/period-sec", &OrbitalPeriod);
+  PropertyManager->Tie("orbital/specific-angular-momentum-ft2_sec", &h);
+  PropertyManager->Tie("orbital/inclination-deg", &Inclination);
+  PropertyManager->Tie("orbital/right-ascension-deg", &RightAscension);
+  PropertyManager->Tie("orbital/eccentricity", &Eccentricity);
+  PropertyManager->Tie("orbital/argument-of-perigee-deg", &PerigeeArgument);
+  PropertyManager->Tie("orbital/true-anomaly-deg", &TrueAnomaly);
+  PropertyManager->Tie("orbital/apoapsis-radius-ft", &ApoapsisRadius);
+  PropertyManager->Tie("orbital/periapsis-radius-ft", &PeriapsisRadius);
+  PropertyManager->Tie("orbital/period-sec", &OrbitalPeriod);
 
-    PropertyManager->Tie("simulation/integrator/rate/rotational", (int*)&integrator_rotational_rate);
-    PropertyManager->Tie("simulation/integrator/rate/translational", (int*)&integrator_translational_rate);
-    PropertyManager->Tie("simulation/integrator/position/rotational", (int*)&integrator_rotational_position);
-    PropertyManager->Tie("simulation/integrator/position/translational", (int*)&integrator_translational_position);
+  PropertyManager->Tie("simulation/integrator/rate/rotational", (int*)&integrator_rotational_rate);
+  PropertyManager->Tie("simulation/integrator/rate/translational", (int*)&integrator_translational_rate);
+  PropertyManager->Tie("simulation/integrator/position/rotational", (int*)&integrator_rotational_position);
+  PropertyManager->Tie("simulation/integrator/position/translational", (int*)&integrator_translational_position);
 
-    PropertyManager->Tie("simulation/write-state-file", this, (iPMF)0, &FGPropagate::WriteStateFile);
-  }
+  PropertyManager->Tie("simulation/write-state-file", this, (iPMF)0, &FGPropagate::WriteStateFile);
+}
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  //    The bitmasked value choices are as follows:
-  //    unset: In this case (the default) JSBSim would only print
-  //       out the normally expected messages, essentially echoing
-  //       the config files as they are read. If the environment
-  //       variable is not set, debug_lvl is set to 1 internally
-  //    0: This requests JSBSim not to output any messages
-  //       whatsoever.
-  //    1: This value explicity requests the normal JSBSim
-  //       startup messages
-  //    2: This value asks for a message to be printed out when
-  //       a class is instantiated
-  //    4: When this value is set, a message is displayed when a
-  //       FGModel object executes its Run() method
-  //    8: When this value is set, various runtime state variables
-  //       are printed out periodically
-  //    16: When set various parameters are sanity checked and
-  //       a message is printed out when they go out of bounds
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+//    The bitmasked value choices are as follows:
+//    unset: In this case (the default) JSBSim would only print
+//       out the normally expected messages, essentially echoing
+//       the config files as they are read. If the environment
+//       variable is not set, debug_lvl is set to 1 internally
+//    0: This requests JSBSim not to output any messages
+//       whatsoever.
+//    1: This value explicity requests the normal JSBSim
+//       startup messages
+//    2: This value asks for a message to be printed out when
+//       a class is instantiated
+//    4: When this value is set, a message is displayed when a
+//       FGModel object executes its Run() method
+//    8: When this value is set, various runtime state variables
+//       are printed out periodically
+//    16: When set various parameters are sanity checked and
+//       a message is printed out when they go out of bounds
 
-  void FGPropagate::Debug(int from)
-  {
-    if (debug_lvl <= 0) return;
+void FGPropagate::Debug(int from)
+{
+  if (debug_lvl <= 0) return;
 
-    if (debug_lvl & 1) { // Standard console startup message output
-      if (from == 0) { // Constructor
+  if (debug_lvl & 1) { // Standard console startup message output
+    if (from == 0) { // Constructor
 
-      }
     }
+  }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-      if (from == 0) log << "Instantiated: FGPropagate" << endl;
-      if (from == 1) log << "Destroyed:    FGPropagate" << endl;
-    }
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGPropagate" << endl;
+    if (from == 1) log << "Destroyed:    FGPropagate" << endl;
+  }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
-    }
-    if (debug_lvl & 8 && from == 2) { // Runtime state variables
-      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-      log << endl << LogFormat::BLUE << LogFormat::BOLD << left
-          << "  Propagation Report (English units: ft, degrees) at simulation time " << FDMExec->GetSimTime() << " seconds"
-          << LogFormat::RESET << endl;
-      log << endl;
-      log << LogFormat::BOLD << "  Earth Position Angle (deg): " << setw(8) << setprecision(3) << LogFormat::RESET
-          << GetEarthPositionAngleDeg() << endl;
-      log << endl;
-      log << LogFormat::BOLD << "  Body velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vUVW << endl;
-      log << LogFormat::BOLD << "  Local velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << vVel << endl;
-      log << LogFormat::BOLD << "  Inertial velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vInertialVelocity << endl;
-      log << LogFormat::BOLD << "  Inertial Position (ft): " << setw(10) << setprecision(3) << LogFormat::RESET << VState.vInertialPosition << endl;
-      log << LogFormat::BOLD << "  Latitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLatitudeDeg() << endl;
-      log << LogFormat::BOLD << "  Longitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLongitudeDeg() << endl;
-      log << LogFormat::BOLD << "  Altitude ASL (ft): " << setw(8) << setprecision(3) << LogFormat::RESET << GetAltitudeASL() << endl;
-      //    log << LogFormat::BOLD << "  Acceleration (NED, ft/sec^2): " << setw(8) << setprecision(3) << LogFormat::RESET << Tb2l*GetUVWdot() << endl;
-      log << endl;
-      log << LogFormat::BOLD << "  Matrix ECEF to Body (Orientation of Body with respect to ECEF): "
-          << LogFormat::RESET << endl << Tec2b.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Tec2b.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+  }
+  if (debug_lvl & 8 && from == 2) { // Runtime state variables
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    log << endl << LogFormat::BLUE << LogFormat::BOLD << left
+        << "  Propagation Report (English units: ft, degrees) at simulation time " << FDMExec->GetSimTime() << " seconds"
+        << LogFormat::RESET << endl;
+    log << endl;
+    log << LogFormat::BOLD << "  Earth Position Angle (deg): " << setw(8) << setprecision(3) << LogFormat::RESET
+        << GetEarthPositionAngleDeg() << endl;
+    log << endl;
+    log << LogFormat::BOLD << "  Body velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vUVW << endl;
+    log << LogFormat::BOLD << "  Local velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << vVel << endl;
+    log << LogFormat::BOLD << "  Inertial velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vInertialVelocity << endl;
+    log << LogFormat::BOLD << "  Inertial Position (ft): " << setw(10) << setprecision(3) << LogFormat::RESET << VState.vInertialPosition << endl;
+    log << LogFormat::BOLD << "  Latitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLatitudeDeg() << endl;
+    log << LogFormat::BOLD << "  Longitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLongitudeDeg() << endl;
+    log << LogFormat::BOLD << "  Altitude ASL (ft): " << setw(8) << setprecision(3) << LogFormat::RESET << GetAltitudeASL() << endl;
+    //    log << LogFormat::BOLD << "  Acceleration (NED, ft/sec^2): " << setw(8) << setprecision(3) << LogFormat::RESET << Tb2l*GetUVWdot() << endl;
+    log << endl;
+    log << LogFormat::BOLD << "  Matrix ECEF to Body (Orientation of Body with respect to ECEF): "
+        << LogFormat::RESET << endl << Tec2b.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Tec2b.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix Body to ECEF (Orientation of ECEF with respect to Body):"
-          << LogFormat::RESET << endl << Tb2ec.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Tb2ec.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix Body to ECEF (Orientation of ECEF with respect to Body):"
+        << LogFormat::RESET << endl << Tb2ec.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Tb2ec.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix Local to Body (Orientation of Body with respect to Local):"
-          << LogFormat::RESET << endl << Tl2b.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Tl2b.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix Local to Body (Orientation of Body with respect to Local):"
+        << LogFormat::RESET << endl << Tl2b.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Tl2b.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix Body to Local (Orientation of Local with respect to Body):"
-          << LogFormat::RESET << endl << Tb2l.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Tb2l.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix Body to Local (Orientation of Local with respect to Body):"
+        << LogFormat::RESET << endl << Tb2l.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Tb2l.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix Local to ECEF (Orientation of ECEF with respect to Local):"
-          << LogFormat::RESET << endl << Tl2ec.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Tl2ec.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix Local to ECEF (Orientation of ECEF with respect to Local):"
+        << LogFormat::RESET << endl << Tl2ec.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Tl2ec.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix ECEF to Local (Orientation of Local with respect to ECEF):"
-          << LogFormat::RESET << endl << Tec2l.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Tec2l.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix ECEF to Local (Orientation of Local with respect to ECEF):"
+        << LogFormat::RESET << endl << Tec2l.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Tec2l.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix ECEF to Inertial (Orientation of Inertial with respect to ECEF):"
-          << LogFormat::RESET << endl << Tec2i.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Tec2i.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix ECEF to Inertial (Orientation of Inertial with respect to ECEF):"
+        << LogFormat::RESET << endl << Tec2i.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Tec2i.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix Inertial to ECEF (Orientation of ECEF with respect to Inertial):"
-          << LogFormat::RESET << endl << Ti2ec.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Ti2ec.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix Inertial to ECEF (Orientation of ECEF with respect to Inertial):"
+        << LogFormat::RESET << endl << Ti2ec.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Ti2ec.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix Inertial to Body (Orientation of Body with respect to Inertial):"
-          << LogFormat::RESET << endl << Ti2b.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Ti2b.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix Inertial to Body (Orientation of Body with respect to Inertial):"
+        << LogFormat::RESET << endl << Ti2b.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Ti2b.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix Body to Inertial (Orientation of Inertial with respect to Body):"
-          << LogFormat::RESET << endl << Tb2i.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Tb2i.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix Body to Inertial (Orientation of Inertial with respect to Body):"
+        << LogFormat::RESET << endl << Tb2i.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Tb2i.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix Inertial to Local (Orientation of Local with respect to Inertial):"
-          << LogFormat::RESET << endl << Ti2l.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Ti2l.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix Inertial to Local (Orientation of Local with respect to Inertial):"
+        << LogFormat::RESET << endl << Ti2l.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Ti2l.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << LogFormat::BOLD << "  Matrix Local to Inertial (Orientation of Inertial with respect to Local):"
-          << LogFormat::RESET << endl << Tl2i.Dump("\t", "    ") << endl;
-      log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
-          << setprecision(3) << LogFormat::RESET << (Tl2i.GetQuaternion().GetEuler()*radtodeg)
-          << endl << endl;
+    log << LogFormat::BOLD << "  Matrix Local to Inertial (Orientation of Inertial with respect to Local):"
+        << LogFormat::RESET << endl << Tl2i.Dump("\t", "    ") << endl;
+    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << setprecision(3) << LogFormat::RESET << (Tl2i.GetQuaternion().GetEuler()*radtodeg)
+                  << endl << endl;
 
-      log << setprecision(6); // reset the output stream
-    }
-    if (debug_lvl & 16) { // Sanity checking
-      if (from == 2) { // State sanity checking
-        if (fabs(VState.vPQR.Magnitude()) > 1000.0) {
-          FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
-          log << "Vehicle rotation rate is excessive (>1000 rad/sec): " << VState.vPQR.Magnitude() << endl;
-          throw BaseException(log.str());
-        }
-        if (fabs(VState.vUVW.Magnitude()) > 1.0e10) {
-          FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
-          log << "Vehicle velocity is excessive (>1e10 ft/sec): " << VState.vUVW.Magnitude() << endl;
-          throw BaseException(log.str());
-        }
-        if (fabs(GetDistanceAGL()) > 1e10) {
-          FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
-          log << "Vehicle altitude is excessive (>1e10 ft): " << GetDistanceAGL() << endl;
-          throw BaseException(log.str());
-        }
+    log << setprecision(6); // reset the output stream
+  }
+  if (debug_lvl & 16) { // Sanity checking
+    if (from == 2) { // State sanity checking
+      if (fabs(VState.vPQR.Magnitude()) > 1000.0) {
+        FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
+        log << "Vehicle rotation rate is excessive (>1000 rad/sec): " << VState.vPQR.Magnitude() << endl;
+        throw BaseException(log.str());
       }
-    }
-    if (debug_lvl & 64) {
-      if (from == 0) { // Constructor
+      if (fabs(VState.vUVW.Magnitude()) > 1.0e10) {
+        FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
+        log << "Vehicle velocity is excessive (>1e10 ft/sec): " << VState.vUVW.Magnitude() << endl;
+        throw BaseException(log.str());
+      }
+      if (fabs(GetDistanceAGL()) > 1e10) {
+        FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
+        log << "Vehicle altitude is excessive (>1e10 ft): " << GetDistanceAGL() << endl;
+        throw BaseException(log.str());
       }
     }
   }
+  if (debug_lvl & 64) {
+    if (from == 0) { // Constructor
+    }
+  }
+}
 }

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -46,6 +46,7 @@ INCLUDES
 #include "FGWinds.h"
 #include "FGFDMExec.h"
 #include "math/FGTable.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -594,8 +595,9 @@ void FGWinds::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGWinds" << endl;
-    if (from == 1) cout << "Destroyed:    FGWinds" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGWinds" << endl;
+    if (from == 1) log << "Destroyed:    FGWinds" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }


### PR DESCRIPTION
This PR is the continuation of the PR #1094. The replacement of `cout` and `cerr` by `FGLogging` is propagated to some additional classes.

The class `FGLogging` has also had some changes:
* It skips calling `FGLogger::Message` if its buffer is empty. This is because we cannot assume that calling `FGLogger::Message` is a cheap operation.
* `FGLogging::operator<<` is extended to all number formats, `FGColumnVector3` and some formatting from `std::ostringstream` such as `std::setw` and `std::ios_base`. This is to ensure that `FGLogging` behaves the same way as `cout` and `cerr`.
  * There is a subtlety regarding `setw_t` as Windows considers `std::setw` and `std::setprecision` to be of the same type while Linux and MacOSX don't.
* `ERROR` has to be undef'ed in `FGfdmSocket.h` because there is a clash between `ERROR` being defined in the Windows headers and `ERROR` being used in our `LogLevel` enum:
https://github.com/JSBSim-Team/jsbsim/blob/b41fcddc505baf041a3082ac3be2312e392c7792/src/input_output/FGLog.h#L62-L69

Regarding the exception management:
* When an error will throw an exception, the error level is always set to **FATAL**.
* The message that is passed to the exception `JSBSim::BaseException` is a copy of the error message so that the same message is logged and send to the exception manager. As a result the code looks like:
```c++
FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
log << "Something terrible happened !" << endl;
throw BaseException(log.str());
```