### PR TITLE
New exception class `LogException` for compatibility with the new logging system.

### DIFF
--- a/julia/CMakeLists.txt
+++ b/julia/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 find_package(JlCxx) # May modify CMAKE_CXX_STANDARD thus called after set(CMAKE_CXX_STANDARD ...)
 
 if(Julia_FOUND)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,7 +5,7 @@ include(UseCython)
 string(TIMESTAMP THIS_YEAR "%Y")
 
 # Declare JSBSim as a C++ project
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(JSBSIM_PYX ${CMAKE_CURRENT_BINARY_DIR}/_jsbsim.pyx)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/jsbsim.pyx.in ${JSBSIM_PYX})

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -98,7 +98,7 @@ convert_CMake_list_to_Python_list = lambda s: [item.strip() for item in s.split(
 
 # `cpp_compile_flag` is used for C++ compilation only (see class `C_CxxCompiler`)
 if compiler.compiler_type == 'unix':
-    cpp_compile_flag = ['-std=c++14', '-DNDEBUG']
+    cpp_compile_flag = ['-std=c++17', '-DNDEBUG']
     cpp_link_flags = []
     link_libraries = convert_CMake_list_to_Python_list('${JSBSIM_LINK_LIBRARIES};${JSBSIM_UNIX_LINK_LIBRARIES}')
 elif compiler.compiler_type == 'msvc':

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 # Define some commons compile flags.                                           #
 ################################################################################
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # MSVC specific compile definitions
 set(MSVC_COMPILE_DEFINITIONS _USE_MATH_DEFINES NOMINMAX)

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -1338,7 +1338,7 @@ void FGFDMExec::DoTrim(int mode)
   if (Constructing) return;
 
   if (mode < 0 || mode > JSBSim::tNone)
-    throw("Illegal trimming mode!");
+    throw TrimFailureException("Illegal trimming mode!");
 
   FGTrim trim(this, (JSBSim::TrimMode)mode);
   bool success = trim.DoTrim();

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -147,14 +147,9 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
     Allocate();
   }
   catch (const string& msg) {
-    FGLogging log(Log, LogLevel::FATAL);
+    LogException log(Log);
     log << endl << "Caught error: " << msg << endl;
-    throw BaseException(log.str());
-  }
-  catch (const BaseException& e) {
-    FGLogging log(Log, LogLevel::FATAL);
-    log << endl << "Caught error: " << e.what() << endl;
-    throw BaseException(log.str());
+    throw log;
   }
 
   trim_status = false;
@@ -767,15 +762,15 @@ bool FGFDMExec::LoadPlanet(const SGPath& PlanetPath, bool useAircraftPath)
 
   // Make sure that the document is valid
   if (!document) {
-    FGLogging log(Log, LogLevel::ERROR);
+    LogException log(Log);
     log << "File: " << PlanetFileName << " could not be read." << endl;
-    throw BaseException(log.str());
+    throw log;
   }
 
   if (document->GetName() != "planet") {
-    FGXMLLogging log(Log, document, LogLevel::ERROR);
+    XMLLogException log(Log, document);
     log << "File: " << PlanetFileName << " is not a planet file." << endl;
-    throw BaseException(log.str());
+    throw log;
   }
 
   bool result = LoadPlanet(document);
@@ -1284,9 +1279,9 @@ bool FGFDMExec::ReadChild(Element* el)
   if (location) {
     child->Loc = location->FindElementTripletConvertTo("IN");
   } else {
-    FGXMLLogging log(Log, el, LogLevel::FATAL);
+    XMLLogException log(Log, el);
     log << "No location was found for this child object!" << endl;
-    throw BaseException(log.str());
+    throw log;
   }
 
   Element* orientation = el->FindElement("orient");

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -145,11 +145,10 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   // this is to catch errors in binding member functions to the property tree.
   try {
     Allocate();
-  }
-  catch (const string& msg) {
-    LogException log(Log);
-    log << endl << "Caught error: " << msg << endl;
-    throw log;
+  } catch (const BaseException& e) {
+    LogException err(Log);
+    err << endl << "Caught error: " << e.what() << endl;
+    throw err;
   }
 
   trim_status = false;
@@ -762,15 +761,15 @@ bool FGFDMExec::LoadPlanet(const SGPath& PlanetPath, bool useAircraftPath)
 
   // Make sure that the document is valid
   if (!document) {
-    LogException log(Log);
-    log << "File: " << PlanetFileName << " could not be read." << endl;
-    throw log;
+    LogException err(Log);
+    err << "File: " << PlanetFileName << " could not be read." << endl;
+    throw err;
   }
 
   if (document->GetName() != "planet") {
-    XMLLogException log(Log, document);
-    log << "File: " << PlanetFileName << " is not a planet file." << endl;
-    throw log;
+    XMLLogException err(Log, document);
+    err << "File: " << PlanetFileName << " is not a planet file." << endl;
+    throw err;
   }
 
   bool result = LoadPlanet(document);
@@ -1279,9 +1278,9 @@ bool FGFDMExec::ReadChild(Element* el)
   if (location) {
     child->Loc = location->FindElementTripletConvertTo("IN");
   } else {
-    XMLLogException log(Log, el);
-    log << "No location was found for this child object!" << endl;
-    throw log;
+    XMLLogException err(Log, el);
+    err << "No location was found for this child object!" << endl;
+    throw err;
   }
 
   Element* orientation = el->FindElement("orient");

--- a/src/FGJSBBase.h
+++ b/src/FGJSBBase.h
@@ -60,7 +60,7 @@ namespace JSBSim {
 
 class JSBSIM_API BaseException : public std::runtime_error {
   public:
-    BaseException(const std::string& msg) : std::runtime_error(msg) {}
+    using std::runtime_error::runtime_error;
 };
 
 /**

--- a/src/input_output/FGLog.cpp
+++ b/src/input_output/FGLog.cpp
@@ -234,6 +234,12 @@ LogException::LogException(LogException& other)
 
 const char* LogException::what() const noexcept
 {
+  // Although using const_cast is generally discouraged, it is justified here because:
+  // 1. The what() method must be const to comply with std::exception interface
+  // 2. We need to ensure all buffered messages are flushed before returning the error message
+  // 3. Conceptually, getting the complete error message is a "logically const" operation
+  //    i.e. from the user's perspective, it doesn't modify the state of the object.
+  const_cast<LogException*>(this)->Flush();
   return static_cast<BufferLogger*>(logger.get())->c_str();
 }
 

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -160,5 +160,18 @@ private:
   std::ostringstream buffer;
   LogLevel min_level = LogLevel::BULK;
 };
+
+class JSBSIM_API LogException : public BaseException, public FGLogging
+{
+public:
+  LogException(std::shared_ptr<FGLogger> logger);
+  LogException(LogException& other);
+};
+
+class JSBSIM_API XMLLogException : public LogException
+{
+public:
+  XMLLogException(std::shared_ptr<FGLogger> logger, Element* el);
+};
 } // namespace JSBSim
 #endif

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -166,6 +166,7 @@ class JSBSIM_API LogException : public BaseException, public FGLogging
 public:
   LogException(std::shared_ptr<FGLogger> logger);
   LogException(LogException& other);
+  const char* what() const noexcept override;
 };
 
 class JSBSIM_API XMLLogException : public LogException

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -129,7 +129,6 @@ public:
   FGLogging& operator<<(const SGPath& path) { buffer << path; return *this; }
   FGLogging& operator<<(const FGColumnVector3& vec) { buffer << vec; return *this; }
   FGLogging& operator<<(LogFormat format);
-  std::string str(void) const { return buffer.str(); }
   void Flush(void);
 protected:
   std::shared_ptr<FGLogger> logger;
@@ -173,6 +172,13 @@ class JSBSIM_API XMLLogException : public LogException
 {
 public:
   XMLLogException(std::shared_ptr<FGLogger> logger, Element* el);
+  /// This constructor can promote a LogException to an XMLLogException
+  /// by adding the file location information to the exception.
+  /// This is useful to add some context to an exception that was thrown in a
+  /// context where the file location of the error was not known.
+  /// @param exception The LogException to promote.
+  /// @param el The Element containing the file location of the error.
+  XMLLogException(LogException& exception, Element* el);
 };
 } // namespace JSBSim
 #endif

--- a/src/models/FGAerodynamics.cpp
+++ b/src/models/FGAerodynamics.cpp
@@ -232,10 +232,10 @@ bool FGAerodynamics::Run(bool Holding)
     break;
   default:
     {
-      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-      log << "\n  A proper axis type has NOT been selected. Check "
+      LogException err(FDMExec->GetLogger());
+      err << "\n  A proper axis type has NOT been selected. Check "
           << "your aerodynamics definition.\n";
-      throw BaseException(log.str());
+      throw err;
     }
   }
   // Calculate aerodynamic reference point shift, if any. The shift takes place
@@ -278,10 +278,10 @@ bool FGAerodynamics::Run(bool Holding)
     break;
   default:
     {
-      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-      log << "\n  A proper axis type has NOT been selected. Check "
+      LogException err(FDMExec->GetLogger());
+      err << "\n  A proper axis type has NOT been selected. Check "
           << "your aerodynamics definition.\n";
-      throw BaseException(log.str());
+      throw err;
     }
   }
 
@@ -471,10 +471,10 @@ void FGAerodynamics::DetermineAxisSystem(Element* document)
             << " aircraft config file. (NORMAL AXIAL)\n";
       }
     } else { // error
-      FGXMLLogging log(FDMExec->GetLogger(), axis_element, LogLevel::FATAL);
-      log << "\n  An unknown axis type, " << axis << " has been specified"
+      XMLLogException err(FDMExec->GetLogger(), axis_element);
+      err << "\n  An unknown axis type, " << axis << " has been specified"
           << " in the aircraft configuration file.\n";
-      throw BaseException(log.str());
+      throw err;
     }
     axis_element = document->FindNextElement("axis");
   }
@@ -524,9 +524,9 @@ void FGAerodynamics::ProcessAxesNameAndFrame(eAxisType& axisType, const string& 
     }
   }
   else {
-    FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::FATAL);
-    log << "\n Unknown axis frame type of - " << frame << "\n";
-    throw BaseException(log.str());
+    XMLLogException err(FDMExec->GetLogger(), el);
+    err << "\n Unknown axis frame type of - " << frame << "\n";
+    throw err;
   }
 }
 

--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -516,12 +516,12 @@ bool FGFCS::Load(Element* document)
     if (sOnOffProperty.length() > 0) {
       FGPropertyNode* OnOffPropertyNode = PropertyManager->GetNode(sOnOffProperty);
       if (OnOffPropertyNode == nullptr) {
-        FGXMLLogging log(FDMExec->GetLogger(), channel_element, LogLevel::FATAL);
-        log << LogFormat::BOLD << LogFormat::RED
+        XMLLogException err(FDMExec->GetLogger(), channel_element);
+        err << LogFormat::BOLD << LogFormat::RED
             << "The On/Off property, " << sOnOffProperty << " specified for channel "
             << channel_element->GetAttributeValue("name") << " is undefined or not "
             << "understood. The simulation will abort" << LogFormat::RESET << endl;
-        throw BaseException(log.str());
+        throw err;
       } else
         newChannel = new FGFCSChannel(this, sChannelName, ChannelRate,
                                       OnOffPropertyNode);
@@ -566,10 +566,10 @@ bool FGFCS::Load(Element* document)
           // <integrator> is equivalent to <pid type="trap">
           Element* c1_el = component_element->FindElement("c1");
           if (!c1_el) {
-            FGXMLLogging log(FDMExec->GetLogger(), component_element, LogLevel::FATAL);
-            log << "INTEGRATOR component " << component_element->GetAttributeValue("name")
+            XMLLogException err(FDMExec->GetLogger(), component_element);
+            err << "INTEGRATOR component " << component_element->GetAttributeValue("name")
                 << " does not provide the parameter <c1>" << endl;
-            throw BaseException(log.str());
+            throw err;
           }
           c1_el->ChangeName("ki");
           if (!c1_el->HasAttribute("type"))

--- a/src/models/FGGasCell.cpp
+++ b/src/models/FGGasCell.cpp
@@ -84,9 +84,9 @@ FGGasCell::FGGasCell(FGFDMExec* exec, Element* el, unsigned int num,
   if (element) {
     vXYZ = element->FindElementTripletConvertTo("IN");
   } else {
-    FGXMLLogging log(exec->GetLogger(), el, LogLevel::FATAL);
-    log << "\nFatal Error: No location found for this gas cell.\n";
-    throw BaseException(log.str());
+    XMLLogException err(exec->GetLogger(), el);
+    err << "\nFatal Error: No location found for this gas cell.\n";
+    throw err;
   }
   if ((el->FindElement("x_radius") || el->FindElement("x_width")) &&
       (el->FindElement("y_radius") || el->FindElement("y_width")) &&
@@ -137,9 +137,9 @@ FGGasCell::FGGasCell(FGFDMExec* exec, Element* el, unsigned int num,
          Xwidth * Ywidth * Zwidth);
     }
   } else {
-    FGXMLLogging log(exec->GetLogger(), el, LogLevel::FATAL);
-    log << "\nGas cell shape must be given.\n";
-    throw BaseException(log.str());
+    XMLLogException err(exec->GetLogger(), el);
+    err << "\nGas cell shape must be given.\n";
+    throw err;
   }
   if (el->FindElement("max_overpressure")) {
     MaxOverpressure = el->FindElementValueAsNumberConvertTo("max_overpressure",
@@ -519,9 +519,9 @@ FGBallonet::FGBallonet(FGFDMExec* exec, Element* el, unsigned int num,
   if (element) {
     vXYZ = element->FindElementTripletConvertTo("IN");
   } else {
-    FGXMLLogging log(exec->GetLogger(), el, LogLevel::FATAL);
-    log << "\nFatal Error: No location found for this ballonet.\n";
-    throw BaseException(log.str());
+    XMLLogException err(exec->GetLogger(), el);
+    err << "\nFatal Error: No location found for this ballonet.\n";
+    throw err;
   }
   if ((el->FindElement("x_radius") || el->FindElement("x_width")) &&
       (el->FindElement("y_radius") || el->FindElement("y_width")) &&
@@ -572,9 +572,9 @@ FGBallonet::FGBallonet(FGFDMExec* exec, Element* el, unsigned int num,
          Xwidth * Ywidth * Zwidth);
     }
   } else {
-    FGXMLLogging log(exec->GetLogger(), el, LogLevel::FATAL);
-    log << "\nFatal Error: Ballonet shape must be given.\n";
-    throw BaseException(log.str());
+    XMLLogException err(exec->GetLogger(), el);
+    err << "\nFatal Error: Ballonet shape must be given.\n";
+    throw err;
   }
   if (el->FindElement("max_overpressure")) {
     MaxOverpressure = el->FindElementValueAsNumberConvertTo("max_overpressure",

--- a/src/models/FGInput.cpp
+++ b/src/models/FGInput.cpp
@@ -158,9 +158,9 @@ bool FGInput::SetDirectivesFile(const SGPath& fname)
   FGXMLFileRead XMLFile;
   Element* document = XMLFile.LoadXMLDocument(fname);
   if (!document) {
-    FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
-    log << "Could not read directive file: " << fname << endl;
-    throw BaseException(log.str());
+    LogException err(FDMExec->GetLogger());
+    err << "Could not read directive file: " << fname << endl;
+    throw err;
   }
   bool result = Load(document);
 

--- a/src/models/FGLGear.cpp
+++ b/src/models/FGLGear.cpp
@@ -183,9 +183,9 @@ FGLGear::FGLGear(Element* el, FGFDMExec* fdmex, int number, const struct Inputs&
   Element* element = el->FindElement("location");
   if (element) vXYZn = element->FindElementTripletConvertTo("IN");
   else {
-    FGXMLLogging log(fdmex->GetLogger(), el, LogLevel::FATAL);
-    log << "\nNo location given for contact " << name << "\n";
-    throw BaseException(log.str());
+    XMLLogException err(fdmex->GetLogger(), el);
+    err << "\nNo location given for contact " << name << "\n";
+    throw err;
   }
   SetTransformType(FGForce::tCustom);
 

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -269,9 +269,9 @@ void FGMassBalance::AddPointMass(Element* el)
   Element* loc_element = el->FindElement("location");
   string pointmass_name = el->GetAttributeValue("name");
   if (!loc_element) {
-    FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::FATAL);
-    log << "Pointmass " << pointmass_name << " has no location." << endl;
-    throw BaseException(log.str());
+    XMLLogException err(FDMExec->GetLogger(), el);
+    err << "Pointmass " << pointmass_name << " has no location." << endl;
+    throw err;
   }
 
   double w = el->FindElementValueAsNumberConvertTo("weight", "LBS");

--- a/src/models/FGOutput.cpp
+++ b/src/models/FGOutput.cpp
@@ -176,9 +176,9 @@ bool FGOutput::SetDirectivesFile(const SGPath& fname)
   FGXMLFileRead XMLFile;
   Element* document = XMLFile.LoadXMLDocument(fname);
   if (!document) {
-    stringstream s;
-    s << "Could not read directive file: " << fname;
-    throw BaseException(s.str());
+    LogException err(FDMExec->GetLogger());
+    err << "Could not read directive file: " << fname;
+    throw err;
   }
 
   bool result = Load(document);

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -360,7 +360,7 @@ void FGPropagate::Integrate( FGColumnVector3& Integrand,
   case eBuss1:
   case eBuss2:
   case eLocalLinearization:
-    throw("Can only use Buss (1 & 2) or local linearization integration methods in for rotational position!");
+    throw BaseException("Can only use Buss (1 & 2) or local linearization integration methods in for rotational position!");
   default:
     break;
   }
@@ -1035,19 +1035,19 @@ void FGPropagate::Debug(int from)
   if (debug_lvl & 16) { // Sanity checking
     if (from == 2) { // State sanity checking
       if (fabs(VState.vPQR.Magnitude()) > 1000.0) {
-        FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
-        log << "Vehicle rotation rate is excessive (>1000 rad/sec): " << VState.vPQR.Magnitude() << endl;
-        throw BaseException(log.str());
+        LogException err(FDMExec->GetLogger());
+        err << "Vehicle rotation rate is excessive (>1000 rad/sec): " << VState.vPQR.Magnitude() << "\n";
+        throw err;
       }
       if (fabs(VState.vUVW.Magnitude()) > 1.0e10) {
-        FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
-        log << "Vehicle velocity is excessive (>1e10 ft/sec): " << VState.vUVW.Magnitude() << endl;
-        throw BaseException(log.str());
+        LogException err(FDMExec->GetLogger());
+        err << "Vehicle velocity is excessive (>1e10 ft/sec): " << VState.vUVW.Magnitude() << "\n";
+        throw err;
       }
       if (fabs(GetDistanceAGL()) > 1e10) {
-        FGLogging log(FDMExec->GetLogger(), LogLevel::FATAL);
-        log << "Vehicle altitude is excessive (>1e10 ft): " << GetDistanceAGL() << endl;
-        throw BaseException(log.str());
+        LogException err(FDMExec->GetLogger());
+        err << "Vehicle altitude is excessive (>1e10 ft): " << GetDistanceAGL() << "\n";
+        throw err;
       }
     }
   }

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -360,7 +360,11 @@ void FGPropagate::Integrate( FGColumnVector3& Integrand,
   case eBuss1:
   case eBuss2:
   case eLocalLinearization:
-    throw BaseException("Can only use Buss (1 & 2) or local linearization integration methods in for rotational position!");
+    {
+      LogException err(FDMExec->GetLogger());
+      err << "Can only use Buss (1 & 2) or local linearization integration methods in for rotational position!";
+      throw err;
+    }
   default:
     break;
   }

--- a/src/models/flight_control/FGAccelerometer.cpp
+++ b/src/models/flight_control/FGAccelerometer.cpp
@@ -62,9 +62,9 @@ FGAccelerometer::FGAccelerometer(FGFCS* fcs, Element* element)
   if (location_element)
     vLocation = location_element->FindElementTripletConvertTo("IN");
   else {
-    FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-    log << "No location given for accelerometer.\n";
-    throw BaseException(log.str());
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "No location given for accelerometer.\n";
+    throw err;
   }
 
   vRadius = MassBalance->StructuralToBody(vLocation);

--- a/src/models/flight_control/FGAngles.cpp
+++ b/src/models/flight_control/FGAngles.cpp
@@ -100,7 +100,9 @@ FGAngles::FGAngles(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
       }
     }
   } else {
-    throw("Target angle is required for component: "+Name);
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "Target angle is required for Angles component: " << Name << "\n";
+    throw err;
   }
 
   if (element->FindElement("source_angle") ) {
@@ -111,14 +113,20 @@ FGAngles::FGAngles(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
       }
     }
   } else {
-    throw("Source latitude is required for Angles component: "+Name);
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "Source angle is required for Angles component: " << Name << "\n";
+    throw err;
   }
 
   unit = element->GetAttributeValue("unit");
   if (!unit.empty()) {
     if      (unit == "DEG") output_unit = 180.0/M_PI;
     else if (unit == "RAD") output_unit = 1.0;
-    else throw("Unknown unit "+unit+" in angle component, "+Name);
+    else {
+      XMLLogException err(fcs->GetExec()->GetLogger(), element);
+      err << "Unknown unit " << unit << " in angle component, " << Name << "\n";
+      throw err;
+    }
   } else {
     output_unit = 1.0; // Default is radians (1.0) if unspecified
   }

--- a/src/models/flight_control/FGFCSComponent.cpp
+++ b/src/models/flight_control/FGFCSComponent.cpp
@@ -132,9 +132,9 @@ FGFCSComponent::FGFCSComponent(FGFCS* _fcs, Element* element) : fcs(_fcs)
     bool node_exists = PropertyManager->HasNode(output_node_name);
     FGPropertyNode* OutputNode = PropertyManager->GetNode( output_node_name, true );
     if (!OutputNode) {
-      FGXMLLogging log(fcs->GetExec()->GetLogger(), out_elem, LogLevel::FATAL);
-      log << "  Unable to process property: " << output_node_name << "\n";
-      throw BaseException(log.str());
+      XMLLogException err(fcs->GetExec()->GetLogger(), out_elem);
+      err << "  Unable to process property: " << output_node_name << "\n";
+      throw err;
     }
     OutputNodes.push_back(OutputNode);
     // If the node has just been created then it must be initialized to a
@@ -221,11 +221,11 @@ void FGFCSComponent::CheckInputNodes(size_t MinNodes, size_t MaxNodes, Element* 
   size_t num = InputNodes.size();
 
   if (num < MinNodes) {
-    FGXMLLogging log(fcs->GetExec()->GetLogger(), el, LogLevel::FATAL);
-    log << "    Not enough <input> nodes are provided\n"
+    XMLLogException err(fcs->GetExec()->GetLogger(), el);
+    err << "    Not enough <input> nodes are provided\n"
         << "    Expecting " << MinNodes << " while " << num
         << " are provided.\n";
-    throw BaseException(log.str());
+    throw err;
   }
 
   if (num > MaxNodes) {

--- a/src/models/flight_control/FGFCSFunction.cpp
+++ b/src/models/flight_control/FGFCSFunction.cpp
@@ -60,9 +60,9 @@ FGFCSFunction::FGFCSFunction(FGFCS* fcs, Element* element)
   if (function_element)
     function = new FGFunction(fcs->GetExec(), function_element);
   else {
-    FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-    log << "FCS Function should contain a \"function\" element\n";
-    throw BaseException(log.str());
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "FCS Function should contain a \"function\" element\n";
+    throw err;
   }
 
   bind(element, fcs->GetPropertyManager().get());

--- a/src/models/flight_control/FGGain.cpp
+++ b/src/models/flight_control/FGGain.cpp
@@ -85,17 +85,20 @@ FGGain::FGGain(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
       }
     }
     scale_element = element->FindElement("range");
-    if (!scale_element)
-      throw(string("No range supplied for aerosurface scale component"));
+    if (!scale_element) {
+      XMLLogException err(fcs->GetExec()->GetLogger(), scale_element);
+      err << "No range supplied for aerosurface scale component\n";
+      throw err;
+    }
     if (scale_element->FindElement("max") && scale_element->FindElement("min") )
     {
       OutMax = scale_element->FindElementValueAsNumber("max");
       OutMin = scale_element->FindElementValueAsNumber("min");
     } else {
-      FGXMLLogging log(fcs->GetExec()->GetLogger(), scale_element, LogLevel::FATAL);
-      log << "Maximum and minimum output values must be supplied for the "
+      XMLLogException err(fcs->GetExec()->GetLogger(), scale_element);
+      err << "Maximum and minimum output values must be supplied for the "
              "aerosurface scale component\n";
-      throw BaseException(log.str());
+      throw err;
     }
     ZeroCentered = true;
     Element* zero_centered = element->FindElement("zero_centered");
@@ -112,9 +115,9 @@ FGGain::FGGain(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
     if (element->FindElement("table")) {
       Table = new FGTable(PropertyManager, element->FindElement("table"));
     } else {
-      FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-      log << "A table must be provided for the scheduled gain component\n";
-      throw BaseException(log.str());
+      XMLLogException err(fcs->GetExec()->GetLogger(), element);
+      err << "A table must be provided for the scheduled gain component\n";
+      throw err;
     }
   }
 

--- a/src/models/flight_control/FGKinemat.cpp
+++ b/src/models/flight_control/FGKinemat.cpp
@@ -71,10 +71,10 @@ FGKinemat::FGKinemat(FGFCS* fcs, Element* element)
   }
 
   if (Detents.size() <= 1) {
-    FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-    log << "\nKinematic component " << Name
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "\nKinematic component " << Name
         << " must have more than 1 setting element\n";
-    throw BaseException(log.str());
+    throw err;
   }
 
   bind(element, fcs->GetPropertyManager().get());

--- a/src/models/flight_control/FGMagnetometer.cpp
+++ b/src/models/flight_control/FGMagnetometer.cpp
@@ -64,9 +64,9 @@ FGMagnetometer::FGMagnetometer(FGFCS* fcs, Element* element)
   if (location_element)
     vLocation = location_element->FindElementTripletConvertTo("IN");
   else {
-    FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-    log << "No location given for magnetometer.\n";
-    throw BaseException(log.str());
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "No location given for magnetometer.\n";
+    throw err;
   }
 
   vRadius = MassBalance->StructuralToBody(vLocation);

--- a/src/models/flight_control/FGSensor.cpp
+++ b/src/models/flight_control/FGSensor.cpp
@@ -270,9 +270,9 @@ void FGSensor::bind(Element* el, FGPropertyManager* PropertyManager)
       string qprop = "fcs/" + PropertyManager->mkPropertyName(quant_property, true);
       FGPropertyNode* node = PropertyManager->GetNode(qprop, true);
       if (node->isTied()) {
-        FGXMLLogging log(fcs->GetExec()->GetLogger(), el, LogLevel::FATAL);
-        log << "Property " << tmp << " has already been successfully bound (late).\n";
-        throw BaseException(log.str());
+        XMLLogException err(fcs->GetExec()->GetLogger(), el);
+        err << "Property " << tmp << " has already been successfully bound (late).\n";
+        throw err;
       }
       else
         PropertyManager->Tie(qprop, this, &FGSensor::GetQuantized);

--- a/src/models/flight_control/FGWaypoint.cpp
+++ b/src/models/flight_control/FGWaypoint.cpp
@@ -78,9 +78,9 @@ FGWaypoint::FGWaypoint(FGFCS* fcs, Element* element)
       }
     }
   } else {
-    FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-    log << "Target latitude is required for waypoint component: " << Name << "\n";
-    throw BaseException(log.str());
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "Target latitude is required for waypoint component: " << Name << "\n";
+    throw err;
   }
 
   if (element->FindElement("target_longitude") ) {
@@ -92,9 +92,9 @@ FGWaypoint::FGWaypoint(FGFCS* fcs, Element* element)
       }
     }
   } else {
-    FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-    log << "Target longitude is required for waypoint component: " << Name << "\n";
-    throw BaseException(log.str());
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "Target longitude is required for waypoint component: " << Name << "\n";
+    throw err;
   }
 
   if (element->FindElement("source_latitude") ) {
@@ -106,9 +106,9 @@ FGWaypoint::FGWaypoint(FGFCS* fcs, Element* element)
       }
     }
   } else {
-    FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-    log << "Source latitude is required for waypoint component: " << Name << "\n";
-    throw BaseException(log.str());
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "Source latitude is required for waypoint component: " << Name << "\n";
+    throw err;
   }
 
   if (element->FindElement("source_longitude") ) {
@@ -120,9 +120,9 @@ FGWaypoint::FGWaypoint(FGFCS* fcs, Element* element)
       }
     }
   } else {
-    FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-    log << "Source longitude is required for waypoint component: " << Name << "\n";
-    throw BaseException(log.str());
+    XMLLogException err(fcs->GetExec()->GetLogger(), element);
+    err << "Source longitude is required for waypoint component: " << Name << "\n";
+    throw err;
   }
 
   unit = element->GetAttributeValue("unit");
@@ -131,9 +131,9 @@ FGWaypoint::FGWaypoint(FGFCS* fcs, Element* element)
       if      (unit == "DEG") eUnit = eDeg;
       else if (unit == "RAD") eUnit = eRad;
       else {
-        FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-        log << "Unknown unit " << unit << " in HEADING waypoint component, " << "\n";
-        throw BaseException(log.str());
+        XMLLogException err(fcs->GetExec()->GetLogger(), element);
+        err << "Unknown unit " << unit << " in HEADING waypoint component, " << "\n";
+        throw err;
       }
     } else {
       eUnit = eRad; // Default is radians if unspecified
@@ -143,10 +143,10 @@ FGWaypoint::FGWaypoint(FGFCS* fcs, Element* element)
       if      (unit == "FT") eUnit = eFeet;
       else if (unit == "M")  eUnit = eMeters;
       else {
-        FGXMLLogging log(fcs->GetExec()->GetLogger(), element, LogLevel::FATAL);
-        log << "Unknown unit " << unit << " in DISTANCE waypoint component, "
+        XMLLogException err(fcs->GetExec()->GetLogger(), element);
+        err << "Unknown unit " << unit << " in DISTANCE waypoint component, "
             << Name << "\n";
-        throw BaseException(log.str());
+        throw err;
       }
     } else {
       eUnit = eFeet; // Default is feet if unspecified
@@ -175,19 +175,19 @@ bool FGWaypoint::Run(void )
   source.SetPositionGeodetic(source_longitude_rad, source_latitude_rad, 0.0);
 
   if (fabs(target_latitude_rad) > M_PI/2.0) {
-    FGLogging log(fcs->GetExec()->GetLogger(), LogLevel::FATAL);
-    log << "\nTarget latitude in waypoint \"" << Name
+    LogException err(fcs->GetExec()->GetLogger());
+    err << "\nTarget latitude in waypoint \"" << Name
         << "\" must be less than or equal to 90 degrees.\n"
         << "(is longitude being mistakenly supplied?)\n\n";
-    throw BaseException(log.str());
+    throw err;
   }
 
   if (fabs(source_latitude_rad) > M_PI/2.0) {
-    FGLogging log(fcs->GetExec()->GetLogger(), LogLevel::FATAL);
-    log << "\nSource latitude in waypoint \"" << Name
+    LogException err(fcs->GetExec()->GetLogger());
+    err << "\nSource latitude in waypoint \"" << Name
         << "\" must be less than or equal to 90 degrees.\n"
         << "(is longitude being mistakenly supplied?)\n\n";
-    throw BaseException(log.str());
+    throw err;
   }
 
   if (WaypointType == eHeading) {     // Calculate Heading

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 set(UNIT_TESTS FGColumnVector3Test
                StringUtilitiesTest

--- a/tests/unit_tests/FGLogTest.h
+++ b/tests/unit_tests/FGLogTest.h
@@ -39,7 +39,6 @@ void testConstructor() {
   TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::BULK);
 
   JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
-  TS_ASSERT(log.str().empty());
   TS_ASSERT(!logger->flushed);
   TS_ASSERT(logger->buffer.empty());
   TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
@@ -49,11 +48,13 @@ void testDestructor() {
   auto logger = std::make_shared<DummyLogger>();
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
-    TS_ASSERT(log.str().empty());
     TS_ASSERT(!logger->flushed);
+    TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->buffer.empty());
   TS_ASSERT(logger->flushed);
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testCharMessage() {
@@ -62,12 +63,13 @@ void testCharMessage() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log <<message;
-    TS_ASSERT_EQUALS(log.str(), message);
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, message);
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testStringMessage() {
@@ -76,12 +78,13 @@ void testStringMessage() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << message;
-    TS_ASSERT_EQUALS(log.str(), message);
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, message);
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testConcatenatedMessages() {
@@ -91,12 +94,13 @@ void testConcatenatedMessages() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << message1 << " " << message2;
-    TS_ASSERT_EQUALS(log.str(), message1 + " " + message2);
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, message1 + " " + message2);
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testEndl() {
@@ -104,12 +108,13 @@ void testEndl() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << "Hello" << std::endl << "World!";
-    TS_ASSERT_EQUALS(log.str(), "Hello\nWorld!");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "Hello\nWorld!");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testNumbers() {
@@ -117,12 +122,13 @@ void testNumbers() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << 1 << 2.1 << -3.4f;
-    TS_ASSERT_EQUALS(log.str(), "12.1-3.4");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "12.1-3.4");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testSetPrecision() {
@@ -130,12 +136,13 @@ void testSetPrecision() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << std::setprecision(3) << 1.23456789;
-    TS_ASSERT_EQUALS(log.str(), "1.23");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "1.23");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testSetWidthRight() {
@@ -143,12 +150,13 @@ void testSetWidthRight() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << std::setw(5) << 123;
-    TS_ASSERT_EQUALS(log.str(), "  123");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "  123");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testSetWidthLeft() {
@@ -156,12 +164,13 @@ void testSetWidthLeft() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << std::left << std::setw(5) << 123;
-    TS_ASSERT_EQUALS(log.str(), "123  ");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "123  ");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testPath() {
@@ -170,12 +179,13 @@ void testPath() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << (path/"file");
-    TS_ASSERT_EQUALS(log.str(), "Path \"path/to/file\"");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "Path \"path/to/file\"");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testColumnVector3() {
@@ -184,12 +194,13 @@ void testColumnVector3() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << vec;
-    TS_ASSERT_EQUALS(log.str(), "1 , 2 , 3");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "1 , 2 , 3");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testFormatOnly() {
@@ -199,12 +210,13 @@ void testFormatOnly() {
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
     log << JSBSim::LogFormat::NORMAL;
-    TS_ASSERT(log.str().empty());
     TS_ASSERT(!logger->flushed);
     TS_ASSERT_EQUALS(logger->buffer, "NORMAL");
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "NORMAL");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testClosingFormat() {
@@ -212,16 +224,17 @@ void testClosingFormat() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << "Hello,";
-    TS_ASSERT_EQUALS(log.str(), "Hello,");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
     log << JSBSim::LogFormat::NORMAL;
-    TS_ASSERT(log.str().empty());
     TS_ASSERT(!logger->flushed);
     TS_ASSERT_EQUALS(logger->buffer, "Hello,NORMAL");
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "Hello,NORMAL");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testMidFormat() {
@@ -229,20 +242,21 @@ void testMidFormat() {
   {
     JSBSim::FGLogging log(logger, JSBSim::LogLevel::INFO);
     log << "Hello,";
-    TS_ASSERT_EQUALS(log.str(), "Hello,");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
     log << JSBSim::LogFormat::NORMAL;
-    TS_ASSERT(log.str().empty());
     TS_ASSERT(!logger->flushed);
     TS_ASSERT_EQUALS(logger->buffer, "Hello,NORMAL");
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
     log << " World!";
-    TS_ASSERT_EQUALS(log.str(), " World!");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT_EQUALS(logger->buffer, "Hello,NORMAL");
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "Hello,NORMAL World!");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::INFO);
 }
 
 void testXMLLogging() {
@@ -252,13 +266,13 @@ void testXMLLogging() {
   el.SetLineNumber(42);
   {
     JSBSim::FGXMLLogging log(logger, &el, JSBSim::LogLevel::DEBUG);
-    TS_ASSERT(log.str().empty());
     TS_ASSERT_EQUALS(logger->buffer, "file.xml:42");
     TS_ASSERT(!logger->flushed);
     TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::DEBUG);
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "file.xml:42");
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::DEBUG);
 }
 };
 
@@ -705,6 +719,36 @@ void testWithMessage() {
   }
   TS_ASSERT(logger->flushed);
   TS_ASSERT_EQUALS(logger->buffer, "file.xml:42" + message);
+  TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::FATAL);
+}
+
+void testPromoteLogException() {
+  auto logger = std::make_shared<DummyLogger>();
+  JSBSim::Element el("element");
+  el.SetFileName("file.xml");
+  el.SetLineNumber(42);
+  try {
+    try {
+      JSBSim::LogException logException(logger);
+      logException << "Hello, World!";
+      TS_ASSERT(!logger->flushed);
+      TS_ASSERT(logger->buffer.empty());
+      TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::BULK);
+      throw logException;
+    } catch (JSBSim::LogException& e) {
+      JSBSim::XMLLogException logException(e, &el);
+      TS_ASSERT(!logger->flushed);
+      TS_ASSERT(logger->buffer.empty());
+      TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::BULK);
+      throw logException;
+    }
+  } catch (JSBSim::LogException&) {
+    TS_ASSERT(!logger->flushed);
+    TS_ASSERT(logger->buffer.empty());
+    TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::BULK);
+  }
+  TS_ASSERT(logger->flushed);
+  TS_ASSERT_EQUALS(logger->buffer, "file.xml:42Hello, World!");
   TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::FATAL);
 }
 };

--- a/tests/unit_tests/FGLogTest.h
+++ b/tests/unit_tests/FGLogTest.h
@@ -594,7 +594,8 @@ void testThrowFormattedMessages3() {
     TS_ASSERT(logger->buffer.empty());
     TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::BULK);
     throw logException;
-  } catch (JSBSim::BaseException&) {
+  } catch (const JSBSim::BaseException& e) {
+    TS_ASSERT_EQUALS(std::string(e.what()), message1 + message2);
     TS_ASSERT(!logger->flushed);
     TS_ASSERT(logger->buffer.empty());
     TS_ASSERT_EQUALS(logger->GetLogLevel(), JSBSim::LogLevel::BULK);


### PR DESCRIPTION
# Motivation

The current exception handling mechanism is not fully compatible with the new logging system (see PR #1094). In the existing system, error messages can be generated both when the exception is created and when it is caught, potentially leading to duplicate log entries. This change ensures that all exceptions are logged consistently and effectively, providing better traceability and debugging capabilities (see #1248).

# Description

## General principles

The new `LogException` class inherits from the `FGLogging` class, which utilizes RAII (Resource Acquisition Is Initialization) to ensure that log messages are written only once (see PR #1094 for a refresher).  The `FGLogging` class constructor acquires the resource (in this case, the ability to write to the log), and the destructor releases it, triggering the actual log writing:
  * When a `LogException` is created, its constructor (inherited from `FGLogging`) initializes the logging system.
  * The `LogException` object may then be passed through several layers of code (thrown and caught) without actually writing to the log.
  * Finally, when the `LogException` object goes out of scope (typically in a `catch` block), its destructor (inherited from `FGLogging`) is automatically called.
    * It is within this destructor that the actual writing of the log message occurs. This ensures that the message is written only once, regardless of how many times the `LogException` object was passed around.
  * This mechanism prevents the duplication of log entries that could occur if the log message were written in the exception's constructor or in every `catch` block.

To ensure that only one instance of the message is logged, the copy constructor of `LogException` does not duplicate the `BufferLogger` instance. Instead, all the copies share ownership of the same `BufferLogger` instance using a smart pointer `std::shared_ptr<>`. When the last copy of the `LogException` object (or the original object itself) is destroyed, the `std::shared_ptr<>`'s destructor is called and the `BufferLogger` is destroyed. It is at this point that the logging message is generated. This guarantees that the message is logged exactly once, when the last `LogException` referencing it is destroyed.

## Avoid early buffer flush

The previous use of `FGLogging` to format error messages directly in the `throw` statement caused problems because of the way the error message is buffered in `FGLogging`. For example:
https://github.com/JSBSim-Team/jsbsim/blob/e1ea4e85524e209037ec868f5a1383ec2ef3c7a1/src/models/FGFCS.cpp#L519-L524
* In this example, the call to `log.str()` is only returning `"\n"`. This is because `LogFormat::RESET` flushes the internal buffer of `FGLogging`. Thus, all the message items before `LogFormat::RESET` are skipped, leaving only the end-of-line character `\n` being passed to the `BaseException` instance.
* The new approach, using `LogException` and a new class `BufferLogger`, solves this problem by storing the whole messaging and its formatting in a buffer.
* An instance of `BufferLogger` is passed to `FGLogging` during the construction of `LogException`. This `BufferLogger` inherits from `FGLogger` and is responsible for storing the error message and its formatting. It uses the same RAII strategy than `FGLogger` to write the log message:
  * When the instance of `LogException` is destroyed, it calls the destructor of `BufferLogger` that triggers the actual log of the message.
* This ensures that the log message contains all the necessary information (text and formatting) and that there is no loss of information due to premature flushing of the buffer.
  
## Simplified exception throwing

The code for throwing an exception is slightly simplified. There is no longer a need to specify the `LogLevel`, which is systematically set to `LogLevel::FATAL` and the `throw` statement becomes trivial. A simplified version of the code mentioned above would become:
```c++
LogException err(logger);
err << LogFormat::RED << "Error" << LogFormat::RESET << "\n";
throw err;
```

## Contextual information enrichment

The new `LogException` class allows adding contextual information when an exception is caught:
```c++
try {
    LogException err(logger);
    err << "Something went wrong\n";
    throw err;
} catch (LogException& e) {
    e << "Could not process data\n";
    throw;
}
```
This is an improvement compared to our base exception `BaseException`, which cannot be modified after its creation.  `LogException` enables enriching the error message with details specific to the catch context, providing more comprehensive logging.

## XML Location Information

The `XMLLogException` class inherits directly from `LogException` and, like `XMLLogging`, allows adding information to the exception about the location of the error in the XML file.

Using a new class also allows finer granularity in the `catch` statement with a differentiated processing depending on the type of the exception. For example, we can add some error location to an exception that does not provide any:
```c++
Element* el;

try {
 // Code that can throw
} catch (const XMLLogException&) {
  throw; // If some XML data is already included, just rethrow
} catch (LogException& e) {
  throw XMLLogException(e, el); // Add some XML data since none were provided.
}
```

## Simplified log management

The use of `LogException` simplifies log management for the programmer who no longer need to track whether a message has already been logged. The RAII mechanism ensures that the log message is written exactly once, and this happens automatically when the last copy of the `LogException` object is destroyed. This eliminates the possibility of accidental duplicate logs and reduces the mental burden on the programmer.

## Transition to C++17

With this change, JSBSim is transitioning to C++17. This has been discussed on several occasions, and this PR inaugurates the transition to C++17.

The choice was motivated by the `what` method inherited from `std::exception`. This method returns a pointer `const char*`, which means that a temporary variable (which will be destroyed on return) cannot be returned. Therefore, the message must be stored as a member in `BufferLogger`. However, since `what` must be `const`, the message must be constructed in advance.

To avoid having two buffers (one to store the message to be returned by `what` and the other to store the formatted message), the implementation of `BufferLogger` uses `std::string_view` which has been added to the STL since C++17.

# Benefits

* **Consistent Logging:** Ensures all exceptions are handled and logged in a uniform format.
* **Eliminates Duplicate Logging:** Prevents redundant log messages by using RAII to manage the logging process.
* **Preserves Message Formatting:** Correctly captures and logs the full error message, including any formatting.
* **Simplified exception throwing:** The code for throwing an exception is slightly simplified.
* **Contextual information enrichment:** The new `LogException` class allows adding contextual information when an exception is caught.
* **Simplified log management:** The use of `LogException` simplifies log management for the programmer.
* **Compatibility:** Guarantees compatibility with the newly implemented logging system.
* **Modern C++:** This change leverages modern C++ features (C++17)

## Changes

* Existing exception classes (e.g., `std::string`, `BasicException`) have been replaced with `LogException` in the classes that have already been updated to use the new logging system.
* Some new unit tests have been added to check that `LogException` works as appropriate.