### PR TITLE
Add roundmultiple function

### DIFF
--- a/JSBSim.xsd
+++ b/JSBSim.xsd
@@ -1426,6 +1426,7 @@
       <xs:element name="random"/>
       <xs:element name="urandom"/>
       <xs:element name="pi"/>
+      <xs:element name="roundmultiple"/>
       <!--xs:element ref="rotation_alpha_local" /-->
       <!--xs:element ref="rotation_beta_local" /-->
       <!--xs:element ref="rotation_gamma_local" /-->
@@ -1625,7 +1626,15 @@
     </xs:complexType>
   </xs:element>
   <xs:element name="value" type="xs:double" />
-
+  <xs:element name="roundmultiple">
+    <xs:complexType>
+	  <xs:choice maxOccurs="2" minOccurs="1">
+        <xs:group ref="func_group" />
+        <xs:element ref="value" />
+        <xs:element ref="property" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="mod">
     <xs:complexType>
       <xs:choice maxOccurs="2" minOccurs="2">

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -527,6 +527,15 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
                  return y != 0.0 ? fmod(p[0]->GetValue(), y) : HUGE_VAL;
                };
       Parameters.push_back(new aFunc<decltype(f), 2>(f, fdmex, element, Prefix, var));
+    } else if (operation == "roundmultiple") {
+      auto f = [](const decltype(Parameters)& p)->double {
+                 double multiple = p.size() == 1 ? 1.0 : p[1]->GetValue();
+                 return round((p[0]->GetValue() / multiple)) * multiple;
+               };
+      if (element->GetNumElements() == 1)
+        Parameters.push_back(new aFunc<decltype(f), 1>(f, fdmex, element, Prefix, var));
+      else
+        Parameters.push_back(new aFunc<decltype(f), 2>(f, fdmex, element, Prefix, var));
     } else if (operation == "atan2") {
       auto f = [](const decltype(Parameters)& p)->double {
                  return atan2(p[0]->GetValue(), p[1]->GetValue());

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -533,7 +533,7 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
                  return round((p[0]->GetValue() / multiple)) * multiple;
                };
       if (element->GetNumElements() == 1)
-        Parameters.push_back(new aFunc<decltype(f), 1>(f, fdmex, element, Prefix, var));
+        Parameters.push_back(make_MathFn(round, fdmex, element, Prefix, var));
       else
         Parameters.push_back(new aFunc<decltype(f), 2>(f, fdmex, element, Prefix, var));
     } else if (operation == "atan2") {

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -535,7 +535,7 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
       if (element->GetNumElements() == 1)
         Parameters.push_back(make_MathFn(round, fdmex, element, Prefix, var));
       else
-        Parameters.push_back(new aFunc<decltype(f), 2>(f, fdmex, element, Prefix, var));
+        Parameters.push_back(new aFunc<decltype(f), 1>(f, fdmex, element, Prefix, var, 2));
     } else if (operation == "atan2") {
       auto f = [](const decltype(Parameters)& p)->double {
                  return atan2(p[0]->GetValue(), p[1]->GetValue());

--- a/src/math/FGFunction.h
+++ b/src/math/FGFunction.h
@@ -88,6 +88,7 @@ A function definition consists of an operation, a value, a table, or a property
 - floor (takes 1 arg)
 - ceil (takes 1 arg)
 - fmod (takes 2 args)
+- roundmultiple (takes 2 args)
 - lt (less than, takes 2 args)
 - le (less equal, takes 2 args)
 - gt (greater than, takes 2 args)
@@ -511,6 +512,15 @@ refers to one or more instances of a property, value, or table.
     </fmod>
     @endcode
     Example: fmod(18.5, 4.2) evaluates to 1.7
+- @b roundmultiple returns the floating-point rounding of X to a multiple of M.
+                   round(X/M) * M
+    @code
+    <roundmultiple>
+      {property, value, table, or other function element}
+      {property, value, table, or other function element}
+    </roundmultiple>
+    @endcode
+    Example: roundmultiple(93.43, 5.0) evaluates to 95.0
 - @b lt returns a 1 if the value of the first immediate child element is less
         than the value of the second immediate child element, returns 0
         otherwise


### PR DESCRIPTION
Based on the request and discussions in issue - https://github.com/JSBSim-Team/jsbsim/issues/1159

I'm in 2 minds whether to rather add a separate `round(x)` function in addition to `roundmultiple(x, m)` where currently if no second argument is provided to `roundmultiple` then it assumes a value of 1.