### PR TITLE
Cygwin build fix

### DIFF
--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -34,6 +34,9 @@ string::find() functions were formerly used.
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+#ifdef __CYGWIN__
+#define _GNU_SOURCE 1
+#endif
 #include <errno.h>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Ensures `strtod_l` is provided which is normally hidden for non-GNU source