### PR TITLE
Ubuntu update for CI workflows

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13, ubuntu-latest, windows-latest ]
+        os: [ macos-13, ubuntu-22.04, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout JSBSim

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -68,13 +68,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         expat: [ON, OFF]
         shared_libs: [ON, OFF]
         build_julia: [OFF]
         display_stack_trace: [ON]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             expat: OFF
             shared_libs: OFF
             build_julia: ON
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13, ubuntu-22.04, windows-latest ]
+        os: [ macos-13, ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout JSBSim


### PR DESCRIPTION
GitHub will [brown out then discard Ubuntu 20.04 runners](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes) and [Ubuntu 24.04 runers are now generally available](https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes).

This PR discards the former and adds the latter to our CI workflow.