### PR TITLE
Solve post-impact collapse problem by adding wind simulation

### DIFF
--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/FDMTypes.cpp
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/FDMTypes.cpp
@@ -1,4 +1,4 @@
-#include "FDMTypes.h"
+﻿#include "FDMTypes.h"
 
 const FSimpleWindState FSimpleWindState::Calm = FSimpleWindState();
 const FSimpleWindState FSimpleWindState::StandardEastZephyr = FSimpleWindState(ETurbType::Standard, 0.0, 0.0, FVector::RightVector, 0.0);

--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/FDMTypes.cpp
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/FDMTypes.cpp
@@ -1,0 +1,7 @@
+#include "FDMTypes.h"
+
+const FSimpleWindState FSimpleWindState::Calm = FSimpleWindState();
+const FSimpleWindState FSimpleWindState::StandardEastZephyr = FSimpleWindState(ETurbType::Standard, 0.0, 0.0, FVector::RightVector, 0.0);
+const FSimpleWindState FSimpleWindState::StandardWestZephyr = FSimpleWindState(ETurbType::Standard, 0.0, 0.0, FVector::RightVector * -1.0, 0.0);
+const FSimpleWindState FSimpleWindState::StandardNorthZephyr = FSimpleWindState(ETurbType::Standard, 0.0, 0.0, FVector::ForwardVector, 0.0);
+const FSimpleWindState FSimpleWindState::StandardSouthZephyr = FSimpleWindState(ETurbType::Standard, 0.0, 0.0, FVector::ForwardVector * -1.0, 0.0);

--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/FDMTypes.h
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/FDMTypes.h
@@ -439,15 +439,15 @@ UENUM(BlueprintType)
 enum class ETurbType:uint8
 {
 	//No turbulence model is used. The aircraft will not experience any random wind effects. This mode can be beneficial for initial testing or when the influence of wind needs to be simplified.
-	None = 0 UMETA(ToolTip = "turbulence disabled"),
+	None = 0 UMETA(DisplayName ="turbulence disabled"),
 	//A basic turbulence model that uses standard statistical characteristics to simulate wind fluctuations. This model is generally used for simple flight simulations.
-	Standard UMETA(ToolTip = "Ordinary turbulence"),
+	Standard UMETA(DisplayName = "Ordinary turbulence"),
 	//The Culp turbulence model typically provides a more detailed simulation of turbulence (considering factors such as turbulence intensity and frequency). The Culp model adapts well to different aircraft and flight conditions, making it suitable for more complex simulations.
-	Culp UMETA(ToolTip = "Culp turbulence model"),
+	Culp UMETA(DisplayName = "Culp turbulence model"),
 	//This model uses the Dryden spectrum to simulate turbulence, adhering to the guidelines set in the MIL-F-8785C document. The parameters are designed differently for flights at altitudes below 1000 feet and above 2000 feet, with linear interpolation applied for altitudes in between. This model is well-suited for military applications and scenarios where specific turbulence characteristics are required.
-	Milspec UMETA(ToolTip = "Milspec turbulence model (Dryden spectrum)"),
+	Milspec UMETA(DisplayName = "Milspec turbulence model (Dryden spectrum)"),
 	//Similar to ttMilspec, this model also uses the Dryden spectrum. The main difference lies in how the transfer functions are implemented based on the specifications in the military document. It helps in simulating realistic turbulence under similar conditions as the Milspec model.
-	Tustin UMETA(ToolTip = "Tustin turbulence model (Dryden spectrum)") ,
+	Tustin UMETA(DisplayName = "Tustin turbulence model (Dryden spectrum)") ,
 	
 };
 /*

--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/FDMTypes.h
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/FDMTypes.h
@@ -433,3 +433,70 @@ struct FAircraftState
 		SpoilersPosition = 0;
 	}
 };
+
+//ue TurbType
+UENUM(BlueprintType)
+enum class ETurbType:uint8
+{
+	//No turbulence model is used. The aircraft will not experience any random wind effects. This mode can be beneficial for initial testing or when the influence of wind needs to be simplified.
+	None = 0 UMETA(ToolTip = "turbulence disabled"),
+	//A basic turbulence model that uses standard statistical characteristics to simulate wind fluctuations. This model is generally used for simple flight simulations.
+	Standard UMETA(ToolTip = "Ordinary turbulence"),
+	//The Culp turbulence model typically provides a more detailed simulation of turbulence (considering factors such as turbulence intensity and frequency). The Culp model adapts well to different aircraft and flight conditions, making it suitable for more complex simulations.
+	Culp UMETA(ToolTip = "Culp turbulence model"),
+	//This model uses the Dryden spectrum to simulate turbulence, adhering to the guidelines set in the MIL-F-8785C document. The parameters are designed differently for flights at altitudes below 1000 feet and above 2000 feet, with linear interpolation applied for altitudes in between. This model is well-suited for military applications and scenarios where specific turbulence characteristics are required.
+	Milspec UMETA(ToolTip = "Milspec turbulence model (Dryden spectrum)"),
+	//Similar to ttMilspec, this model also uses the Dryden spectrum. The main difference lies in how the transfer functions are implemented based on the specifications in the military document. It helps in simulating realistic turbulence under similar conditions as the Milspec model.
+	Tustin UMETA(ToolTip = "Tustin turbulence model (Dryden spectrum)") ,
+	
+};
+/*
+ * Wind State
+ * I hope that in the future there will be a new class that can provide more settings. However, this data is sufficient for now.
+ */
+USTRUCT(BlueprintType)
+struct JSBSIMFLIGHTDYNAMICSMODEL_API FSimpleWindState
+{
+	GENERATED_BODY()
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Wind")
+	ETurbType TurbType = ETurbType::None;
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Wind")
+	double TurbGain = 0.0;
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Wind")
+	double TurbRate = 0.0;
+	//unit knots
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Wind")
+	FVector WindNED = FVector::ZeroVector;
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Wind")
+	double ProbabilityOfExceedence = 0.0;
+
+	FSimpleWindState() = default;
+
+	FSimpleWindState(ETurbType InTurbType, double InTurbGain, double InTurbRate, FVector InWindNED,
+		double InProbabilityOfExceedence) : TurbType(InTurbType), TurbGain(InTurbGain), TurbRate(InTurbRate),
+		WindNED(InWindNED),
+		ProbabilityOfExceedence(InProbabilityOfExceedence)
+	{
+
+	}
+	FString GetDebugMessage()const
+	{
+		FString DebugMessage;
+		DebugMessage += FString::Printf(TEXT("TurbType %d     TurbGain %.2f     TurbRate %.2f     WindNED %s     ProbabilityOfExceedence %.2f"), TurbType, TurbGain, TurbRate, *WindNED.ToString(), ProbabilityOfExceedence);
+		return DebugMessage;
+	}
+
+		static const FSimpleWindState Calm;
+		// East wind, a wind speed that people perceive as relatively strong.
+		static const FSimpleWindState StandardEastZephyr;
+		// West wind, a wind speed that people perceive as relatively strong.
+		static const FSimpleWindState StandardWestZephyr;
+		//North wind, a wind speed that people perceive as relatively strong.
+		static const FSimpleWindState StandardNorthZephyr;
+		//South wind, a wind speed that people perceive as relatively strong.
+		static const FSimpleWindState StandardSouthZephyr;
+	
+	
+	
+};
+

--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/JSBSimMovementComponent.h
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/JSBSimMovementComponent.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -243,12 +243,13 @@ public:
   *     otherwise you will override the system value! */
 	UFUNCTION(BlueprintCallable, DisplayName = "Command Console Batch")
     void CommandConsoleBatch(TArray<FString> Property, TArray<FString> InValue, TArray<FString>& OutValue);
-	UFUNCTION(BlueprintCallable, DisplayName = "Set Winds")
-	void SetWind(FSimpleWindState WindState);
 	/**
 	 * Set environmental wind parameters
-	 * 
+	 *
 	 */
+	UFUNCTION(BlueprintCallable, DisplayName = "Set Winds")
+	void SetWind(FSimpleWindState WindState);
+	
 protected:
 	// Called when the game starts
 	virtual void BeginPlay() override;

--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/JSBSimMovementComponent.h
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Public/JSBSimMovementComponent.h
@@ -243,8 +243,12 @@ public:
   *     otherwise you will override the system value! */
 	UFUNCTION(BlueprintCallable, DisplayName = "Command Console Batch")
     void CommandConsoleBatch(TArray<FString> Property, TArray<FString> InValue, TArray<FString>& OutValue);
-
-
+	UFUNCTION(BlueprintCallable, DisplayName = "Set Winds")
+	void SetWind(FSimpleWindState WindState);
+	/**
+	 * Set environmental wind parameters
+	 * 
+	 */
 protected:
 	// Called when the game starts
 	virtual void BeginPlay() override;
@@ -341,6 +345,9 @@ private:
 	void InitEnginesCommandAndStates();
 	void GetEnginesStates();
 
+
+	//aircrafts
+	void CrashedEvent();
 
 	/////////// Logging and Debugging Methods
 	void LogInitialization();


### PR DESCRIPTION
1. Fixed plane crash caused by rendering thread after impact.
2. Added support for wind simulation