### PR TITLE
Prevent time catch up in real time mode

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -509,6 +509,17 @@ jobs:
           rm -f _jsbsim.cxx  # Make sure that jsbsim.cxx is not stored in the source distribution
           python -m build --sdist
           echo "::endgroup::"
+      - name: Check reset for real time execution
+        if: matrix.os == 'macos-14'
+        run: |
+          start_time=$(date +%s)
+          ./build/src/JSBSim scripts/c172_cruise_8K.xml --realtime --nice
+          end_time=$(date +%s)
+          elapsed_time=$((end_time - start_time))
+          if [ $elapsed_time -lt 90 ]; then
+            echo "Failed - Program finished in less than 90 seconds"
+            exit 1
+          fi
 
     # On failure, upload logs
       - name: On failure - Upload logs

--- a/scripts/c172_cruise_8K.xml
+++ b/scripts/c172_cruise_8K.xml
@@ -6,8 +6,8 @@
   <description>This run is for testing the C172 altitude hold autopilot and cruise performance</description>
   <use aircraft="c172x" initialize="reset01"/>
 
-  <run start="0.0" end="50" dt="0.0083333">
-  
+  <run start="0.0" end="40" dt="0.0083333">
+
     <property value="0" persistent="true"> simulation/run_id </property>
 
     <event name="Set Temperature">
@@ -26,17 +26,17 @@
       </set>
       <set name="ap/altitude_setpoint" value="4000.0"/>
     </event>
-    
+
     <event name="Start engine">
       <condition>
         simulation/sim-time-sec  ge  0.01
       </condition>
       <set name="fcs/throttle-cmd-norm" action="FG_RAMP" value="0.50" tc="0.05"/>
-      <set name="fcs/mixture-cmd-norm" action="FG_RAMP" value="1.0" tc="0.05"/> 
+      <set name="fcs/mixture-cmd-norm" action="FG_RAMP" value="1.0" tc="0.05"/>
       <set name="propulsion/magneto_cmd" value="3"/>
       <set name="propulsion/starter_cmd" value="1"/>
       <notify/>
-    </event> 
+    </event>
 
     <event name="Trim">
       <condition>
@@ -102,8 +102,8 @@
 
     <event name="Reset">
       <condition logic="AND">
-        simulation/sim-time-sec >= 30.0
-        simulation/terminate != 1
+        simulation/sim-time-sec >= 25.0
+        simulation/run_id lt 2
       </condition>
       <set name="ap/heading_setpoint" value="0"/>
 <!--      <set name="ap/altitude_setpoint" value="0"/> -->
@@ -115,16 +115,5 @@
         <property> simulation/run_id </property>
       </notify>
     </event>
-
-    <event name="Terminate on run ID">
-      <condition>
-        simulation/run_id  ge  3
-      </condition>
-      <set name="simulation/terminate" value="1"/>
-      <notify>
-        <property caption="Terminate: "> simulation/terminate </property>
-      </notify>
-    </event>
-
   </run>
 </runscript>

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -183,15 +183,24 @@ public:
   }
 };
 
+/** The Timer class measures the elapsed real time and can be paused and resumed.
+    It inherits from SGPropertyChangeListener to restart the timer whenever a
+    property change is detected. */
 class Timer : public SGPropertyChangeListener {
 public:
-  Timer() : SGPropertyChangeListener(), isPaused(false) { initialize(); }
-  void initialize(void) { initial_seconds = getcurrentseconds(); }
+  Timer() : SGPropertyChangeListener(), isPaused(false) { start(); }
+  void start(void) { initial_seconds = getcurrentseconds(); }
+
+  /// Restart the timer when the listened property is modified.
   void valueChanged(SGPropertyNode* prop) override {
-    initialize();
+    start();
     if (isPaused) pause_start_seconds = initial_seconds;
   }
+  /// Get the elapsed real time in seconds since the timer was started.
   double getElapsedTime(void) { return getcurrentseconds() - initial_seconds; }
+
+  /** Pause the timer if the `paused` parameter is true and resume it if the
+      `paused` parameter is false. */
   void pause(bool paused) {
     if (paused) {
       if (!isPaused) {
@@ -202,7 +211,7 @@ public:
       if (isPaused) {
         isPaused = false;
         double pause_duration = getcurrentseconds() - pause_start_seconds;
-        initial_seconds += pause_duration;
+        initial_seconds += pause_duration; // Shift the initial time to account for the pause duration.
       }
     }
   }
@@ -567,7 +576,7 @@ int real_main(int argc, char* argv[])
   else          sleep_nseconds = (sleep_period )*1e9;           // 0.01 seconds
 
   tzset();
-  timer.initialize();
+  timer.start();
 
   // *** CYCLIC EXECUTION LOOP, AND MESSAGE READING *** //
   while (result && FDMExec->GetSimTime() <= end_time) {

--- a/src/simgear/props/props.hxx
+++ b/src/simgear/props/props.hxx
@@ -228,7 +228,7 @@ public:
      */
     virtual simgear::props::Type getType() const = 0;
     virtual ~SGRaw() {}
-    
+
     /**
      * Create a new deep copy of this raw value.
      *
@@ -244,7 +244,7 @@ public:
 class SGRawExtended : public SGRaw
 {
 public:
-    /**    
+    /**
      * Make an SGRawValueContainer from the SGRawValue.
      *
      * This is a virtual function of SGRawExtended so that
@@ -723,7 +723,7 @@ typedef std::vector<SGPropertyNode_ptr> PropertyList;
  * <p>Any class that needs to listen for property changes must implement
  * this interface.</p>
  */
-class SGPropertyChangeListener
+class JSBSIM_API SGPropertyChangeListener
 {
 public:
   virtual ~SGPropertyChangeListener ();
@@ -1150,7 +1150,7 @@ public:
    * Set all of the mode attributes for the property node.
    */
   void setAttributes (int attr) { _attr = attr; }
-  
+
 
   //
   // Leaf Value (primitive).
@@ -1284,7 +1284,7 @@ public:
   {
     return setValue(&val[0]);
   }
-  
+
   /**
    * Set relative node to given value and afterwards make read only.
    *
@@ -1344,7 +1344,7 @@ public:
    * Print the value of the property to a stream.
    */
   std::ostream& printOn(std::ostream& stream) const;
-  
+
   //
   // Data binding.
   //


### PR DESCRIPTION
This PR fixes the bug reported in the issue #1187.

A new class `Timer` is added that manages elapsed time. It is inheriting `SGPropertyChangeListener` so that every time the property `simulation/reset` is set the timer is properly reset.

The CI workflow is also modified to check that executing the following command takes at least 90 seconds (i.e. 2 runs of 25 seconds and 1 run of 40 seconds):
```bash
JSBSim scripts/c172_cruise_8K.xml --realtime --nice
```
The script `c172_cruise_8K.xml` is also simplified:
* It runs quicker: the end time and the time that triggers the reset have been shortened.
* The termination event has been removed. Instead the last run is executed until the end time is reached.