### PR TITLE
Upgrade `macos-12` runners to `macos-13`.

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-12, ubuntu-22.04, windows-latest ]
+        os: [ macos-13, ubuntu-22.04, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout JSBSim
@@ -438,7 +438,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-13]
         python-version: [3.8]
         include:
           - os: macos-14
@@ -467,7 +467,7 @@ jobs:
       - name: Set up Julia
         uses: julia-actions/setup-julia@v2
       - name: Install & Configure Doxygen
-        if: env.release == 'true' && matrix.os == 'macos-12'
+        if: env.release == 'true' && matrix.os == 'macos-13'
         run: |
           brew install doxygen
           # We don't want Doxygen to generate the HTML docs in this job (saves time)
@@ -496,7 +496,7 @@ jobs:
         working-directory: build
         run: ctest --parallel $(sysctl -n hw.logicalcpu) --output-on-failure
       - name: Build the source package for Python
-        if: env.release == 'true' && matrix.os == 'macos-12'
+        if: env.release == 'true' && matrix.os == 'macos-13'
         working-directory: build/tests
         run: |
           echo "::group::Build the type hints stubs"
@@ -522,7 +522,7 @@ jobs:
 
       - name: Upload Files for Release
         uses: actions/upload-artifact@v4
-        if: env.release == 'true' && matrix.os == 'macos-12'
+        if: env.release == 'true' && matrix.os == 'macos-13'
         with:
           name: ${{ runner.os }}.binaries
           path: |
@@ -585,7 +585,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-2019]
+        os: [ubuntu-latest, macos-13, windows-2019]
 
     steps:
       - name: Checkout JSBSim
@@ -602,7 +602,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install doxygen
       - name: Install Doxygen (MacOSX)
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-13'
         run: brew install doxygen
       - name: Install Doxygen (Windows)
         if: runner.os == 'Windows'

--- a/tests/unit_tests/FGInitialConditionTest.h
+++ b/tests/unit_tests/FGInitialConditionTest.h
@@ -137,8 +137,8 @@ public:
           TS_ASSERT_DELTA(ic.GetLongitudeDegIC(), lon, epsilon*100.);
           TS_ASSERT_DELTA(ic.GetLongitudeRadIC(), lon*M_PI/180., epsilon);
           // TS_ASSERT_DELTA(ic.GetAltitudeASLFtIC()/(agl+2000.), 1.0, 2E-8);
-          // For some reasons, MinGW32, MSVC and M1 MacOS are less accurate than other platforms.
-#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__arm64__)
+          // For some reasons, MinGW32, MSVC and MacOS are less accurate than Linux.
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__APPLE__)
           TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC()/agl, 1.0, 4E-8);
 #else
           TS_ASSERT_DELTA(ic.GetAltitudeAGLFtIC()/agl, 1.0, 2E-8);


### PR DESCRIPTION
Following https://github.com/actions/runner-images/issues/10721, the runner `macos-12` will be deprecated in favor of `macos-13` by Dec 03, 2024.

This PR updates our CI workflow to use `macos-13` runners wherever `macos-12` was used.