### PR TITLE
Fix an uninitialized variable in GeographicLib.

### DIFF
--- a/src/GeographicLib/Geodesic.cpp
+++ b/src/GeographicLib/Geodesic.cpp
@@ -206,7 +206,7 @@ namespace GeographicLib {
     // check, e.g., on verifying quadrants in atan2.  In addition, this
     // enforces some symmetries in the results returned.
 
-    real sbet1, cbet1, sbet2, cbet2, s12x, m12x;
+    real sbet1, cbet1, sbet2, cbet2, s12x, m12x = 0.0;
 
     Math::sincosd(lat1, sbet1, cbet1); sbet1 *= _f1;
     // Ensure cbet1 = +epsilon at poles; doing the fix on beta means that sig12

--- a/src/GeographicLib/Geodesic.cpp
+++ b/src/GeographicLib/Geodesic.cpp
@@ -206,7 +206,7 @@ namespace GeographicLib {
     // check, e.g., on verifying quadrants in atan2.  In addition, this
     // enforces some symmetries in the results returned.
 
-    real sbet1, cbet1, sbet2, cbet2, s12x, m12x = 0.0;
+    real sbet1, cbet1, sbet2, cbet2, s12x, m12x = Math::NaN();
 
     Math::sincosd(lat1, sbet1, cbet1); sbet1 *= _f1;
     // Ensure cbet1 = +epsilon at poles; doing the fix on beta means that sig12

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -292,7 +292,7 @@ int main(int argc, char* argv[])
   _controlfp(_controlfp(0, 0) & ~(_EM_INVALID | _EM_ZERODIVIDE | _EM_OVERFLOW),
            _MCW_EM);
 #elif defined(__GNUC__) && !defined(sgi) && !defined(__APPLE__)
-  feenableexcept(FE_DIVBYZERO | FE_INVALID);
+  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
 #endif
 
   try {


### PR DESCRIPTION
Fixes the issue #475.

~~Unlike the option that has been chosen by the GeographicLib project (see https://github.com/geographiclib/geographiclib/issues/33#issuecomment-2408610762), the variable `m12x` is set to zero, instead of `Math::NaN`, to avoid raising floating point exceptions.~~

A new floating point exception flag `FE_OVERFLOW` has also been added to `JSBSim.cpp` because it is the exception that is triggered by this bug and `JSBSim.cpp` was not catching it on Linux. This setting helped debugging the issue while running the script `c3101.xml` on an Ubuntu distribution.

**UPDATE:** The variable `m12x` is initialized to `Math::NaN` as in the GeographicLib project. See the discussion below for details.