### PR TITLE
Fix locale dependent number parsing

### DIFF
--- a/src/FGJSBBase.h
+++ b/src/FGJSBBase.h
@@ -47,7 +47,6 @@ INCLUDES
 #include <chrono>
 
 #include "JSBSim_API.h"
-#include "input_output/string_utilities.h"
 
 #ifndef M_PI
 #  define M_PI 3.14159265358979323846

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -43,6 +43,7 @@ INCLUDES
 #include "initialization/FGInitialCondition.h"
 #include "FGFDMExec.h"
 #include "input_output/FGXMLFileRead.h"
+#include "input_output/string_utilities.h"
 
 #if !defined(__GNUC__) && !defined(sgi) && !defined(_MSC_VER)
 #  include <time>
@@ -681,7 +682,7 @@ bool options(int count, char **arg)
       play_nice = true;
       if (n != string::npos) {
         try {
-          sleep_period = atof( value.c_str() );
+          sleep_period = JSBSim::atof_locale_c( value.c_str() );
         } catch (...) {
           cerr << endl << "  Invalid sleep period given!" << endl << endl;
           result = false;
@@ -741,11 +742,17 @@ bool options(int count, char **arg)
       }
     } else if (keyword == "--property") {
       if (n != string::npos) {
-         string propName = value.substr(0,value.find("="));
-         string propValueString = value.substr(value.find("=")+1);
-         double propValue = atof(propValueString.c_str());
-         CommandLineProperties.push_back(propName);
-         CommandLinePropertyValues.push_back(propValue);
+        string propName = value.substr(0,value.find("="));
+        string propValueString = value.substr(value.find("=")+1);
+        double propValue;
+        try {
+          propValue = JSBSim::atof_locale_c(propValueString.c_str());
+        } catch (JSBSim::InvalidNumber&) {
+          gripe;
+          exit(1);
+        }
+        CommandLineProperties.push_back(propName);
+        CommandLinePropertyValues.push_back(propValue);
       } else {
         gripe;
         exit(1);
@@ -754,7 +761,7 @@ bool options(int count, char **arg)
     } else if (keyword.substr(0,5) == "--end") {
       if (n != string::npos) {
         try {
-        end_time = atof( value.c_str() );
+          end_time = JSBSim::atof_locale_c( value.c_str() );
         } catch (...) {
           cerr << endl << "  Invalid end time given!" << endl << endl;
           result = false;
@@ -767,7 +774,7 @@ bool options(int count, char **arg)
     } else if (keyword == "--simulation-rate") {
       if (n != string::npos) {
         try {
-          simulation_rate = atof( value.c_str() );
+          simulation_rate = JSBSim::atof_locale_c( value.c_str() );
           override_sim_rate = true;
         } catch (...) {
           cerr << endl << "  Invalid simulation rate given!" << endl << endl;

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -52,6 +52,7 @@ INCLUDES
 #include "input_output/FGXMLFileRead.h"
 #include "FGTrim.h"
 #include "FGFDMExec.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 

--- a/src/input_output/FGInputSocket.cpp
+++ b/src/input_output/FGInputSocket.cpp
@@ -47,6 +47,7 @@ INCLUDES
 #include "FGFDMExec.h"
 #include "models/FGAircraft.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 
@@ -168,17 +169,13 @@ void FGInputSocket::Read(bool Holding)
           socket->Reply("Not a leaf property\r\n");
           break;
         } else {
-          if (is_number(trim(str_value))) {
-            try {
-              double value = atof_locale_c(str_value);
-              node->setDoubleValue(value);
-            } catch(BaseException& e) {
-              socket->Reply(e.what());
-              break;
-            }
-          }
-          else {
-            socket->Reply("Invalid number\r\n");
+          try {
+            double value = atof_locale_c(str_value);
+            node->setDoubleValue(value);
+          } catch(InvalidNumber& e) {
+            string msg(e.what());
+            msg += "\r\n";
+            socket->Reply(msg);
             break;
           }
         }

--- a/src/input_output/FGOutputSocket.cpp
+++ b/src/input_output/FGOutputSocket.cpp
@@ -56,6 +56,7 @@ INCLUDES
 #include "models/atmosphere/FGWinds.h"
 #include "input_output/FGXMLElement.h"
 #include "math/FGPropertyValue.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 
@@ -85,25 +86,25 @@ void FGOutputSocket::SetOutputName(const string& fname)
   // tokenize the output name
   size_t dot_pos = fname.find(':', 0);
   size_t slash_pos = fname.find('/', 0);
-  
+
   string name = fname.substr(0, dot_pos);
-  
+
   string proto = "TCP";
   if(dot_pos + 1 < slash_pos)
     proto = fname.substr(dot_pos + 1, slash_pos - dot_pos - 1);
-  
+
   string port = "1138";
   if(slash_pos < string::npos)
     port = fname.substr(slash_pos + 1, string::npos);
-  
+
   // set the model name
   Name = name + ":" + port + "/" + proto;
-  
+
   // set the socket params
   SockName = name;
-  
+
   SockPort = atoi(port.c_str());
-  
+
   if (to_upper(proto) == "UDP")
     SockProtocol = FGfdmSocket::ptUDP;
   else // Default to TCP

--- a/src/input_output/FGOutputTextFile.cpp
+++ b/src/input_output/FGOutputTextFile.cpp
@@ -52,6 +52,7 @@ INCLUDES
 #include "models/FGFCS.h"
 #include "models/atmosphere/FGWinds.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 

--- a/src/input_output/FGScript.cpp
+++ b/src/input_output/FGScript.cpp
@@ -50,6 +50,7 @@ INCLUDES
 #include "models/FGInput.h"
 #include "math/FGCondition.h"
 #include "math/FGFunctionValue.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 

--- a/src/input_output/FGUDPInputSocket.cpp
+++ b/src/input_output/FGUDPInputSocket.cpp
@@ -44,6 +44,7 @@ INCLUDES
 #include "FGUDPInputSocket.h"
 #include "FGFDMExec.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 
@@ -106,15 +107,13 @@ void FGUDPInputSocket::Read(bool Holding)
 
     vector<double> values;
 
-    for (string& token : tokens) {
-      if (is_number(trim(token))) {
-        try {
-          values.push_back(atof_locale_c(token));
-        } catch(BaseException& e) {
-          return;
-        }
-      }
-     }
+    try {
+      for (string& token : tokens)
+        values.push_back(atof_locale_c(token));
+    } catch(InvalidNumber& e) {
+      cerr << e.what() << endl;
+      return;
+    }
 
     if (values[0] < oldTimeStamp) {
       return;

--- a/src/input_output/FGXMLElement.cpp
+++ b/src/input_output/FGXMLElement.cpp
@@ -31,8 +31,10 @@ INCLUDES
 #include <iostream>
 #include <sstream>  // for assembling the error messages / what of exceptions.
 #include <stdexcept>  // using domain_error, invalid_argument, and length_error.
+
 #include "FGXMLElement.h"
 #include "FGJSBBase.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 
@@ -293,11 +295,11 @@ double Element::GetAttributeValueAsNumber(const string& attr)
   }
   else {
     double number=0;
-    if (is_number(trim(attribute)))
+    try {
       number = atof_locale_c(attribute);
-    else {
+    } catch (InvalidNumber& e) {
       std::stringstream s;
-      s << ReadFrom() << "Expecting numeric attribute value, but got: " << attribute;
+      s << ReadFrom() << e.what();
       cerr << s.str() << endl;
       throw BaseException(s.str());
     }
@@ -347,11 +349,11 @@ double Element::GetDataAsNumber(void)
 {
   if (data_lines.size() == 1) {
     double number=0;
-    if (is_number(trim(data_lines[0])))
+    try {
       number = atof_locale_c(data_lines[0]);
-    else {
+    } catch (InvalidNumber& e) {
       std::stringstream s;
-      s << ReadFrom() << "Expected numeric value, but got: " << data_lines[0];
+      s << ReadFrom() << e.what();
       cerr << s.str() << endl;
       throw BaseException(s.str());
     }

--- a/src/input_output/FGfdmSocket.cpp
+++ b/src/input_output/FGfdmSocket.cpp
@@ -55,7 +55,9 @@ INCLUDES
 #include <sstream>
 #include <cstring>
 #include <assert.h>
+
 #include "FGfdmSocket.h"
+#include "input_output/string_utilities.h"
 
 using std::cout;
 using std::cerr;

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -91,17 +91,11 @@ double atof_locale_c(const string& input)
   // Skip leading whitespaces
   while (isspace(*first)) ++first;
 
-  if (!*first) {
-    InvalidNumber e("Expecting a numeric attribute value, but only got spaces");
-    cerr << e.what() << endl;
-    throw e;
-  }
+  if (!*first)
+    throw InvalidNumber("Expecting a numeric attribute value, but only got spaces");
 
-  if (!std::regex_match(input, number_format)) {
-    InvalidNumber e("Expecting a numeric attribute value, but got: " + input);
-    cerr << e.what() << endl;
-    throw e;
-  }
+  if (!std::regex_match(input, number_format))
+    throw InvalidNumber("Expecting a numeric attribute value, but got: " + input);
 
   CNumericLocale numeric_c;
   errno = 0;          // Reset the error code
@@ -117,7 +111,6 @@ double atof_locale_c(const string& input)
   else
     return value;
 
-  std::cerr << s.str() << std::endl;
   throw InvalidNumber(s.str());
 }
 

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -88,12 +88,9 @@ double atof_locale_c(const string& input)
   static const std::regex number_format(R"(^\s*[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?\s*$)");
   const char* first = input.c_str();
 
-  while (*first) {
-    if (!isspace(*first)) break;
-    first++;
-  }
-
   // Skip leading whitespaces
+  while (isspace(*first)) ++first;
+
   if (!*first) {
     InvalidNumber e("Expecting a numeric attribute value, but only got spaces");
     cerr << e.what() << endl;

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -93,6 +93,7 @@ double atof_locale_c(const string& input)
     first++;
   }
 
+  // Skip leading whitespaces
   if (!*first) {
     InvalidNumber e("Expecting a numeric attribute value, but only got spaces");
     cerr << e.what() << endl;

--- a/src/input_output/string_utilities.cpp
+++ b/src/input_output/string_utilities.cpp
@@ -84,17 +84,17 @@ struct CNumericLocale
  */
 double atof_locale_c(const string& input)
 {
-  if (input.empty()) {
-    InvalidNumber e("Expecting numeric attribute value, but got an empty string");
+  string v = input;
+  trim(v);
+
+  if (v.empty()) {
+    InvalidNumber e("Expecting a numeric attribute value, but got an empty string");
     cerr << e.what() << endl;
     throw e;
   }
 
-  string v = input;
-  trim(v);
-
   if (v.find_first_not_of("+-.0123456789Ee") != std::string::npos) {
-    InvalidNumber e("Expecting numeric attribute value, but got: " + input);
+    InvalidNumber e("Expecting a numeric attribute value, but got: " + input);
     cerr << e.what() << endl;
     throw e;
   }
@@ -114,7 +114,7 @@ double atof_locale_c(const string& input)
   if (fabs(value) == HUGE_VAL && errno == ERANGE)
     s << "This number is too large: " << input;
   else if (fabs(value) == 0 && errno == EINVAL)
-    s << "Expecting numeric attribute value, but got: " << input;
+    s << "Expecting a numeric attribute value, but got: " << input;
   else
     return value;
 
@@ -171,9 +171,6 @@ std::string& to_lower(std::string& str)
 
 bool is_number(const std::string& str)
 {
-  if (str.empty())
-    return false;
-
   try {
     atof_locale_c(str);
   } catch (InvalidNumber&) {

--- a/src/input_output/string_utilities.h
+++ b/src/input_output/string_utilities.h
@@ -41,6 +41,8 @@ INCLUDES
 #include <string>
 #include <vector>
 
+#include "FGJSBBase.h"
+
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
@@ -56,6 +58,11 @@ JSBSIM_API std::string& to_lower(std::string& str);
 JSBSIM_API bool is_number(const std::string& str);
 JSBSIM_API std::vector <std::string> split(std::string str, char d);
 JSBSIM_API std::string replace(std::string str, const std::string& old, const std::string& newstr);
+
+class JSBSIM_API InvalidNumber : public BaseException {
+public:
+  InvalidNumber(const std::string& msg) : BaseException(msg) {}
+};
 };
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/input_output/string_utilities.h
+++ b/src/input_output/string_utilities.h
@@ -61,7 +61,7 @@ JSBSIM_API std::string replace(std::string str, const std::string& old, const st
 
 class JSBSIM_API InvalidNumber : public BaseException {
 public:
-  InvalidNumber(const std::string& msg) : BaseException(msg) {}
+  using BaseException::BaseException;
 };
 };
 

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -38,6 +38,7 @@ INCLUDES
 #include "FGRealValue.h"
 #include "input_output/FGXMLElement.h"
 #include "math/FGFunctionValue.h"
+#include "input_output/string_utilities.h"
 
 
 using namespace std;
@@ -611,21 +612,19 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
       string mean_attr = element->GetAttributeValue("mean");
       string stddev_attr = element->GetAttributeValue("stddev");
       if (!mean_attr.empty()) {
-        if (is_number(trim(mean_attr)))
+        try {
           mean = atof_locale_c(mean_attr);
-        else {
-          cerr << element->ReadFrom()
-               << "Expecting a number, but got: " << mean_attr <<endl;
-          throw BaseException("Invalid number");
+        } catch (InvalidNumber& e) {
+          cerr << element->ReadFrom() << e.what() << endl;
+          throw e;
         }
       }
       if (!stddev_attr.empty()) {
-        if (is_number(trim(stddev_attr)))
+        try {
           stddev = atof_locale_c(stddev_attr);
-        else {
-          cerr << element->ReadFrom()
-               << "Expecting a number, but got: " << stddev_attr <<endl;
-          throw BaseException("Invalid number");
+        } catch (InvalidNumber& e) {
+          cerr << element->ReadFrom() << e.what() << endl;
+          throw e;
         }
       }
       auto generator(makeRandomGenerator(element, fdmex));
@@ -641,21 +640,19 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
       string lower_attr = element->GetAttributeValue("lower");
       string upper_attr = element->GetAttributeValue("upper");
       if (!lower_attr.empty()) {
-        if (is_number(trim(lower_attr)))
+        try {
           lower = atof_locale_c(lower_attr);
-        else {
-          cerr << element->ReadFrom()
-               << "Expecting a number, but got: " << lower_attr <<endl;
-          throw BaseException("Invalid number");
+        } catch (InvalidNumber &e) {
+          cerr << element->ReadFrom() << e.what() << endl;
+          throw e;
         }
       }
       if (!upper_attr.empty()) {
-        if (is_number(trim(upper_attr)))
+        try {
           upper = atof_locale_c(upper_attr);
-        else {
-          cerr << element->ReadFrom()
-               << "Expecting a number, but got: " << upper_attr <<endl;
-          throw BaseException("Invalid number");
+        } catch (InvalidNumber &e) {
+          cerr << element->ReadFrom() << e.what() << endl;
+          throw e;
         }
       }
       auto generator(makeRandomGenerator(element, fdmex));

--- a/src/math/FGParameterValue.h
+++ b/src/math/FGParameterValue.h
@@ -37,6 +37,7 @@
 #include "math/FGRealValue.h"
 #include "math/FGPropertyValue.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/string_utilities.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   FORWARD DECLARATIONS
@@ -77,9 +78,9 @@ public:
 
   FGParameterValue(const std::string& value, std::shared_ptr<FGPropertyManager> pm,
                    Element* el) {
-    if (is_number(value)) {
-      param = new FGRealValue(atof(value.c_str()));
-    } else {
+    try {
+      param = new FGRealValue(atof_locale_c(value.c_str()));
+    } catch (InvalidNumber&) {
       // "value" must be a property if execution passes to here.
       param = new FGPropertyValue(value, pm, el);
     }

--- a/src/math/FGTable.cpp
+++ b/src/math/FGTable.cpp
@@ -41,6 +41,7 @@ INCLUDES
 
 #include "FGTable.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 

--- a/src/models/FGInput.cpp
+++ b/src/models/FGInput.cpp
@@ -44,6 +44,7 @@ INCLUDES
 #include "input_output/FGXMLFileRead.h"
 #include "input_output/FGModelLoader.h"
 #include "input_output/FGLog.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 

--- a/src/models/FGOutput.cpp
+++ b/src/models/FGOutput.cpp
@@ -45,6 +45,7 @@ INCLUDES
 #include "input_output/FGXMLFileRead.h"
 #include "input_output/FGModelLoader.h"
 #include "input_output/FGLog.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 

--- a/src/models/flight_control/FGSwitch.cpp
+++ b/src/models/flight_control/FGSwitch.cpp
@@ -91,9 +91,9 @@ FGSwitch::FGSwitch(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
       current_test->setTestValue(value, Name, PropertyManager, test_element);
       current_test->Default = true;
       auto output_value = current_test->OutputValue.ptr();
-      if (delay > 0 && dynamic_cast<FGRealValue*>(output_value)) {
+      if (delay > 0 && dynamic_cast<FGRealValue*>(output_value)) { // If there is a delay
         double v = output_value->GetValue();
-        for (unsigned int i=0; i<delay-1; i++) {  // delay buffer to the default value
+        for (unsigned int i=0; i<delay-1; i++) {  // Initialize the delay buffer to the default value
           output_array[i] = v;                    // for the switch if that value is a number.
         }
       }

--- a/src/models/flight_control/FGSwitch.cpp
+++ b/src/models/flight_control/FGSwitch.cpp
@@ -65,6 +65,7 @@ INCLUDES
 #include "models/FGFCS.h"
 #include "math/FGCondition.h"
 #include "input_output/FGLog.h"
+#include "math/FGRealValue.h"
 
 using namespace std;
 
@@ -89,8 +90,9 @@ FGSwitch::FGSwitch(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
       value = test_element->GetAttributeValue("value");
       current_test->setTestValue(value, Name, PropertyManager, test_element);
       current_test->Default = true;
-      if (delay > 0 && is_number(trim(value))) {  // If there is a delay, initialize the
-        double v = atof_locale_c(value);
+      auto output_value = current_test->OutputValue.ptr();
+      if (delay > 0 && dynamic_cast<FGRealValue*>(output_value)) {
+        double v = output_value->GetValue();
         for (unsigned int i=0; i<delay-1; i++) {  // delay buffer to the default value
           output_array[i] = v;                    // for the switch if that value is a number.
         }

--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -48,6 +48,7 @@ INCLUDES
 #include "FGTurbine.h"
 #include "FGThruster.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/string_utilities.h"
 
 using namespace std;
 
@@ -487,19 +488,21 @@ bool FGTurbine::Load(FGFDMExec* exec, Element *el)
   JSBSim::Element* tsfcElement = el->FindElement("tsfc");
   if (tsfcElement) {
     string value = tsfcElement->GetDataLine();
-    if (is_number(trim(value)))
+    try {
       TSFC = std::make_unique<FGSimplifiedTSFC>(this, atof_locale_c(value));
-    else
+    } catch (InvalidNumber&) {
       TSFC = std::make_unique<FGFunction>(FDMExec, tsfcElement, to_string(EngineNumber));
+    }
   }
 
   JSBSim::Element* atsfcElement = el->FindElement("atsfc");
   if (atsfcElement) {
     string value = atsfcElement->GetDataLine();
-    if (is_number(trim(value)))
+    try {
       ATSFC = std::make_unique<FGRealValue>(atof_locale_c(value));
-    else
+    } catch (InvalidNumber&) {
       ATSFC = std::make_unique<FGFunction>(FDMExec, atsfcElement, to_string((int)EngineNumber));
+    }
   }
 
   // Pre-calculations and initializations

--- a/tests/unit_tests/StringUtilitiesTest.h
+++ b/tests/unit_tests/StringUtilitiesTest.h
@@ -89,14 +89,60 @@ public:
   }
 
   void testAtofLocaleC() {
-    TS_ASSERT_EQUALS(atof_locale_c("+1  "), 1.0);
+    // Test legal numbers
+    TS_ASSERT_EQUALS(atof_locale_c("0.0"), 0.0);
+    TS_ASSERT_EQUALS(atof_locale_c("+1"), 1.0);
+    TS_ASSERT_EQUALS(atof_locale_c("1"), 1.0);
+    TS_ASSERT_EQUALS(atof_locale_c("-1"), -1.0);
     TS_ASSERT_EQUALS(atof_locale_c(" 123.4"), 123.4);
+    TS_ASSERT_EQUALS(atof_locale_c("123.4 "), 123.4);
+    TS_ASSERT_EQUALS(atof_locale_c(" 123.4 "), 123.4);
+    TS_ASSERT_EQUALS(atof_locale_c(".25"), 0.25);
+    TS_ASSERT_EQUALS(atof_locale_c("1.e1"), 10.);
+    TS_ASSERT_EQUALS(atof_locale_c("1e1"), 10.);
+    TS_ASSERT_EQUALS(atof_locale_c(".1e1"), 1.);
+    TS_ASSERT_EQUALS(atof_locale_c("+.1e1"), 1.);
+    TS_ASSERT_EQUALS(atof_locale_c("-.1e1"), -1.);
+    TS_ASSERT_EQUALS(atof_locale_c("31.4e1"), 314);
+    TS_ASSERT_EQUALS(atof_locale_c("+3.14e+2"), 314);
+    TS_ASSERT_EQUALS(atof_locale_c("+3.14e2"), 314);
+    TS_ASSERT_EQUALS(atof_locale_c("+3.14e-2"), 0.0314);
+    TS_ASSERT_EQUALS(atof_locale_c("3.14e+2"), 314);
+    TS_ASSERT_EQUALS(atof_locale_c("3.14e2"), 314);
+    TS_ASSERT_EQUALS(atof_locale_c("3.14e-2"), 0.0314);
+    TS_ASSERT_EQUALS(atof_locale_c("-3.14e+2"), -314);
+    TS_ASSERT_EQUALS(atof_locale_c("-3.14e2"), -314);
     TS_ASSERT_EQUALS(atof_locale_c("-3.14e-2"), -0.0314);
+    TS_ASSERT_EQUALS(atof_locale_c("+3.14E+2"), 314);
+    TS_ASSERT_EQUALS(atof_locale_c("+3.14E2"), 314);
+    TS_ASSERT_EQUALS(atof_locale_c("+3.14E-2"), 0.0314);
+    TS_ASSERT_EQUALS(atof_locale_c("3.14E+2"), 314);
+    TS_ASSERT_EQUALS(atof_locale_c("3.14E2"), 314);
+    TS_ASSERT_EQUALS(atof_locale_c("3.14E-2"), 0.0314);
+    TS_ASSERT_EQUALS(atof_locale_c("-3.14E+2"), -314);
+    TS_ASSERT_EQUALS(atof_locale_c("-3.14E2"), -314);
+    TS_ASSERT_EQUALS(atof_locale_c("-3.14E-2"), -0.0314);
+    // Test rounded down numbers
     TS_ASSERT_EQUALS(atof_locale_c("1E-999"), 0.0);
     TS_ASSERT_EQUALS(atof_locale_c("-1E-999"), 0.0);
-    TS_ASSERT_EQUALS(atof_locale_c("0.0"), 0.0);
-    TS_ASSERT_THROWS(atof_locale_c("1E+999"), BaseException&);
-    TS_ASSERT_THROWS(atof_locale_c("-1E+999"), BaseException&);
+    // Test invalid numbers
+    TS_ASSERT_THROWS(atof_locale_c("1E+999"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("-1E+999"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("invalid"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("1.0.0"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("1E-"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("E-2"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("."), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c(".E"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c(".E2"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c(".E-2"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("1.2E"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("1.2E+"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("1.2E1.0"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("--1"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c("++1"), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c(""), InvalidNumber&);
+    TS_ASSERT_THROWS(atof_locale_c(" "), InvalidNumber&);
   }
 
 private:

--- a/tests/unit_tests/StringUtilitiesTest.h
+++ b/tests/unit_tests/StringUtilitiesTest.h
@@ -50,6 +50,19 @@ public:
     TS_ASSERT(is_number("-1.0e+1"));
     TS_ASSERT(!is_number(empty));
     TS_ASSERT(!is_number("125x5#"));
+    TS_ASSERT(!is_number("x"));
+    TS_ASSERT(!is_number("1.0.0"));
+    TS_ASSERT(!is_number("1.0e"));
+    TS_ASSERT(!is_number("1.0e+"));
+    TS_ASSERT(!is_number("1.0e1.0"));
+    TS_ASSERT(!is_number("--1"));
+    TS_ASSERT(!is_number("++1"));
+    TS_ASSERT(!is_number("1+"));
+    TS_ASSERT(!is_number("1-"));
+    TS_ASSERT(!is_number(""));
+    TS_ASSERT(!is_number(" "));
+    TS_ASSERT(!is_number("3.14a"));
+    TS_ASSERT(!is_number("-.1e-"));
   }
 
   void testSplit() {


### PR DESCRIPTION
Following the issue #1227, this PR is making the function `atof_locale_c` much more pedantic and rejects any number that do not match a strict syntax such as `[+-]0.12E[+-]34` or `12.34`. A [regular expression](https://en.wikipedia.org/wiki/Regular_expression) is used for that purpose ([they have been introduced in C++11](https://en.wikipedia.org/wiki/C%2B%2B11#Regular_expressions)).

### 1. New exception `InvalidNumer`

A new exception class `JSBSim::InvalidNumber` has been created which inherits from `JSBSim::BaseException`. Since the former is defined in `input_output/string_utilities.h` and the latter in `FGJSBBase.h`, it was no longer possible that `FGJSBBase.h` includes `string_utilities.h` because that was creating a mutual dependence that compilers complain about. Actually `FGJSBBase.h` does not need to include `string_utilities.h` so the corresponding `#include` has simply been removed from `FGJSBBase.h`. As a consequence, a number of source files have been modified to explicitly include `string_utilities.h`.

### 2. `atof_locale_c` pedantry

The function `is_number` will now be much more pedantic and will basically be a function that checks that `atof_locale_c` succeeds.

All the occurrences of the following code:
```c++
double a_value;
std::string a_string;

if (is_number(a_string)) {
  a_value = atof_locale_c(trim(a_string));
} else {
  // Error management
}
```
have been replaced by
```c++
double a_value;
std::string a_string;

try {
  a_value = atof_locale_c(trim(a_string));
} catch (InvalidNumber& e) {
  // Error management
}
```
The problem was that both `is_number` and `strtod_l` have a relaxed interpretation of what a valid number syntax is. For example `strtod_l("1.3.2", nullptr, numeric_c.Locale);` returns `1.3` and the strings `x` and `.` return `0.0`. In addition the strings `1.3.2` and `.` are considered valid numbers by `is_number` although it rejects `x`. The regular expression will allow rejecting these strings as invalid.

Once this PR will be merged, all the validation and conversion work will be made by `atof_locale_c` which is now extremely pedantic. Also since the PR #799, `atof_locale_c` uses the locale "C" for numerical value whatever is the setting of `LC_NUMERIC`.

### 3. Removal of calls to `atof`

Most of the calls to `atof` have been replaced by `atof_locale_c`. The remaining calls to `atof` are all located in `simger/props/props.cxx`:
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/props/props.cxx#L1434
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/props/props.cxx#L1770
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/props/props.cxx#L1822
These calls are respectively made in the methods `SGPropertyNode::getFloatValue`, `SGPropertyNode::setStringValue` and `SGPropertyNode::setUnspecifiedValue` which are not used in the code.

### 4. Remaining calls to `strto` functions

Some calls to the standard library functions starting with `strto` (such as `strtol`, `strtod`, ...) remain.
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/props/props.cxx#L1401
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/props/props.cxx#L1767
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/props/props.cxx#L1773
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/props/props.cxx#L1819
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/props/props.cxx#L1825
These calls are respectively made in the methods `SGPropertyNode::getLongValue`, `SGPropertyNode::setStringValue` and `SGPropertyNode::setUnspecifiedValue` which are not used in the code.

The following call to `strtod` is made in `SGPropertyNode::getLongValue`:
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/props/props.cxx#L1466-L1468
However for that case to be selected, the property should have been previously set by `SGPropertyNode::setStringValue` or `SGPropertyNode::setUnspecifiedValue` which we are not using.

The following call to `strtoul` is made in `simgear/xml/xmlparse.c`
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/simgear/xml/xmlparse.c#L8533
The function `getDebugLevel` is internally used by `xmlparse.c` to get the value of the environment variables `EXPAT_ENTROPY_DEBUG`, `EXPAT_ACCOUNTING_DEBUG` and `EXPAT_ENTITY_DEBUG`. These are used internally by Expat for debug purposes. It is unlikely that they are related to the issue #1227.

### Conclusion

- This PR is making the conversion from string to double much more pedantic.
- Most of the calls to `atof` have been removed and replaced by `atof_locale_c`. For the record, the behavior of `atof` depends on the environment variable `LC_NUMERIC`.
- Some calls to the `atof` and `strto` functions remain but they are located in functions which we do not use.
  - Most of these calls are located in `simgear/props/props.cxx` and I am reluctant to use `atof_locale_c` in this piece of code. If we want to be super safe, I'd rather remove the aforementioned functions from `SGPropertyNode` since we are not using them anyway.