### PR TITLE
Updates to the tools used to build Python wheels.

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -656,7 +656,7 @@ jobs:
           Copy-Item -Path .\JSBSim-*\jsbsim\*.pyi -Destination ..\..\build\python\jsbsim
           echo "::endgroup::"
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19
+        uses: pypa/cibuildwheel@v2.23
         env:
           CIBW_BEFORE_ALL_LINUX: |
             cd build

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,16 +4,16 @@
 # Require setuptools >= 60.0.0 to be able to access its local copy of distutils
 # as distutils is deprecated for Python 3.10+ and will no longer be distributed
 # with Python 3.12+.
-requires = ["setuptools>=60.0.0", "cython!=0.29.26"]
+requires = ["setuptools>=60.0.0,<72.0.0", "cython!=0.29.26"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
 # Skip building against musl libc images as JSBSim is not compatible with them.
 skip = "cp*-musllinux_*"
 
 [[tool.cibuildwheel.overrides]]
-select = "pp39-* pp310-* cp311* cp312*"
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
+select = "pp38-* cp38*"
+manylinux-x86_64-image = "manylinux2010"
+manylinux-i686-image = "manylinux2010"

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -168,7 +168,7 @@ for d in os.scandir('jsbsim/aircraft'):
 
 # Build & installation process for the JSBSim Python module
 setup(
-    name="${PROJECT_NAME}",
+    name="${PROJECT_NAME}".lower(),
     version="${PROJECT_VERSION}",
     url="https://github.com/JSBSim-Team/jsbsim",
     author="Jon S. Berndt et al.",


### PR DESCRIPTION
This PR updates [pypa/cibuildwheel](https://github.com/pypa/cibuildwheel) to the latest version `2.19`.

It also upgrades all the wheels[^1] to using [the platform image `manylinux2014`](https://peps.python.org/pep-0599/) since the images `manylinux2010` are now outdated.
[^1]: With the exception of the wheels for Python 3.8 and PyPy 3.8, notably because Python 3.8 is no longer supported by the Python Fondation (see [PEP 569](https://peps.python.org/pep-0569)) and as such these versions should no longer be used.

The maximum version of `setuptools` is set to `72.0.0` because for some reason higher versions fail to compile JSBSim wheels for PyPy.

Finally, the package name is forced to lower case because [this is required by PyPA](https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization) and failing to comply with this requirement floods my mailbox with deprecation notices (one per faulty package name which makes a total of 36 e-mails for a release that does not comply - thanks PyPA :+1:):

> This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'JSBSim'.
>
> In the future, PyPI will require all newly uploaded binary distribution filenames to comply with the [binary distribution format](https://packaging.python.org/en/latest/specifications/binary-distribution-format/). Any binary distributions already uploaded will remain in place as-is and do not need to be updated.
>
> Specifically, your recent upload of `JSBSim-0.99.101-pp39-pypy39_pp73-win_amd64.whl` is incompatible with the distribution format specification because the filename does not contain the normalized project name `jsbsim`.
>
> In most cases, this can be resolved by upgrading the version of your build tooling to a later version that fully supports the specification and produces compliant filenames. You do not need to remove the file.
>
> If you have questions, you can email [admin@pypi.org](mailto:admin@pypi.org) to communicate with the PyPI [admin@pypi.org](mailto:admin@pypi.org) to communicate with the PyPI administrators.