### PR TITLE
Fix Unreal crashing when deleting an actor with a JSBMovement component.

### DIFF
--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModelEditor/Private/JSBSimMovementCompVisualizer.cpp
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModelEditor/Private/JSBSimMovementCompVisualizer.cpp
@@ -52,6 +52,11 @@ FJSBSimMovementCompVisualizer::~FJSBSimMovementCompVisualizer()
 void FJSBSimMovementCompVisualizer::DrawVisualization(const UActorComponent* Component, const FSceneView* View, FPrimitiveDrawInterface* PDI)
 {
 	const UJSBSimMovementComponent* MovementComponent = Cast<UJSBSimMovementComponent>(Component);
+	if (!MovementComponent)
+	{
+		return;
+	}
+
 	AActor* Owner = Component->GetOwner();
 
 	// Make sure we are ready to visualize this component
@@ -101,6 +106,11 @@ void FJSBSimMovementCompVisualizer::DrawVisualization(const UActorComponent* Com
 void FJSBSimMovementCompVisualizer::DrawVisualizationHUD(const UActorComponent* Component, const FViewport* Viewport, const FSceneView* View, FCanvas* Canvas)
 {
 	const UJSBSimMovementComponent* MovementComponent = Cast<UJSBSimMovementComponent>(Component);
+	if (!MovementComponent)
+	{
+		return;
+	}
+
 	AActor* Owner = MovementComponent->GetOwner();
 
 	FVector2D PixelLocation;


### PR DESCRIPTION
Below is the crash log that occurred.


```
Unhandled Exception: EXCEPTION_ACCESS_VIOLATION reading address 0x00000000000000ac

UnrealEditor_JSBSimFlightDynamicsModelEditor!FJSBSimMovementCompVisualizer::DrawVisualization() [C:\workspace\jsbsim\UnrealEngine\Plugins\JSBSimFlightDynamicsModel\Source\JSBSimFlightDynamicsModelEditor\Private\JSBSimMovementCompVisualizer.cpp:55]
UnrealEditor_UnrealEd
UnrealEditor_UnrealEd
UnrealEditor_Renderer
UnrealEditor_Renderer
UnrealEditor_Renderer
UnrealEditor_Renderer
UnrealEditor_Renderer
UnrealEditor_UnrealEd
UnrealEditor_Engine
UnrealEditor_UnrealEd
UnrealEditor_UnrealEd
UnrealEditor_UnrealEd
UnrealEditor
UnrealEditor
UnrealEditor
UnrealEditor
UnrealEditor
UnrealEditor
kernel32
ntdll
```