### PR TITLE
Render debug data and visuals after actor's pose is updated

### DIFF
--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
@@ -291,13 +291,6 @@ void UJSBSimMovementComponent::TickComponent(float DeltaTime, ELevelTick TickTyp
             // Get the results from JSBSim
 			CopyFromJSBSim();
 
-            // Basic debugging string and symbols
-			if (DrawDebug)
-			{
-				DrawDebugMessage();
-				DrawDebugObjects();
-			}
-
             // Transform the aircraft coordinates from ECEF Frame to UE Frame, using the georeferencing plugin.
 			if (Parent)
 			{
@@ -322,6 +315,14 @@ void UJSBSimMovementComponent::TickComponent(float DeltaTime, ELevelTick TickTyp
 				// Apply the transform to the Parent actor			
 				Parent->SetActorLocationAndRotation(EngineLocation, EngineRotationQuat);
 			}
+
+      // Basic debugging string and symbols
+      if (DrawDebug)
+      {
+        DrawDebugMessage();
+        DrawDebugObjects();
+      }
+
 		}
 	}
 


### PR DESCRIPTION
Based on the discussion in https://github.com/JSBSim-Team/jsbsim/discussions/1160 it was determined that the debug data strings and lines for gear positions etc. were being rendered before the actor's pose had been updated for the latest frame. Which meant the debug data would be displaying slightly out of date data causing potential confusion.