### PR TITLE
Memory leak fix and general improvements of `FGDistributor`

### DIFF
--- a/src/math/FGCondition.cpp
+++ b/src/math/FGCondition.cpp
@@ -157,7 +157,7 @@ FGCondition::FGCondition(const string& test, std::shared_ptr<FGPropertyManager> 
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-bool FGCondition::Evaluate(void )
+bool FGCondition::Evaluate(void) const
 {
   bool pass = false;
 
@@ -213,7 +213,7 @@ bool FGCondition::Evaluate(void )
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGCondition::PrintCondition(string indent)
+void FGCondition::PrintCondition(string indent) const
 {
   string scratch;
 

--- a/src/math/FGCondition.h
+++ b/src/math/FGCondition.h
@@ -68,8 +68,8 @@ public:
   FGCondition(const std::string& test, std::shared_ptr<FGPropertyManager> PropertyManager,
               Element* el);
 
-  bool Evaluate(void);
-  void PrintCondition(std::string indent="  ");
+  bool Evaluate(void) const;
+  void PrintCondition(std::string indent="  ") const;
 
 private:
 

--- a/src/models/flight_control/FGDistributor.cpp
+++ b/src/models/flight_control/FGDistributor.cpp
@@ -71,7 +71,7 @@ FGDistributor::FGDistributor(FGFCS* fcs, Element* element)
     auto current_case = make_unique<Case>();
     Element* test_element = case_element->FindElement("test");
     try {
-      if (test_element) current_case->SetTest(new FGCondition(test_element, PropertyManager));
+      if (test_element) current_case->SetTest(test_element, PropertyManager);
     } catch (BaseException& e) {
       FGXMLLogging log(fcs->GetExec()->GetLogger(), test_element, LogLevel::FATAL);
       log << LogFormat::RED << e.what() << LogFormat::RESET << "\n\n";
@@ -81,11 +81,11 @@ FGDistributor::FGDistributor(FGFCS* fcs, Element* element)
     while (prop_val_element) {
       string value_string = prop_val_element->GetAttributeValue("value");
       string property_string = prop_val_element->GetDataLine();
-      current_case->AddPropValPair(new PropValPair(property_string, value_string,
-                                                   PropertyManager, prop_val_element));
+      current_case->AddPropValPair(property_string, value_string, PropertyManager,
+                                   prop_val_element);
       prop_val_element = case_element->FindNextElement("property");
     }
-    Cases.push_back(current_case.release());
+    Cases.push_back(std::move(current_case));
     case_element = element->FindNextElement("case");
   }
 
@@ -94,18 +94,10 @@ FGDistributor::FGDistributor(FGFCS* fcs, Element* element)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-FGDistributor::~FGDistributor()
-{
-  for (auto Case: Cases) delete Case;
-  Debug(1);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
 bool FGDistributor::Run(void )
 {
   bool completed = false;
-  for (auto Case: Cases) { // Loop through all Cases
+  for (auto& Case: Cases) { // Loop through all Cases
     if (Case->HasTest()) {
       if (Case->GetTestResult() && !((Type == eExclusive) && completed)) {
         Case->SetPropValPairs();
@@ -146,19 +138,19 @@ void FGDistributor::Debug(int from)
     if (from == 0) { // Constructor
       FGLogging log(fcs->GetExec()->GetLogger(), LogLevel::DEBUG);
       unsigned int ctr=0;
-      for (auto Case: Cases) {
+      for (const auto& Case: Cases) {
         log << "      Case: " << fixed << ctr << "\n";
         if (Case->HasTest()) {
-          Case->GetTest()->PrintCondition("        ");
+          Case->GetTest().PrintCondition("        ");
         } else {
           log << "        Set these properties by default: \n";
         }
         log << "\n";
-        for (auto propVal = Case->IterPropValPairs(); propVal != Case->EndPropValPairs(); ++propVal) {
-          log << "        Set property " << (*propVal)->GetPropName();
-          if ((*propVal)->GetLateBoundProp()) log << " (late bound)";
-          log << " to " << (*propVal)->GetValString();
-          if ((*propVal)->GetLateBoundValue()) log << " (late bound)";
+        for (const auto& propVal: *Case) {
+          log << "        Set property " << propVal->GetPropName();
+          if (propVal->GetLateBoundProp()) log << " (late bound)";
+          log << " to " << propVal->GetValString();
+          if (propVal->GetLateBoundValue()) log << " (late bound)";
           log << "\n";
         }
         ctr++;

--- a/src/models/flight_control/FGDistributor.cpp
+++ b/src/models/flight_control/FGDistributor.cpp
@@ -68,14 +68,13 @@ FGDistributor::FGDistributor(FGFCS* fcs, Element* element)
 
   Element* case_element = element->FindElement("case");
   while (case_element) {
-    Case* current_case = new Case;
+    auto current_case = make_unique<Case>();
     Element* test_element = case_element->FindElement("test");
     try {
       if (test_element) current_case->SetTest(new FGCondition(test_element, PropertyManager));
     } catch (BaseException& e) {
       FGXMLLogging log(fcs->GetExec()->GetLogger(), test_element, LogLevel::FATAL);
       log << LogFormat::RED << e.what() << LogFormat::RESET << "\n\n";
-      delete current_case;
       throw;
     }
     Element* prop_val_element = case_element->FindElement("property");
@@ -86,7 +85,7 @@ FGDistributor::FGDistributor(FGFCS* fcs, Element* element)
                                                    PropertyManager, prop_val_element));
       prop_val_element = case_element->FindNextElement("property");
     }
-    Cases.push_back(current_case);
+    Cases.push_back(current_case.release());
     case_element = element->FindNextElement("case");
   }
 

--- a/src/models/flight_control/FGDistributor.h
+++ b/src/models/flight_control/FGDistributor.h
@@ -53,7 +53,7 @@ CLASS DOCUMENTATION
 
 /** Encapsulates a distributor for the flight control system.
 
-The distributor component models a distributor - 
+The distributor component models a distributor -
 
 Within a test, additional tests can be specified, which allows for
 complex groupings of logical comparisons. Each test contains
@@ -174,6 +174,7 @@ private:
 
     ~Case() {
       for (auto pair: PropValPairs) delete pair;
+      delete Test;
     }
 
     void SetTest(FGCondition* test) {Test = test;}

--- a/src/models/flight_control/FGDistributor.h
+++ b/src/models/flight_control/FGDistributor.h
@@ -131,9 +131,6 @@ public:
              that represents this distributor component */
   FGDistributor(FGFCS* fcs, Element* element);
 
-  /// Destructor
-  ~FGDistributor();
-
   /** Executes the distributor logic.
       @return true - always*/
   bool Run(void) override;
@@ -141,6 +138,7 @@ public:
 private:
 
   enum eType {eInclusive=0, eExclusive} Type;
+  template<typename T> using vector_of_unique_ptr = std::vector<std::unique_ptr<T>>;
 
   class PropValPair {
   public:
@@ -154,15 +152,14 @@ private:
         Prop->SetValue(Val->GetValue());
       }
       catch(...) {
-        throw(Prop->GetName()+" in distributor component is not known");
+        throw BaseException(Prop->GetName()+" in distributor component is not known");
       }
     }
 
-    std::string GetPropName() { return Prop->GetName(); }
-    std::string GetValString() { return Val->GetName(); }
-    bool GetLateBoundProp() { return Prop->IsLateBound(); }
-    bool GetLateBoundValue() {return Val->IsLateBound();
-    }
+    std::string GetPropName() const { return Prop->GetName(); }
+    std::string GetValString() const { return Val->GetName(); }
+    bool GetLateBoundProp() const { return Prop->IsLateBound(); }
+    bool GetLateBoundValue() const { return Val->IsLateBound(); }
   private:
     FGPropertyValue_ptr Prop;
     FGParameterValue_ptr Val;
@@ -172,30 +169,30 @@ private:
   public:
     Case() : Test(nullptr) {}
 
-    ~Case() {
-      for (auto pair: PropValPairs) delete pair;
-      delete Test;
+    void SetTest(Element* test_element, std::shared_ptr<FGPropertyManager> propMan) {
+      Test = std::make_unique<FGCondition>(test_element, propMan);
     }
-
-    void SetTest(FGCondition* test) {Test = test;}
-    FGCondition* GetTest(void) {return Test;}
-    void AddPropValPair(PropValPair* pvPair) {PropValPairs.push_back(pvPair);}
+    const FGCondition& GetTest(void) const noexcept { return *Test; }
+    void AddPropValPair(const std::string& property, const std::string& value,
+                        std::shared_ptr<FGPropertyManager> propManager, Element* prop_val_el) {
+      PropValPairs.push_back(std::make_unique<PropValPair>(property, value, propManager, prop_val_el));
+    }
     void SetPropValPairs() {
-      for (auto pair: PropValPairs) pair->SetPropToValue();
+      for (auto& pair: PropValPairs) pair->SetPropToValue();
     }
-    std::vector<PropValPair*>::const_iterator IterPropValPairs(void) const
+    vector_of_unique_ptr<PropValPair>::const_iterator begin(void) const
     { return PropValPairs.cbegin(); }
-    std::vector<PropValPair*>::const_iterator EndPropValPairs(void) const
+    vector_of_unique_ptr<PropValPair>::const_iterator end(void) const
     { return PropValPairs.cend(); }
-    bool HasTest() {return Test != nullptr;}
-    bool GetTestResult() { return Test->Evaluate(); }
+    bool HasTest() const noexcept { return Test != nullptr; }
+    bool GetTestResult() const { return Test->Evaluate(); }
 
   private:
-    FGCondition* Test;
-    std::vector <PropValPair*> PropValPairs;
+    std::unique_ptr<FGCondition> Test;
+    vector_of_unique_ptr<PropValPair> PropValPairs;
   };
 
-  std::vector <Case*> Cases;
+  vector_of_unique_ptr<Case> Cases;
 
   void Debug(int from) override;
 };


### PR DESCRIPTION
This is a follow up of PR #1244: the destructor `FGDistributor::Case::~Case` is not deleting its member `Test` because the call to `delete Test` is missing. It should have been:
```diff
    ~Case() {
      for (auto pair: PropValPairs) delete pair;
+     delete Test;
    }
```
Given this and the leak that has been fixed in PR #1244, this PR is addressing the issue upfront and replaces all pointers in `FGDistributor` by smart pointers (namely `std::unique_ptr<>`) which should fix all sources of memory leakage in `FGDistributor`.

The opportunity is taken to rename the iterator methods of the class `FGDistributor::Case` from `IterPropValPairs`, `EndPropValPairs` to the standardized names `begin`, `end`. This allows using a for-range loop instead of an explicit `for` loop:
```diff
-        for (auto propVal = Case->IterPropValPairs(); propVal != Case->EndPropValPairs(); ++propVal) {
+        for (const auto& propVal: *Case) {
```
which is easier to read.

Finally, the methods `FGCondition::Evaluate` and `FGCondition::PrintCondition` are constified to ensure that they are not having side effects on the instances of the class `FGDistributor::Case`.

Please note that the class `FGDistributor::Case` is private to `FGDistributor` and modifying its API has no side effects beyond the internal code of `FGDistributor`.