### PR TITLE
Fix memory leaks in `FGSwitch`

### DIFF
--- a/src/models/flight_control/FGSwitch.h
+++ b/src/models/flight_control/FGSwitch.h
@@ -146,7 +146,7 @@ public:
 private:
 
   struct Test {
-    FGCondition* condition;
+    std::unique_ptr<FGCondition> condition;
     bool Default;
     FGParameter_ptr OutputValue;
 


### PR DESCRIPTION
This PR fixes memory leaks that can occur in `FGSwitch` when an exception is thrown.

With the current code, there is 2 `try` blocks where a `Test` pointer is created with `new`. However if an exception is thrown, these pointers are not deleted which results in a memory leak.

The same is true for the pointer `current_test->condition` which is created with `new` but is not deleted when an exception is thrown.
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/models/flight_control/FGSwitch.cpp#L87-L103
https://github.com/JSBSim-Team/jsbsim/blob/0ac6194e3558c224accdd836545ef3c26d15f63c/src/models/flight_control/FGSwitch.cpp#L108-L118
The problem is solved by using `std::unique_ptr<>` which deletes the content it points to when its destructor is called.