### PR TITLE
Logging redesign - part 3

### DIFF
--- a/src/input_output/FGLog.cpp
+++ b/src/input_output/FGLog.cpp
@@ -85,7 +85,7 @@ FGXMLLogging::FGXMLLogging(std::shared_ptr<FGLogger> logger, Element* el, LogLev
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGLogConsole::Flush(void) {
-  switch (level)
+  switch (log_level)
   {
   case LogLevel::BULK:
   case LogLevel::DEBUG:

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -147,7 +147,7 @@ class JSBSIM_API FGLogConsole : public FGLogger
 public:
   void SetMinLevel(LogLevel level) { min_level = level; }
   void FileLocation(const std::string& filename, int line) override
-  { buffer << std::endl << "In file " << filename << ": line " << line << std::endl; }
+  { buffer << "\nIn file " << filename << ": line " << line << "\n"; }
   void Format(LogFormat format) override;
   void Flush(void) override;
 

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -97,13 +97,13 @@ class JSBSIM_API FGLogger
 {
 public:
   virtual ~FGLogger() {}
-  virtual void SetLevel(LogLevel l) { level = l; }
+  virtual void SetLevel(LogLevel level) { log_level = level;}
   virtual void FileLocation(const std::string& filename, int line) {}
   virtual void Message(const std::string& message) = 0;
   virtual void Format(LogFormat format) {}
   virtual void Flush(void) {}
 protected:
-  LogLevel level = LogLevel::BULK;
+  LogLevel log_level = LogLevel::BULK;
 };
 
 class JSBSIM_API FGLogging
@@ -152,7 +152,7 @@ public:
   void Flush(void) override;
 
   void Message(const std::string& message) override {
-    if (level < min_level) return;
+    if (log_level < min_level) return;
     buffer << message;
   }
 

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -99,13 +99,11 @@ public:
   virtual ~FGLogger() {}
   virtual void SetLevel(LogLevel l) { level = l; }
   virtual void FileLocation(const std::string& filename, int line) {}
-  void SetMinLevel(LogLevel level) { min_level = level; }
   virtual void Message(const std::string& message) = 0;
   virtual void Format(LogFormat format) {}
   virtual void Flush(void) {}
 protected:
   LogLevel level = LogLevel::BULK;
-  LogLevel min_level = LogLevel::INFO;
 };
 
 class JSBSIM_API FGLogging
@@ -147,18 +145,20 @@ public:
 class JSBSIM_API FGLogConsole : public FGLogger
 {
 public:
+  void SetMinLevel(LogLevel level) { min_level = level; }
   void FileLocation(const std::string& filename, int line) override
   { buffer << std::endl << "In file " << filename << ": line " << line << std::endl; }
   void Format(LogFormat format) override;
   void Flush(void) override;
 
   void Message(const std::string& message) override {
-    // if (level < min_level) return;
+    if (level < min_level) return;
     buffer << message;
   }
 
 private:
   std::ostringstream buffer;
+  LogLevel min_level = LogLevel::BULK;
 };
 } // namespace JSBSim
 #endif

--- a/src/models/FGAccelerations.cpp
+++ b/src/models/FGAccelerations.cpp
@@ -413,8 +413,8 @@ void FGAccelerations::Debug(int from)
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
     FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-    if (from == 0) log << "Instantiated: FGAccelerations" << endl;
-    if (from == 1) log << "Destroyed:    FGAccelerations" << endl;
+    if (from == 0) log << "Instantiated: FGAccelerations\n";
+    if (from == 1) log << "Destroyed:    FGAccelerations\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGAccelerations.cpp
+++ b/src/models/FGAccelerations.cpp
@@ -55,6 +55,7 @@ INCLUDES
 
 #include "FGAccelerations.h"
 #include "FGFDMExec.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -411,8 +412,9 @@ void FGAccelerations::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGAccelerations" << endl;
-    if (from == 1) cout << "Destroyed:    FGAccelerations" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGAccelerations" << endl;
+    if (from == 1) log << "Destroyed:    FGAccelerations" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGAerodynamics.cpp
+++ b/src/models/FGAerodynamics.cpp
@@ -233,8 +233,8 @@ bool FGAerodynamics::Run(bool Holding)
   default:
     {
       FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-      log << endl << "  A proper axis type has NOT been selected. Check "
-          << "your aerodynamics definition." << endl;
+      log << "\n  A proper axis type has NOT been selected. Check "
+          << "your aerodynamics definition.\n";
       throw BaseException(log.str());
     }
   }
@@ -279,8 +279,8 @@ bool FGAerodynamics::Run(bool Holding)
   default:
     {
       FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-      log << endl << "  A proper axis type has NOT been selected. Check "
-          << "your aerodynamics definition." << endl;
+      log << "\n  A proper axis type has NOT been selected. Check "
+          << "your aerodynamics definition.\n";
       throw BaseException(log.str());
     }
   }
@@ -381,20 +381,18 @@ bool FGAerodynamics::Load(Element *document)
       try {
         ca.push_back( new FGFunction(FDMExec, function_element) );
       } catch (const string& str) {
-        FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
-        log << endl << axis_element->ReadFrom()
-            << endl << LogFormat::RED << "Error loading aerodynamic function in "
-            << current_func_name << ":" << str << " Aborting." << LogFormat::RESET << endl;
+        FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::ERROR);
+        log << LogFormat::RED << "\nError loading aerodynamic function in "
+            << current_func_name << ":" << str << " Aborting.\n" << LogFormat::RESET;
         return false;
       }
       } else {
         try {
           ca_atCG.push_back( new FGFunction(FDMExec, function_element) );
         } catch (const string& str) {
-          FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
-          log << endl << axis_element->ReadFrom()
-              << endl << LogFormat::RED << "Error loading aerodynamic function in "
-              << current_func_name << ":" << str << " Aborting." << LogFormat::RESET << endl;
+          FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::ERROR);
+          log << LogFormat::RED << "\nError loading aerodynamic function in "
+              << current_func_name << ":" << str << " Aborting.\n" << LogFormat::RESET;
           return false;
         }
       }
@@ -467,26 +465,26 @@ void FGAerodynamics::DetermineAxisSystem(Element* document)
       if (forceAxisType == atNone) forceAxisType = atWind;
       else if (forceAxisType != atWind) {
         FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::WARN);
-        log << endl << "  Mixed aerodynamic axis systems have been used in the"
-            << " aircraft config file. (LIFT DRAG)" << endl;
+        log << "\n  Mixed aerodynamic axis systems have been used in the"
+            << " aircraft config file. (LIFT DRAG)\n";
       }
     } else if (axis == "SIDE") {
       if (forceAxisType != atNone && forceAxisType != atWind && forceAxisType != atBodyAxialNormal) {
         FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::WARN);
-        log << endl << "  Mixed aerodynamic axis systems have been used in the"
-            << " aircraft config file. (SIDE)" << endl;
+        log << "\n  Mixed aerodynamic axis systems have been used in the"
+            << " aircraft config file. (SIDE)\n";
       }
     } else if (axis == "AXIAL" || axis == "NORMAL") {
       if (forceAxisType == atNone) forceAxisType = atBodyAxialNormal;
       else if (forceAxisType != atBodyAxialNormal) {
         FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::WARN);
-        log << endl << "  Mixed aerodynamic axis systems have been used in the"
-            << " aircraft config file. (NORMAL AXIAL)" << endl;
+        log << "\n  Mixed aerodynamic axis systems have been used in the"
+            << " aircraft config file. (NORMAL AXIAL)\n";
       }
     } else { // error
       FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::FATAL);
-      log << endl << "  An unknown axis type, " << axis << " has been specified"
-          << " in the aircraft configuration file." << endl;
+      log << "\n  An unknown axis type, " << axis << " has been specified"
+          << " in the aircraft configuration file.\n";
       throw BaseException(log.str());
     }
     axis_element = document->FindNextElement("axis");
@@ -495,14 +493,14 @@ void FGAerodynamics::DetermineAxisSystem(Element* document)
   if (forceAxisType == atNone) {
     forceAxisType = atWind;
     FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
-    log << endl << "  The aerodynamic axis system has been set by default"
-        << " to the Lift/Side/Drag system." << endl;
+    log << "\n  The aerodynamic axis system has been set by default"
+        << " to the Lift/Side/Drag system.\n";
   }
   if (momentAxisType == atNone) {
     momentAxisType = atBodyXYZ;
     FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
-    log << endl << "  The aerodynamic moment axis system has been set by default"
-        << " to the bodyXYZ system." << endl;
+    log << "\n  The aerodynamic moment axis system has been set by default"
+        << " to the bodyXYZ system.\n";
   }
 }
 
@@ -516,29 +514,29 @@ void FGAerodynamics::ProcessAxesNameAndFrame(eAxisType& axisType, const string& 
     if (axisType == atNone) axisType = atBodyXYZ;
     else if (axisType != atBodyXYZ) {
       FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::WARN);
-      log << endl << " Mixed aerodynamic axis systems have been used in the "
-          << " aircraft config file." << validNames << " - BODY" << endl;
+      log << "\n Mixed aerodynamic axis systems have been used in the "
+          << " aircraft config file." << validNames << " - BODY\n";
     }
   }
   else if (frame == "STABILITY") {
     if (axisType == atNone) axisType = atStability;
     else if (axisType != atStability) {
       FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::WARN);
-      log << endl << " Mixed aerodynamic axis systems have been used in the "
-          << " aircraft config file." << validNames << " - STABILITY" << endl;
+      log << "\n Mixed aerodynamic axis systems have been used in the "
+          << " aircraft config file." << validNames << " - STABILITY\n";
     }
   }
   else if (frame == "WIND") {
     if (axisType == atNone) axisType = atWind;
     else if (axisType != atWind){
       FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::WARN);
-      log << endl << " Mixed aerodynamic axis systems have been used in the "
-          << " aircraft config file." << validNames << " - WIND" << endl;
+      log << "\n Mixed aerodynamic axis systems have been used in the "
+          << " aircraft config file." << validNames << " - WIND\n";
     }
   }
   else {
     FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::FATAL);
-    log << endl << " Unknown axis frame type of - " << frame << endl;
+    log << "\n Unknown axis frame type of - " << frame << "\n";
     throw BaseException(log.str());
   }
 }
@@ -703,27 +701,27 @@ void FGAerodynamics::Debug(int from)
       FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
       switch (forceAxisType) {
       case (atWind):
-        log << endl << "  Aerodynamics (Lift|Side|Drag axes):" << endl << endl;
+        log << "\n  Aerodynamics (Lift|Side|Drag axes):\n\n";
         break;
       case (atBodyAxialNormal):
-        log << endl << "  Aerodynamics (Axial|Side|Normal axes):" << endl << endl;
+        log << "\n  Aerodynamics (Axial|Side|Normal axes):\n\n";
         break;
       case (atBodyXYZ):
-        log << endl << "  Aerodynamics (Body X|Y|Z axes):" << endl << endl;
+        log << "\n  Aerodynamics (Body X|Y|Z axes):\n\n";
         break;
       case (atStability):
-        log << endl << "  Aerodynamics (Stability X|Y|Z axes):" << endl << endl;
+        log << "\n  Aerodynamics (Stability X|Y|Z axes):\n\n";
         break;
       case (atNone):
-        log << endl << "  Aerodynamics (undefined axes):" << endl << endl;
+        log << "\n  Aerodynamics (undefined axes):\n\n";
         break;
       }
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
     FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-    if (from == 0) log << "Instantiated: FGAerodynamics" << endl;
-    if (from == 1) log << "Destroyed:    FGAerodynamics" << endl;
+    if (from == 0) log << "Instantiated: FGAerodynamics\n";
+    if (from == 1) log << "Destroyed:    FGAerodynamics\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGAerodynamics.cpp
+++ b/src/models/FGAerodynamics.cpp
@@ -37,7 +37,9 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include "FGAerodynamics.h"
+#include "FGFDMExec.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -230,11 +232,10 @@ bool FGAerodynamics::Run(bool Holding)
     break;
   default:
     {
-      stringstream s;
-      s << "  A proper axis type has NOT been selected. Check "
-        << "your aerodynamics definition.";
-      cerr << endl << s.str() << endl;
-      throw BaseException(s.str());
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      log << endl << "  A proper axis type has NOT been selected. Check "
+          << "your aerodynamics definition." << endl;
+      throw BaseException(log.str());
     }
   }
   // Calculate aerodynamic reference point shift, if any. The shift takes place
@@ -277,11 +278,10 @@ bool FGAerodynamics::Run(bool Holding)
     break;
   default:
     {
-      stringstream s;
-      s << "  A proper axis type has NOT been selected. Check "
-        << "your aerodynamics definition.";
-      cerr << endl << s.str() << endl;
-      throw BaseException(s.str());
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      log << endl << "  A proper axis type has NOT been selected. Check "
+          << "your aerodynamics definition." << endl;
+      throw BaseException(log.str());
     }
   }
 
@@ -381,18 +381,20 @@ bool FGAerodynamics::Load(Element *document)
       try {
         ca.push_back( new FGFunction(FDMExec, function_element) );
       } catch (const string& str) {
-        cerr << endl << axis_element->ReadFrom()
-             << endl << fgred << "Error loading aerodynamic function in "
-             << current_func_name << ":" << str << " Aborting." << reset << endl;
+        FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+        log << endl << axis_element->ReadFrom()
+            << endl << LogFormat::RED << "Error loading aerodynamic function in "
+            << current_func_name << ":" << str << " Aborting." << LogFormat::RESET << endl;
         return false;
       }
       } else {
         try {
           ca_atCG.push_back( new FGFunction(FDMExec, function_element) );
         } catch (const string& str) {
-          cerr << endl << axis_element->ReadFrom()
-               << endl << fgred << "Error loading aerodynamic function in "
-               << current_func_name << ":" << str << " Aborting." << reset << endl;
+          FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+          log << endl << axis_element->ReadFrom()
+              << endl << LogFormat::RED << "Error loading aerodynamic function in "
+              << current_func_name << ":" << str << " Aborting." << LogFormat::RESET << endl;
           return false;
         }
       }
@@ -464,43 +466,43 @@ void FGAerodynamics::DetermineAxisSystem(Element* document)
     } else if (axis == "LIFT" || axis == "DRAG") {
       if (forceAxisType == atNone) forceAxisType = atWind;
       else if (forceAxisType != atWind) {
-        cerr << endl << axis_element->ReadFrom()
-             << endl << "  Mixed aerodynamic axis systems have been used in the"
-             << " aircraft config file. (LIFT DRAG)" << endl;
+        FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::WARN);
+        log << endl << "  Mixed aerodynamic axis systems have been used in the"
+            << " aircraft config file. (LIFT DRAG)" << endl;
       }
     } else if (axis == "SIDE") {
       if (forceAxisType != atNone && forceAxisType != atWind && forceAxisType != atBodyAxialNormal) {
-        cerr << endl << axis_element->ReadFrom()
-             << endl << "  Mixed aerodynamic axis systems have been used in the"
-             << " aircraft config file. (SIDE)" << endl;
+        FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::WARN);
+        log << endl << "  Mixed aerodynamic axis systems have been used in the"
+            << " aircraft config file. (SIDE)" << endl;
       }
     } else if (axis == "AXIAL" || axis == "NORMAL") {
       if (forceAxisType == atNone) forceAxisType = atBodyAxialNormal;
       else if (forceAxisType != atBodyAxialNormal) {
-        cerr << endl << axis_element->ReadFrom()
-             << endl << "  Mixed aerodynamic axis systems have been used in the"
-             << " aircraft config file. (NORMAL AXIAL)" << endl;
+        FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::WARN);
+        log << endl << "  Mixed aerodynamic axis systems have been used in the"
+            << " aircraft config file. (NORMAL AXIAL)" << endl;
       }
     } else { // error
-      stringstream s;
-      s << axis_element->ReadFrom()
-        << endl << "  An unknown axis type, " << axis << " has been specified"
-        << " in the aircraft configuration file.";
-      cerr << endl << s.str() << endl;
-      throw BaseException(s.str());
+      FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::FATAL);
+      log << endl << "  An unknown axis type, " << axis << " has been specified"
+          << " in the aircraft configuration file." << endl;
+      throw BaseException(log.str());
     }
     axis_element = document->FindNextElement("axis");
   }
 
   if (forceAxisType == atNone) {
     forceAxisType = atWind;
-    cerr << endl << "  The aerodynamic axis system has been set by default"
-                 << " to the Lift/Side/Drag system." << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
+    log << endl << "  The aerodynamic axis system has been set by default"
+        << " to the Lift/Side/Drag system." << endl;
   }
   if (momentAxisType == atNone) {
     momentAxisType = atBodyXYZ;
-    cerr << endl << "  The aerodynamic moment axis system has been set by default"
-      << " to the bodyXYZ system." << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
+    log << endl << "  The aerodynamic moment axis system has been set by default"
+        << " to the bodyXYZ system." << endl;
   }
 }
 
@@ -512,30 +514,32 @@ void FGAerodynamics::ProcessAxesNameAndFrame(eAxisType& axisType, const string& 
 {
   if (frame == "BODY" || frame.empty()) {
     if (axisType == atNone) axisType = atBodyXYZ;
-    else if (axisType != atBodyXYZ)
-      cerr << endl << el->ReadFrom()
-           << endl << " Mixed aerodynamic axis systems have been used in the "
-                   << " aircraft config file." << validNames << " - BODY" << endl;
+    else if (axisType != atBodyXYZ) {
+      FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::WARN);
+      log << endl << " Mixed aerodynamic axis systems have been used in the "
+          << " aircraft config file." << validNames << " - BODY" << endl;
+    }
   }
   else if (frame == "STABILITY") {
     if (axisType == atNone) axisType = atStability;
-    else if (axisType != atStability)
-      cerr << endl << el->ReadFrom()
-           << endl << " Mixed aerodynamic axis systems have been used in the "
-                   << " aircraft config file." << validNames << " - STABILITY" << endl;
+    else if (axisType != atStability) {
+      FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::WARN);
+      log << endl << " Mixed aerodynamic axis systems have been used in the "
+          << " aircraft config file." << validNames << " - STABILITY" << endl;
+    }
   }
   else if (frame == "WIND") {
     if (axisType == atNone) axisType = atWind;
-    else if (axisType != atWind)
-      cerr << endl << el->ReadFrom()
-           << endl << " Mixed aerodynamic axis systems have been used in the "
-                   << " aircraft config file." << validNames << " - WIND" << endl;
+    else if (axisType != atWind){
+      FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::WARN);
+      log << endl << " Mixed aerodynamic axis systems have been used in the "
+          << " aircraft config file." << validNames << " - WIND" << endl;
+    }
   }
   else {
-    stringstream s;
-    s << " Unknown axis frame type of - " << frame;
-    cerr << endl << s.str() << endl;
-    throw BaseException(s.str());
+    FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::FATAL);
+    log << endl << " Unknown axis frame type of - " << frame << endl;
+    throw BaseException(log.str());
   }
 }
 
@@ -696,28 +700,30 @@ void FGAerodynamics::Debug(int from)
 
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 2) { // Loader
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
       switch (forceAxisType) {
       case (atWind):
-        cout << endl << "  Aerodynamics (Lift|Side|Drag axes):" << endl << endl;
+        log << endl << "  Aerodynamics (Lift|Side|Drag axes):" << endl << endl;
         break;
       case (atBodyAxialNormal):
-        cout << endl << "  Aerodynamics (Axial|Side|Normal axes):" << endl << endl;
+        log << endl << "  Aerodynamics (Axial|Side|Normal axes):" << endl << endl;
         break;
       case (atBodyXYZ):
-        cout << endl << "  Aerodynamics (Body X|Y|Z axes):" << endl << endl;
+        log << endl << "  Aerodynamics (Body X|Y|Z axes):" << endl << endl;
         break;
       case (atStability):
-        cout << endl << "  Aerodynamics (Stability X|Y|Z axes):" << endl << endl;
+        log << endl << "  Aerodynamics (Stability X|Y|Z axes):" << endl << endl;
         break;
       case (atNone):
-        cout << endl << "  Aerodynamics (undefined axes):" << endl << endl;
+        log << endl << "  Aerodynamics (undefined axes):" << endl << endl;
         break;
       }
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGAerodynamics" << endl;
-    if (from == 1) cout << "Destroyed:    FGAerodynamics" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGAerodynamics" << endl;
+    if (from == 1) log << "Destroyed:    FGAerodynamics" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGAircraft.cpp
+++ b/src/models/FGAircraft.cpp
@@ -225,24 +225,24 @@ void FGAircraft::Debug(int from)
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 2) { // Loading
       FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-      log << endl << "  Aircraft Metrics:" << endl << fixed;
-      log << "    WingArea: " << WingArea  << endl;
-      log << "    WingSpan: " << WingSpan  << endl;
-      log << "    Incidence: " << WingIncidence << endl;
-      log << "    Chord: " << cbar << endl;
-      log << "    H. Tail Area: " << HTailArea << endl;
-      log << "    H. Tail Arm: " << HTailArm << endl;
-      log << "    V. Tail Area: " << VTailArea << endl;
-      log << "    V. Tail Arm: " << VTailArm << endl;
-      log << "    Eyepoint (x, y, z): " << vXYZep << endl;
-      log << "    Ref Pt (x, y, z): " << vXYZrp << endl;
-      log << "    Visual Ref Pt (x, y, z): " << vXYZvrp << endl;
+      log << "\n  Aircraft Metrics:\n"  << fixed;
+      log << "    WingArea: " << WingArea  << "\n";
+      log << "    WingSpan: " << WingSpan  << "\n";
+      log << "    Incidence: " << WingIncidence << "\n";
+      log << "    Chord: " << cbar << "\n";
+      log << "    H. Tail Area: " << HTailArea << "\n";
+      log << "    H. Tail Arm: " << HTailArm << "\n";
+      log << "    V. Tail Area: " << VTailArea << "\n";
+      log << "    V. Tail Arm: " << VTailArm << "\n";
+      log << "    Eyepoint (x, y, z): " << vXYZep << "\n";
+      log << "    Ref Pt (x, y, z): " << vXYZrp << "\n";
+      log << "    Visual Ref Pt (x, y, z): " << vXYZvrp << "\n";
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
     FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-    if (from == 0) log << "Instantiated: FGAircraft" << endl;
-    if (from == 1) log << "Destroyed:    FGAircraft" << endl;
+    if (from == 0) log << "Instantiated: FGAircraft\n";
+    if (from == 1) log << "Destroyed:    FGAircraft\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGAircraft.cpp
+++ b/src/models/FGAircraft.cpp
@@ -39,7 +39,9 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include "FGAircraft.h"
+#include "FGFDMExec.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -222,23 +224,25 @@ void FGAircraft::Debug(int from)
 
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 2) { // Loading
-      cout << endl << "  Aircraft Metrics:" << endl;
-      cout << "    WingArea: " << WingArea  << endl;
-      cout << "    WingSpan: " << WingSpan  << endl;
-      cout << "    Incidence: " << WingIncidence << endl;
-      cout << "    Chord: " << cbar << endl;
-      cout << "    H. Tail Area: " << HTailArea << endl;
-      cout << "    H. Tail Arm: " << HTailArm << endl;
-      cout << "    V. Tail Area: " << VTailArea << endl;
-      cout << "    V. Tail Arm: " << VTailArm << endl;
-      cout << "    Eyepoint (x, y, z): " << vXYZep << endl;
-      cout << "    Ref Pt (x, y, z): " << vXYZrp << endl;
-      cout << "    Visual Ref Pt (x, y, z): " << vXYZvrp << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      log << endl << "  Aircraft Metrics:" << endl << fixed;
+      log << "    WingArea: " << WingArea  << endl;
+      log << "    WingSpan: " << WingSpan  << endl;
+      log << "    Incidence: " << WingIncidence << endl;
+      log << "    Chord: " << cbar << endl;
+      log << "    H. Tail Area: " << HTailArea << endl;
+      log << "    H. Tail Arm: " << HTailArm << endl;
+      log << "    V. Tail Area: " << VTailArea << endl;
+      log << "    V. Tail Arm: " << VTailArm << endl;
+      log << "    Eyepoint (x, y, z): " << vXYZep << endl;
+      log << "    Ref Pt (x, y, z): " << vXYZrp << endl;
+      log << "    Visual Ref Pt (x, y, z): " << vXYZvrp << endl;
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGAircraft" << endl;
-    if (from == 1) cout << "Destroyed:    FGAircraft" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGAircraft" << endl;
+    if (from == 1) log << "Destroyed:    FGAircraft" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGBuoyantForces.cpp
+++ b/src/models/FGBuoyantForces.cpp
@@ -39,6 +39,7 @@ INCLUDES
 #include "FGFDMExec.h"
 #include "FGBuoyantForces.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -126,7 +127,7 @@ bool FGBuoyantForces::Load(Element *document)
     Cells.push_back(new FGGasCell(FDMExec, gas_cell_element, Cells.size(), in));
     gas_cell_element = document->FindNextElement("gas_cell");
   }
-  
+
   PostLoad(document, FDMExec);
 
   if (!NoneDefined) {
@@ -165,7 +166,7 @@ const FGColumnVector3& FGBuoyantForces::GetGasMassMoment(void)
 const FGMatrix33& FGBuoyantForces::GetGasMassInertia(void)
 {
   size_t size = Cells.size();
-  
+
   if (size == 0) return gasCellJ;
 
   gasCellJ.InitMatrix();
@@ -173,7 +174,7 @@ const FGMatrix33& FGBuoyantForces::GetGasMassInertia(void)
   for (unsigned int i=0; i < size; i++) {
     gasCellJ += Cells[i]->GetInertia();
   }
-  
+
   return gasCellJ;
 }
 
@@ -281,12 +282,14 @@ void FGBuoyantForces::Debug(int from)
 
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 2) { // Loader
-      cout << endl << "  Buoyant Forces: " << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      log << endl << "  Buoyant Forces: " << endl;
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGBuoyantForces" << endl;
-    if (from == 1) cout << "Destroyed:    FGBuoyantForces" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGBuoyantForces" << endl;
+    if (from == 1) log << "Destroyed:    FGBuoyantForces" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGBuoyantForces.cpp
+++ b/src/models/FGBuoyantForces.cpp
@@ -283,13 +283,13 @@ void FGBuoyantForces::Debug(int from)
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 2) { // Loader
       FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-      log << endl << "  Buoyant Forces: " << endl;
+      log << "\n  Buoyant Forces: \n";
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
     FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-    if (from == 0) log << "Instantiated: FGBuoyantForces" << endl;
-    if (from == 1) log << "Destroyed:    FGBuoyantForces" << endl;
+    if (from == 0) log << "Instantiated: FGBuoyantForces\n";
+    if (from == 1) log << "Destroyed:    FGBuoyantForces\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGExternalForce.cpp
+++ b/src/models/FGExternalForce.cpp
@@ -95,8 +95,7 @@ FGParameter* FGExternalForce::bind(Element *el, const string& magName,
   if (sFrame.empty()) {
     FGXMLLogging log(fdmex->GetLogger(), el, LogLevel::WARN);
     log << "No frame specified for external " << el->GetName() << ", \""
-        << Name << "\"." << endl
-        << "Frame set to Body" << endl;
+        << Name << "\".\nFrame set to Body\n";
     ttype = tNone;
   } else if (sFrame == "BODY") {
     ttype = tNone;
@@ -109,8 +108,7 @@ FGParameter* FGExternalForce::bind(Element *el, const string& magName,
   } else {
     FGXMLLogging log(fdmex->GetLogger(), el, LogLevel::WARN);
     log << "Invalid frame specified for external " << el->GetName() << ", \""
-        << Name << "\"." << endl
-        << "Frame set to Body" << endl;
+        << Name << "\".\nFrame set to Body\n";
     ttype = tNone;
   }
 
@@ -118,7 +116,7 @@ FGParameter* FGExternalForce::bind(Element *el, const string& magName,
   if (!direction_element) {
     FGXMLLogging log(fdmex->GetLogger(), el, LogLevel::WARN);
     log << "No direction element specified in " << el->GetName()
-        << " object. Default is (0,0,0)." << endl;
+        << " object. Default is (0,0,0).\n";
   } else {
     FGColumnVector3 direction = direction_element->FindElementTripletConvertTo("IN");
     direction.Normalize();
@@ -156,7 +154,7 @@ void FGExternalForce::setForce(Element *el)
   Element* location_element = el->FindElement("location");
   if (!location_element) {
     FGXMLLogging log(fdmex->GetLogger(), el, LogLevel::WARN);
-    log << "No location element specified in force object." << endl;
+    log << "No location element specified in force object.\n";
   } else {
     FGColumnVector3 location = location_element->FindElementTripletConvertTo("IN");
     SetLocation(location);
@@ -231,8 +229,8 @@ void FGExternalForce::Debug(int from)
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 0) { // Constructor
       FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
-      log << "    " << Name << endl;
-      log << "    Frame: ";
+      log << "    " << Name;
+      log << "\n    Frame: ";
       switch(ttype) {
       case tNone:
         log << "BODY";
@@ -249,13 +247,14 @@ void FGExternalForce::Debug(int from)
       default:
         log << "ERROR/UNKNOWN";
       }
-      log << endl << "    Location: (" << vXYZn(eX) << ", " << vXYZn(eY) << ", " << vXYZn(eZ) << ")" << endl;
+      log << "\n    Location: (" << fixed << vXYZn(eX) << ", " << vXYZn(eY)
+          << ", " << vXYZn(eZ) << ")\n";
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
     FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
-    if (from == 0) log << "Instantiated: FGExternalForce" << endl;
-    if (from == 1) log << "Destroyed:    FGExternalForce" << endl;
+    if (from == 0) log << "Instantiated: FGExternalForce\n";
+    if (from == 1) log << "Destroyed:    FGExternalForce\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGExternalForce.cpp
+++ b/src/models/FGExternalForce.cpp
@@ -31,9 +31,9 @@
 
     <!-- Interface properties, a.k.a. property declarations -->
     <property> ... </property>
-      
+
     <force name="name" frame="BODY|LOCAL|WIND">
-      
+
       <function> ... </function>
 
       <location unit="units"> <!-- location -->
@@ -66,6 +66,7 @@
 #include "FGFDMExec.h"
 #include "FGExternalForce.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -92,10 +93,10 @@ FGParameter* FGExternalForce::bind(Element *el, const string& magName,
   // Set frame (from FGForce).
   string sFrame = el->GetAttributeValue("frame");
   if (sFrame.empty()) {
-    cerr << el->ReadFrom()
-         << "No frame specified for external " << el->GetName() << ", \""
-         << Name << "\"." << endl
-         << "Frame set to Body" << endl;
+    FGXMLLogging log(fdmex->GetLogger(), el, LogLevel::WARN);
+    log << "No frame specified for external " << el->GetName() << ", \""
+        << Name << "\"." << endl
+        << "Frame set to Body" << endl;
     ttype = tNone;
   } else if (sFrame == "BODY") {
     ttype = tNone;
@@ -106,18 +107,18 @@ FGParameter* FGExternalForce::bind(Element *el, const string& magName,
   } else if (sFrame == "INERTIAL") {
     ttype = tInertialBody;
   } else {
-    cerr << el->ReadFrom()
-         << "Invalid frame specified for external " << el->GetName() << ", \""
-         << Name << "\"." << endl
-         << "Frame set to Body" << endl;
+    FGXMLLogging log(fdmex->GetLogger(), el, LogLevel::WARN);
+    log << "Invalid frame specified for external " << el->GetName() << ", \""
+        << Name << "\"." << endl
+        << "Frame set to Body" << endl;
     ttype = tNone;
   }
 
   Element* direction_element = el->FindElement("direction");
   if (!direction_element) {
-    cerr << el->ReadFrom()
-         << "No direction element specified in " << el->GetName()
-         << " object. Default is (0,0,0)." << endl;
+    FGXMLLogging log(fdmex->GetLogger(), el, LogLevel::WARN);
+    log << "No direction element specified in " << el->GetName()
+        << " object. Default is (0,0,0)." << endl;
   } else {
     FGColumnVector3 direction = direction_element->FindElementTripletConvertTo("IN");
     direction.Normalize();
@@ -154,8 +155,8 @@ void FGExternalForce::setForce(Element *el)
 
   Element* location_element = el->FindElement("location");
   if (!location_element) {
-    cerr << el->ReadFrom()
-         << "No location element specified in force object." << endl;
+    FGXMLLogging log(fdmex->GetLogger(), el, LogLevel::WARN);
+    log << "No location element specified in force object." << endl;
   } else {
     FGColumnVector3 location = location_element->FindElementTripletConvertTo("IN");
     SetLocation(location);
@@ -229,30 +230,32 @@ void FGExternalForce::Debug(int from)
 
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 0) { // Constructor
-      cout << "    " << Name << endl;
-      cout << "    Frame: ";
+      FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+      log << "    " << Name << endl;
+      log << "    Frame: ";
       switch(ttype) {
       case tNone:
-        cout << "BODY";
+        log << "BODY";
         break;
       case tLocalBody:
-        cout << "LOCAL";
+        log << "LOCAL";
         break;
       case tWindBody:
-        cout << "WIND";
+        log << "WIND";
         break;
       case tInertialBody:
-        cout << "INERTIAL";
+        log << "INERTIAL";
         break;
       default:
-        cout << "ERROR/UNKNOWN";
+        log << "ERROR/UNKNOWN";
       }
-      cout << endl << "    Location: (" << vXYZn(eX) << ", " << vXYZn(eY) << ", " << vXYZn(eZ) << ")" << endl;
+      log << endl << "    Location: (" << vXYZn(eX) << ", " << vXYZn(eY) << ", " << vXYZn(eZ) << ")" << endl;
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGExternalForce" << endl;
-    if (from == 1) cout << "Destroyed:    FGExternalForce" << endl;
+    FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGExternalForce" << endl;
+    if (from == 1) log << "Destroyed:    FGExternalForce" << endl;
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/FGFCSChannel.h
+++ b/src/models/FGFCSChannel.h
@@ -101,7 +101,7 @@ public:
       return FCSComponents[i];
     } else {
       FGLogging log(fcs->GetExec()->GetLogger(), LogLevel::ERROR);
-      log << "Tried to get nonexistent component" << std::endl;
+      log << "Tried to get nonexistent component\n";
       return nullptr;
     }
   }

--- a/src/models/FGFCSChannel.h
+++ b/src/models/FGFCSChannel.h
@@ -53,12 +53,12 @@ CLASS DOCUMENTATION
   /** Represents a <channel> in a control system definition.
       The <channel> may be defined within a <system>, <autopilot> or <flight_control>
       element. Channels are a way to group sets of components that perform
-      a specific purpose or algorithm. 
+      a specific purpose or algorithm.
       Created within a <system> tag, the channel is defined as follows
       <channel name="name" [execute="property"] [execrate="rate"]>
       name is the name of the channel - in the old way this would also be used to bind elements
       execute [optional] is the property that defines when to execute this channel; an on/off switch
-      execrate [optional] is the rate at which the channel should execute. 
+      execrate [optional] is the rate at which the channel should execute.
                A value of 0 or 1 will execute the channel every frame, a value of 2
                every other frame (half rate), a value of 4 is every 4th frame (quarter rate)
       */
@@ -97,11 +97,12 @@ public:
   size_t GetNumComponents() {return FCSComponents.size();}
   /// Retrieves a specific component.
   FGFCSComponent* GetComponent(unsigned int i) {
-    if (i >= GetNumComponents()) {
-      std::cerr << "Tried to get nonexistent component" << std::endl;
-      return 0;
-    } else {
+    if (i < GetNumComponents()) {
       return FCSComponents[i];
+    } else {
+      FGLogging log(fcs->GetExec()->GetLogger(), LogLevel::ERROR);
+      log << "Tried to get nonexistent component" << std::endl;
+      return nullptr;
     }
   }
   /// Reset the components that can be reset
@@ -131,7 +132,7 @@ public:
     // channel will be run at rate 1 if trimming, or when the next execrate
     // frame is reached
     if (fcs->GetTrimStatus() || ExecFrameCountSinceLastRun >= ExecRate) {
-      for (unsigned int i=0; i<FCSComponents.size(); i++) 
+      for (unsigned int i=0; i<FCSComponents.size(); i++)
         FCSComponents[i]->Run();
     }
   }

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -458,7 +458,7 @@ void FGMassBalance::GetMassPropertiesReport(int i)
       << "    CG-Z         Ixx         Iyy         Izz"
       << "         Ixy         Ixz         Iyz" << LogFormat::UNDERLINE_OFF << endl;
   log << fixed << setprecision(1);
-  log << LogFormat::BOLD << setw(34) << left << "    Base Vehicle " << normint
+  log << LogFormat::BOLD << setw(34) << left << "    Base Vehicle " << LogFormat::NORMAL
       << right << setw(12) << EmptyWeight
       << setw(8) << vbaseXYZcg(eX) << setw(8) << vbaseXYZcg(eY) << setw(8) << vbaseXYZcg(eZ)
       << setw(12) << baseJ(1,1) << setw(12) << baseJ(2,2) << setw(12) << baseJ(3,3)
@@ -467,7 +467,7 @@ void FGMassBalance::GetMassPropertiesReport(int i)
   for (unsigned int i=0;i<PointMasses.size();i++) {
     PointMass* pm = PointMasses[i];
     double pmweight = pm->GetPointMassWeight();
-    log << LogFormat::BOLD << left << setw(4) << i << setw(30) << pm->GetName() << normint
+    log << LogFormat::BOLD << left << setw(4) << i << setw(30) << pm->GetName() << LogFormat::NORMAL
         << right << setw(12) << pmweight << setw(8) << pm->GetLocation()(eX)
         << setw(8) << pm->GetLocation()(eY) << setw(8) << pm->GetLocation()(eZ)
         << setw(12) << pm->GetPointMassMoI(1,1) << setw(12) << pm->GetPointMassMoI(2,2) << setw(12) << pm->GetPointMassMoI(3,3)

--- a/tests/unit_tests/FGLogTest.h
+++ b/tests/unit_tests/FGLogTest.h
@@ -5,7 +5,7 @@
 class DummyLogger : public JSBSim::FGLogger
 {
 public:
-  JSBSim::LogLevel GetLogLevel() const { return level; }
+  JSBSim::LogLevel GetLogLevel() const { return log_level; }
   void Message(const std::string& message) override { buffer.append(message); }
   void FileLocation(const std::string& filename, int line) override {
     buffer.append(filename);

--- a/tests/unit_tests/FGLogTest.h
+++ b/tests/unit_tests/FGLogTest.h
@@ -306,6 +306,24 @@ void testXMLLogging() {
   TS_ASSERT_EQUALS(buffer.str(), "\nIn file name.xml: line 42\n");
 }
 
+void testMinLevel() {
+  auto logger = std::make_shared<JSBSim::FGLogConsole>();
+  logger->SetMinLevel(JSBSim::LogLevel::DEBUG);
+  std::ostringstream buffer;
+  auto cout_buffer = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+  {
+    JSBSim::FGLogging log(logger, JSBSim::LogLevel::BULK);
+    log << "BULK";
+  }
+  {
+    JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
+    log << "INFO";
+  }
+  std::cout.rdbuf(cout_buffer);
+  TS_ASSERT_EQUALS(buffer.str(), "INFO");
+}
+
 void testRedFormat() {
   auto logger = std::make_shared<JSBSim::FGLogConsole>();
   std::ostringstream buffer;


### PR DESCRIPTION
After some consolidation of the logging code (PR #1141, ##1142 and ##1145), this PR resumes the migration of the code to the new logging system.

I took this opportunity to:
* Rename the member of `FGLogging` from `level` to `log_level` for more clarity and to avoid confusion with the method parameters of `FGLogging` which tend to be named `level` as well.
* The minimum level feature has been moved from `FGLogger` to `FGLogConsole` as I think the implementation of this feature should not be imposed by the mother class `FGLogger`.
  * The unit test of `FGLogConsole` has been extended to check that the minimum logged level behave as intended.
  * The minimum logged level default is set to `LogLevel::BULK` so that it does not filter anything by default.

There are also a few white spaces changes because I've set my editor to remove trailing spaces before saving. Yes I'm that kind of person who can't resist taking care of this kind of futile details :smile: 