### PR TITLE
Fixed multiple root elements in JSBSimForUnreal.vcxproj

### DIFF
--- a/JSBSimForUnreal.vcxproj
+++ b/JSBSimForUnreal.vcxproj
@@ -385,7 +385,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-</Project>
   <ItemDefinitionGroup>
     <PostBuildEvent>
         <Command>mkdir UnrealEngine\Plugins\JSBSimFlightDynamicsModel\Source\ThirdParty\JSBSim\Include
@@ -408,3 +407,4 @@
   exit/B %errlev%</Command>
       </PostBuildEvent>
   </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
It looks like [PR 1119](https://github.com/JSBSim-Team/jsbsim/pull/1119) broke the `JSBSimForUnreal.vcxproj` by applying their change outside of the `<Project>` element. I moved their change back within `<Project>` which fixed the issue for myself. One other user also confirmed this change was broken for them too.