### PR TITLE
Improve the performance of logging.

### DIFF
--- a/src/input_output/FGLog.cpp
+++ b/src/input_output/FGLog.cpp
@@ -53,10 +53,9 @@ void FGLogging::Flush(void)
   if (!message.empty()) {
     logger->Message(message);
     buffer.str("");
-    logger->Flush();
   }
 
-  buffer.clear();
+  logger->Flush();
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -104,29 +103,29 @@ void FGLogConsole::Format(LogFormat format) {
   switch (format)
   {
   case LogFormat::RED:
-    out << FGJSBBase::fgred;
+    buffer << FGJSBBase::fgred;
     break;
   case LogFormat::BLUE:
-    out << FGJSBBase::fgblue;
+    buffer << FGJSBBase::fgblue;
     break;
   case LogFormat::BOLD:
-    out << FGJSBBase::highint;
+    buffer << FGJSBBase::highint;
     break;
   case LogFormat::NORMAL:
-    out << FGJSBBase::normint;
+    buffer << FGJSBBase::normint;
     break;
   case LogFormat::UNDERLINE_ON:
-    out << FGJSBBase::underon;
+    buffer << FGJSBBase::underon;
     break;
   case LogFormat::UNDERLINE_OFF:
-    out << FGJSBBase::underoff;
+    buffer << FGJSBBase::underoff;
     break;
   case LogFormat::DEFAULT:
-    out << FGJSBBase::fgdef;
+    buffer << FGJSBBase::fgdef;
     break;
   case LogFormat::RESET:
   default:
-    out << FGJSBBase::reset;
+    buffer << FGJSBBase::reset;
     break;
   }
 }

--- a/src/input_output/FGLog.cpp
+++ b/src/input_output/FGLog.cpp
@@ -37,6 +37,8 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+#include <iostream>
+
 #include "FGLog.h"
 #include "input_output/FGXMLElement.h"
 
@@ -82,19 +84,22 @@ FGXMLLogging::FGXMLLogging(std::shared_ptr<FGLogger> logger, Element* el, LogLev
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGLogConsole::SetLevel(LogLevel level) {
-  FGLogger::SetLevel(level);
+void FGLogConsole::Flush(void) {
   switch (level)
   {
   case LogLevel::BULK:
   case LogLevel::DEBUG:
   case LogLevel::INFO:
-    out.tie(&std::cout);
+    std::cout << buffer.str();
+    std::cout.flush(); // Force the message to be immediately displayed in the console
     break;
   default:
-    out.tie(&std::cerr);
+    std::cerr << buffer.str();
+    std::cerr.flush(); // Force the message to be immediately displayed in the console
     break;
   }
+
+  buffer.str("");
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -152,20 +152,22 @@ public:
 
   void SetLevel(LogLevel level) override;
   void FileLocation(const std::string& filename, int line) override
-  { out << std::endl << "In file " << filename << ": line" << line << std::endl; }
+  { buffer << std::endl << "In file " << filename << ": line" << line << std::endl; }
   void Format(LogFormat format) override;
   void Flush(void) override {
+    out << buffer.str();
     out.flush();
-    out.clear();
+    buffer.str("");
   }
 
   void Message(const std::string& message) override {
     // if (level < min_level) return;
-    out << message;
+    buffer << message;
   }
 
 private:
   std::ostream out;
+  std::ostringstream buffer;
 };
 } // namespace JSBSim
 #endif

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -39,7 +39,6 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <iomanip>
-#include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -148,17 +147,10 @@ public:
 class JSBSIM_API FGLogConsole : public FGLogger
 {
 public:
-  FGLogConsole() : out(std::cout.rdbuf()) {}
-
-  void SetLevel(LogLevel level) override;
   void FileLocation(const std::string& filename, int line) override
   { buffer << std::endl << "In file " << filename << ": line" << line << std::endl; }
   void Format(LogFormat format) override;
-  void Flush(void) override {
-    out << buffer.str();
-    out.flush();
-    buffer.str("");
-  }
+  void Flush(void) override;
 
   void Message(const std::string& message) override {
     // if (level < min_level) return;
@@ -166,7 +158,6 @@ public:
   }
 
 private:
-  std::ostream out;
   std::ostringstream buffer;
 };
 } // namespace JSBSim


### PR DESCRIPTION
Following the concerns about the logging performance raised in comments https://github.com/JSBSim-Team/jsbsim/pull/1136#issuecomment-2286717524 and https://github.com/JSBSim-Team/jsbsim/pull/1141#issuecomment-2294839014, this PR submits some improvements to the logging code.

In this PR, the class `FGLogConsole` no longer redirects messages to `std::cout` or `std::cerr` as it receives them. Instead all the messages received from `FGLogging` are buffered and the whole message is sent all at once to `std::cout` or `std::cerr` when `FGLogConsole::Flush()` is called. This change significantly reduces the number of calls to `std::cout` and `std::cerr` which seem to be the bottleneck in the current code from the branch `master`.

|JSBSIM_DEBUG|v1.2.1|PR #1141|This PR| % improvement over #1141 | % over v1.2.1 |
|-|-|-|-|-|-|
|0|0.454s|0.453s|0.456s|+0.6%|+0.4%|
|1|0.445s|0.470s|0.468s|-0.5%|+5.2%|
|2|0.540s|0.620s|0.645s|+4.0%|+19.4%|
|4|1.392s|1.834s|1.769s|-3.5%|+27.1%|
|8|4.158s|5.821s|2.887s|-50.4%|-30.5%|
|9|4.225s|5.717s|2.908s|-49.1%|-31.2%|
|15|5.381s|7.276s|4.224s|-41.9%|-21.5%|

One can see that the major improvements are seen for debug levels that request heavy outputs. The improvements of this PR over PR #1141 are up to -50% ! The current code is even faster than the reference `v1.2.1` (i.e. pre-logging system) for debug levels higher than 8.

For low debug levels, some overhead still exists most likely due to the additional workload added by the `FGLogging` and `FGLogger` classes.

Note that `logger->Flush()` should be unconditionally called by `FGLogging:Flush()` for the output to be displayed in the console. Hence the change in `FGLog.cpp`.