### PR TITLE
Handle properly the exceptions returned by FGCondition

### DIFF
--- a/src/input_output/FGScript.cpp
+++ b/src/input_output/FGScript.cpp
@@ -241,11 +241,12 @@ bool FGScript::LoadScript(const SGPath& script, double default_dT,
 
     // Process the conditions
     Element* condition_element = event_element->FindElement("condition");
-    if (condition_element != 0) {
+    if (condition_element) {
       try {
         newCondition = new FGCondition(condition_element, PropertyManager);
-      } catch(string& str) {
-        cout << endl << fgred << str << reset << endl << endl;
+      } catch(BaseException& e) {
+        cerr << condition_element->ReadFrom()
+             << fgred << e.what() << reset << endl << endl;
         delete newEvent;
         return false;
       }

--- a/src/math/FGCondition.cpp
+++ b/src/math/FGCondition.cpp
@@ -65,9 +65,7 @@ FGCondition::FGCondition(Element* element, std::shared_ptr<FGPropertyManager> Pr
     if (logic == "OR") Logic = eOR;
     else if (logic == "AND") Logic = eAND;
     else { // error
-      cerr << element->ReadFrom()
-           << "Unrecognized LOGIC token " << logic << endl;
-      throw BaseException("FGCondition: unrecognized logic value:'" + logic + "'");
+      throw BaseException("FGCondition: unrecognized LOGIC token:'" + logic + "'");
     }
   } else {
     Logic = eAND; // default
@@ -87,21 +85,14 @@ FGCondition::FGCondition(Element* element, std::shared_ptr<FGPropertyManager> Pr
     string tagName = condition_element->GetName();
 
     if (tagName != elName) {
-      cerr << condition_element->ReadFrom()
-           << "Unrecognized tag <" << tagName << "> in the condition statement."
-           << endl;
-      throw BaseException("FGCondition: unrecognized tag:'" + tagName + "'");
+      throw BaseException("FGCondition: unrecognized TAG:'" + tagName + "' in the condition statement.");
     }
 
     conditions.push_back(make_shared<FGCondition>(condition_element, PropertyManager));
     condition_element = element->GetNextElement();
   }
 
-  if (conditions.empty()) {
-    cerr << element->ReadFrom()
-         << "Empty conditional" << endl;
-    throw BaseException("Empty conditional");
-  }
+  if (conditions.empty()) throw BaseException("Empty conditional");
 
   Debug(0);
 }
@@ -143,11 +134,11 @@ FGCondition::FGCondition(const string& test, std::shared_ptr<FGPropertyManager> 
     conditional = test_strings[1];
     TestParam2 = new FGParameterValue(test_strings[2], PropertyManager, el);
   } else {
-    cerr << el->ReadFrom()
-         << "  Conditional test is invalid: \"" << test
-         << "\" has " << test_strings.size() << " elements in the "
-         << "test condition." << endl;
-    throw BaseException("FGCondition: incorrect number of test elements:" + std::to_string(test_strings.size()));
+    stringstream s;
+    s << "  Conditional test is invalid: \"" << test
+      << "\" has " << test_strings.size() << " elements in the "
+      << "test condition." << endl;
+    throw BaseException(s.str());
   }
 
   assert(Comparison == ecUndef);

--- a/src/math/FGCondition.cpp
+++ b/src/math/FGCondition.cpp
@@ -134,10 +134,10 @@ FGCondition::FGCondition(const string& test, std::shared_ptr<FGPropertyManager> 
     conditional = test_strings[1];
     TestParam2 = new FGParameterValue(test_strings[2], PropertyManager, el);
   } else {
-    stringstream s;
+    ostringstream s;
     s << "  Conditional test is invalid: \"" << test
       << "\" has " << test_strings.size() << " elements in the "
-      << "test condition." << endl;
+      << "test condition.\n";
     throw BaseException(s.str());
   }
 

--- a/src/models/flight_control/FGDistributor.cpp
+++ b/src/models/flight_control/FGDistributor.cpp
@@ -63,14 +63,21 @@ FGDistributor::FGDistributor(FGFCS* fcs, Element* element)
   if (type_string == "inclusive") Type = eInclusive;
   else if (type_string == "exclusive") Type = eExclusive;
   else {
-    throw("Not a known Distributor type, "+type_string);
+    throw BaseException("Not a known Distributor type, "+type_string);
   }
 
   Element* case_element = element->FindElement("case");
   while (case_element) {
     Case* current_case = new Case;
     Element* test_element = case_element->FindElement("test");
-    if (test_element) current_case->SetTest(new FGCondition(test_element, PropertyManager));
+    try {
+      if (test_element) current_case->SetTest(new FGCondition(test_element, PropertyManager));
+    } catch (BaseException& e) {
+      cerr << test_element->ReadFrom()
+           << fgred << e.what() << reset << endl << endl;
+      delete current_case;
+      throw;
+    }
     Element* prop_val_element = case_element->FindElement("property");
     while (prop_val_element) {
       string value_string = prop_val_element->GetAttributeValue("value");

--- a/src/models/flight_control/FGDistributor.cpp
+++ b/src/models/flight_control/FGDistributor.cpp
@@ -73,8 +73,8 @@ FGDistributor::FGDistributor(FGFCS* fcs, Element* element)
     try {
       if (test_element) current_case->SetTest(new FGCondition(test_element, PropertyManager));
     } catch (BaseException& e) {
-      cerr << test_element->ReadFrom()
-           << fgred << e.what() << reset << endl << endl;
+      FGXMLLogging log(fcs->GetExec()->GetLogger(), test_element, LogLevel::FATAL);
+      log << LogFormat::RED << e.what() << LogFormat::RESET << "\n\n";
       delete current_case;
       throw;
     }


### PR DESCRIPTION
The constructor of `FGCondition` may throw exceptions of type `JSBSim::BaseException` when a `<condition>` element is improperly specified in the XML input files. The constructor of `FGCondition` is called by `FGScript::LoadScript` and the constructor of `FGDistributor` but none of them are handling properly the case where an exception is thrown by `FGCondition`:
* The method `FGScript::LoadScript` expects an exception of type `std::string` and therefore misses the deletion of the variable `newEvent` when `FGCondition` throws an exception `BaseException`.
* The constructor of `FGDistributor` does not catch any exception thrown by `FGCondition` so the variable `current_case` is not deleted when `FGCondition` throws.

These are 2 potential memory leaks that occur when JSBSim finds an error in a `<condition>` element.

Fixing these memory leaks have brought an opportunity to avoid the constructor of `FGCondition` outputting messages in the console. The error messages are now issued by the callers of the constructor of `FGCondition` which saves passing the instance of `FGLogger` to the constructor of `FGCondition`.