### PR TITLE
Fixes to the logging code

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -1417,8 +1417,7 @@ void FGFDMExec::Debug(int from)
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
     if (from == 2) {
-      FGLogging log(Log, LogLevel::DEBUG);
-      log << "================== Frame: " << Frame << "  Time: "
+      log << "================== Frame: " << Frame << "  Time: " << fixed
           << sim_time << " dt: " << dT << endl;
     }
   }

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -630,6 +630,10 @@ public:
   auto GetRandomGenerator(void) const { return RandomGenerator; }
 
 private:
+  // Declare Log first so that it's destroyed last: the logger may be used by
+  // some FGFDMExec members to log data during their destruction.
+  std::shared_ptr<FGLogger> Log;
+
   unsigned int Frame;
   unsigned int IdFDM;
   int disperse;
@@ -696,8 +700,6 @@ private:
   std::vector <std::shared_ptr<childData>> ChildFDMList;
   std::vector <std::shared_ptr<FGModel>> Models;
   std::map<std::string, FGTemplateFunc_ptr> TemplateFunctions;
-
-  std::shared_ptr<FGLogger> Log;
 
   bool ReadFileHeader(Element*);
   bool ReadChild(Element*);

--- a/src/initialization/FGTrimAxis.cpp
+++ b/src/initialization/FGTrimAxis.cpp
@@ -293,7 +293,7 @@ void FGTrimAxis::AxisReport(void) {
   std::ios_base::fmtflags originalFormat = cout.flags();
   std::streamsize originalPrecision = cout.precision();
   std::streamsize originalWidth = cout.width();
-  cout << "  " << setw(20) << GetControlName() << ": ";
+  cout << "  " << left << setw(20) << GetControlName() << ": ";
   cout << setw(6) << setprecision(2) << GetControl()*control_convert << ' ';
   cout << setw(5) << GetStateName() << ": ";
   cout << setw(9) << setprecision(2) << scientific << GetState()+state_target;

--- a/src/input_output/FGLog.cpp
+++ b/src/input_output/FGLog.cpp
@@ -53,7 +53,6 @@ void FGLogging::Flush(void)
   if (!message.empty()) {
     logger->Message(message);
     buffer.str("");
-    logger->Format(LogFormat::RESET);
     logger->Flush();
   }
 

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -457,7 +457,7 @@ void FGMassBalance::GetMassPropertiesReport(int i)
   log << "                                  " << LogFormat::UNDERLINE_ON << "    Weight    CG-X    CG-Y"
       << "    CG-Z         Ixx         Iyy         Izz"
       << "         Ixy         Ixz         Iyz" << LogFormat::UNDERLINE_OFF << endl;
-  log << setprecision(1);
+  log << fixed << setprecision(1);
   log << LogFormat::BOLD << setw(34) << left << "    Base Vehicle " << normint
       << right << setw(12) << EmptyWeight
       << setw(8) << vbaseXYZcg(eX) << setw(8) << vbaseXYZcg(eY) << setw(8) << vbaseXYZcg(eZ)
@@ -516,7 +516,7 @@ void FGMassBalance::Debug(int from)
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 2) { // Loading
       FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-      log << endl << "  Mass and Balance:" << endl;
+      log << endl << "  Mass and Balance:" << endl << fixed;
       log << "    baseIxx: " << baseJ(1,1) << " slug-ft2" << endl;
       log << "    baseIyy: " << baseJ(2,2) << " slug-ft2" << endl;
       log << "    baseIzz: " << baseJ(3,3) << " slug-ft2" << endl;

--- a/src/models/FGModel.cpp
+++ b/src/models/FGModel.cpp
@@ -89,14 +89,14 @@ bool FGModel::InitModel(void)
 
 bool FGModel::Run(bool Holding)
 {
+  FGModel::Debug(2);
+
   if (rate == 1) return false; // Fast exit if nothing to do
 
   if (exe_ctr >= rate) exe_ctr = 0;
 
   if (exe_ctr++ == 1) return false;
   else              return true;
-
-  Debug(2);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -184,7 +184,7 @@ void FGModel::Debug(int from)
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
     FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-    log << "Entering Run() for model " << Name << endl;
+    if (from ==2) log << "Entering Run() for model " << Name << endl;
   }
   if (debug_lvl & 8 ) { // Runtime state variables
   }

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -83,7 +83,6 @@ CLASS IMPLEMENTATION
 FGPropagate::FGPropagate(FGFDMExec* fdmex)
   : FGModel(fdmex)
 {
-  Debug(0);
   Name = "FGPropagate";
 
   Inertial = FDMExec->GetInertial();
@@ -707,7 +706,7 @@ void FGPropagate::DumpState(void)
   log << endl;
   log << LogFormat::BLUE
       << "------------------------------------------------------------------" << LogFormat::RESET << endl;
-  log << LogFormat::BOLD
+  log << LogFormat::BOLD << fixed
       << "State Report at sim time: " << FDMExec->GetSimTime() << " seconds" << LogFormat::RESET << endl;
   log << "  " << LogFormat::UNDERLINE_ON
       << "Position" << LogFormat::UNDERLINE_OFF << endl;
@@ -945,7 +944,7 @@ void FGPropagate::Debug(int from)
   }
   if (debug_lvl & 8 && from == 2) { // Runtime state variables
     FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-    log << endl << LogFormat::BLUE << LogFormat::BOLD << left
+    log << endl << LogFormat::BLUE << LogFormat::BOLD << left << fixed
         << "  Propagation Report (English units: ft, degrees) at simulation time " << FDMExec->GetSimTime() << " seconds"
         << LogFormat::RESET << endl;
     log << endl;
@@ -1032,8 +1031,6 @@ void FGPropagate::Debug(int from)
     log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tl2i.GetQuaternion().GetEuler()*radtodeg)
                   << endl << endl;
-
-    log << setprecision(6); // reset the output stream
   }
   if (debug_lvl & 16) { // Sanity checking
     if (from == 2) { // State sanity checking


### PR DESCRIPTION
Following @seanmcleod's comment https://github.com/JSBSim-Team/jsbsim/pull/1136#issuecomment-2286717524, this PR introduces some fixes to the logging format as well as a bug fix. So when this PR will be merged, the output should have the same format as previously.

Regarding the bug fix: it is occurring when using the debug level 2 (`JSBSIM_DEBUG=2`) where the member `FGFDMExec::Log` is referenced after it is deleted. Below is a diagram of the call sequence when the instance of `FGFDMExec` is destroyed. Note that `FGAuxiliary::Debug` calls the constructor of `FGLogging` only if `if (debuglvl & 2 || debuglvl & 16)`:
```mermaid
graph TD;
  C1[("`**FGFDMExec**`")];
  M1[/"`*Log*`"/];
  D1[["~FGFDMExec"]];
  D2[["`*~FGInitialConditions*`"]];
  D3[["`*~FGAuxiliary*`"]];
  D4[["`*FGAuxiliary::Debug*`"]];
  L[["`*FGLogging*`"]];
  C1-->D1-->D2-->D3-->D4;
  D4-.->|"if (debuglvl & 2 || debuglvl & 16)"|L;
  C1-.->M1;
  L-->M1;
```
So the member `FGFDMExec::Log` is referenced by the destructor `~FGAuxiliary` which means that `FGFMExec::Log` must be destroyed **after** the instance of `FGAuxiliary`. This is achieved by moving the `Log` member at the top of the members declarations in the class `FGFDMExec` since C++ ensures that members are constructed in the order they are declared, and destructed in the reverse order of their declaration.
