### PR TITLE
Consistency for some FGFDMExec properties

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -168,8 +168,8 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   instance->Tie("simulation/reset", this, (iPMF)0, &FGFDMExec::ResetToInitialConditions);
   instance->Tie("simulation/disperse", this, &FGFDMExec::GetDisperse);
   instance->Tie("simulation/randomseed", this, (iPMF)&FGFDMExec::SRand, &FGFDMExec::SRand);
-  instance->Tie("simulation/terminate", (int *)&Terminate);
-  instance->Tie("simulation/pause", (int *)&holding);
+  instance->Tie("simulation/terminate", (bool *)&Terminate);
+  instance->Tie("simulation/pause", (bool *)&holding);
   instance->Tie("simulation/sim-time-sec", this, &FGFDMExec::GetSimTime);
   instance->Tie("simulation/dt", this, &FGFDMExec::GetDeltaT);
   instance->Tie("simulation/jsbsim-debug", this, &FGFDMExec::GetDebugLevel, &FGFDMExec::SetDebugLevel);

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -637,7 +637,7 @@ private:
   unsigned int Frame;
   unsigned int IdFDM;
   int disperse;
-  unsigned short Terminate;
+  bool Terminate;
   double dT;
   double saved_dT;
   double sim_time;


### PR DESCRIPTION
Based on a PowerPC specific difference mentioned in - https://github.com/JSBSim-Team/jsbsim/issues/834#issuecomment-2380057224 some inconsistency with regards to how boolean like properties where being implemented specifically with regards to exposing them to the JSBSim property tree.

This PR implements a consistent approach for these boolean properties.