### PR TITLE
Allow for a separate random seed for wind turbulence

### DIFF
--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -629,6 +629,8 @@ public:
 
   auto GetRandomGenerator(void) const { return RandomGenerator; }
 
+  int  SRand(void) const { return RandomSeed; }
+
 private:
   // Declare Log first so that it's destroyed last: the logger may be used by
   // some FGFDMExec members to log data during their destruction.
@@ -705,7 +707,6 @@ private:
   bool ReadChild(Element*);
   bool ReadPrologue(Element*);
   void SRand(int sr);
-  int  SRand(void) const {return RandomSeed;}
   void LoadInputs(unsigned int idx);
   void LoadPlanetConstants(void);
   bool LoadPlanet(Element* el);

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -133,6 +133,12 @@ bool FGWinds::InitModel(void)
   oneMinusCosineGust.gustProfile.Running = false;
   oneMinusCosineGust.gustProfile.elapsedTime = 0.0;
 
+  xi_u_km1 = nu_u_km1 = 0;
+  xi_v_km1 = xi_v_km2 = nu_v_km1 = nu_v_km2 = 0;
+  xi_w_km1 = xi_w_km2 = nu_w_km1 = nu_w_km2 = 0;
+  xi_p_km1 = nu_p_km1 = 0;
+  xi_q_km1 = xi_r_km1 = 0;
+
   return true;
 }
 
@@ -279,16 +285,6 @@ void FGWinds::Turbulence(double h)
       L_u = L_w = 1750.; //  MIL-F-8785c, Sec. 3.7.2.1, p. 48
       sig_u = sig_w = POE_Table->GetValue(probability_of_exceedence_index, h);
     }
-
-    // keep values from last timesteps
-    // TODO maybe use deque?
-    static double
-      xi_u_km1 = 0, nu_u_km1 = 0,
-      xi_v_km1 = 0, xi_v_km2 = 0, nu_v_km1 = 0, nu_v_km2 = 0,
-      xi_w_km1 = 0, xi_w_km2 = 0, nu_w_km1 = 0, nu_w_km2 = 0,
-      xi_p_km1 = 0, nu_p_km1 = 0,
-      xi_q_km1 = 0, xi_r_km1 = 0;
-
 
     double
       T_V = in.totalDeltaT, // for compatibility of nomenclature

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -486,6 +486,17 @@ void FGWinds::UpDownBurst()
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+// User is supplying a wind specific random seed to override the random seed
+// used by FGFDMExec. So initialise a new random number generator with this
+// random seed rather than referencing the FGFDMExec random number generator.
+
+void FGWinds::SetRandomSeed(int sr)
+{
+  RandomSeed = sr;
+  generator = std::make_shared<RandomNumberGenerator>(RandomSeed);
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGWinds::bind(void)
 {
@@ -565,6 +576,8 @@ void FGWinds::bind(void)
   PropertyManager->Tie("atmosphere/total-wind-east-fps",  this, eEast,  (PMF)&FGWinds::GetTotalWindNED);
   PropertyManager->Tie("atmosphere/total-wind-down-fps",  this, eDown,  (PMF)&FGWinds::GetTotalWindNED);
 
+  // Allow user to specify a separate random seed independent of the FDMExec random seed
+  PropertyManager->Tie("atmosphere/randomseed", this, (PMFt)&FGWinds::GetRandomSeed, &FGWinds::SetRandomSeed);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -489,7 +489,14 @@ void FGWinds::UpDownBurst()
 void FGWinds::SetRandomSeed(int sr)
 {
   RandomSeed = sr;
-  generator = std::make_shared<RandomNumberGenerator>(RandomSeed);
+  generator = std::make_shared<RandomNumberGenerator>(*RandomSeed);
+}
+
+int  FGWinds::GetRandomSeed(void) const {
+  if (RandomSeed)
+    return *RandomSeed;
+  else
+    return FDMExec->SRand();
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/atmosphere/FGWinds.h
+++ b/src/models/atmosphere/FGWinds.h
@@ -40,6 +40,7 @@ INCLUDES
 
 #include "models/FGModel.h"
 #include "math/FGMatrix33.h"
+#include <optional>
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 FORWARD DECLARATIONS
@@ -402,11 +403,11 @@ private:
   FGColumnVector3 vBurstGust;
   FGColumnVector3 vTurbulenceNED;
 
-  unsigned int RandomSeed;
+  std::optional<unsigned int> RandomSeed;
   std::shared_ptr<RandomNumberGenerator> generator;
 
   void SetRandomSeed(int sr);
-  int  GetRandomSeed(void) const { return RandomSeed; }
+  int  GetRandomSeed(void) const;
 
   void Turbulence(double h);
   void UpDownBurst();

--- a/src/models/atmosphere/FGWinds.h
+++ b/src/models/atmosphere/FGWinds.h
@@ -394,7 +394,11 @@ private:
   FGColumnVector3 vBurstGust;
   FGColumnVector3 vTurbulenceNED;
 
+  unsigned int RandomSeed;
   std::shared_ptr<RandomNumberGenerator> generator;
+
+  void SetRandomSeed(int sr);
+  int  GetRandomSeed(void) const { return RandomSeed; }
 
   void Turbulence(double h);
   void UpDownBurst();

--- a/src/models/atmosphere/FGWinds.h
+++ b/src/models/atmosphere/FGWinds.h
@@ -386,6 +386,14 @@ private:
   int probability_of_exceedence_index; ///< this is bound as the severity property
   FGTable *POE_Table; ///< probability of exceedence table
 
+  // keep values from last timesteps
+  // TODO maybe use deque?
+  double xi_u_km1, nu_u_km1;
+  double xi_v_km1, xi_v_km2, nu_v_km1, nu_v_km2;
+  double xi_w_km1, xi_w_km2, nu_w_km1, nu_w_km2;
+  double xi_p_km1, nu_p_km1;
+  double xi_q_km1, xi_r_km1;
+
   double psiw;
   FGColumnVector3 vTotalWindNED;
   FGColumnVector3 vWindNED;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(PYTHON_TESTS ResetOutputFiles
                  CheckOutputRate
                  TestAccelerometer
                  CheckDebugLvl
+                 TestTurbulenceRandomSeed
                  TestCosineGust
                  TestScriptOutput
                  CheckSimTimeReset

--- a/tests/TestTurbulenceRandomSeed.py
+++ b/tests/TestTurbulenceRandomSeed.py
@@ -72,4 +72,17 @@ class TestTurbulenceRandomSeed(JSBSimTestCase):
 
         return (wn, we, wd)
 
+    def testUnassignedSeed(self):
+        # Test that if no random seed is assigned for turbulence that the seed
+        # for turbulence is the same as the FGFDMExec seed.
+        fdm = self.create_fdm()
+
+        # Set a random seed for FGFDMExec
+        exec_seed = 47
+        fdm["simulation/randomseed"] = exec_seed
+
+        wind_seed = fdm["atmosphere/randomseed"]
+
+        self.assertEqual(exec_seed, wind_seed)
+
 RunTest(TestTurbulenceRandomSeed)

--- a/tests/TestTurbulenceRandomSeed.py
+++ b/tests/TestTurbulenceRandomSeed.py
@@ -1,0 +1,74 @@
+# TestTurbulenceRandomSeed.py
+#
+# Check that turbulence and gusts end their effect when completed or cancelled.
+#
+# Copyright (c) 2025 Sean McLeod
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses/>
+#
+
+from JSBSim_utils import JSBSimTestCase, CreateFDM, RunTest
+
+
+class TestTurbulenceRandomSeed(JSBSimTestCase):
+
+    def testTurbulenceRandomSeed(self):
+        # Test that the wind turbulence random seed is reproducible as
+        # FGFDMExec seed is changed between runs.
+        wind_random_seed = 2
+        wn1, we1, wd1 = self.captureTurbulence(wind_random_seed, 4)
+        wn2, we2, wd2 = self.captureTurbulence(wind_random_seed, 5)
+        for i in range(len(wn1)):
+            self.assertAlmostEqual(wn1[i], wn2[i], delta=1E-8)
+            self.assertAlmostEqual(we1[i], we2[i], delta=1E-8)
+            self.assertAlmostEqual(wd1[i], wd2[i], delta=1E-8)
+
+    def captureTurbulence(self, wind_seed, exec_seed):
+        fdm = self.create_fdm()
+
+        # Set random seeds for FGFDMExec and FGWinds
+        fdm["simulation/randomseed"] = exec_seed
+        fdm["atmosphere/randomseed"] = wind_seed
+
+        fdm.load_model('A4') 
+
+        # Set engine running
+        fdm['propulsion/engine[0]/set-running'] = 1
+
+        fdm['ic/h-sl-ft'] = 20000
+        fdm['ic/vc-kts'] = 250
+        fdm['ic/gamma-deg'] = 0
+
+        fdm.run_ic()
+
+        fdm['simulation/do_simple_trim'] = 1
+
+        # Setup turbulence
+        fdm["atmosphere/turb-type"] = 3
+        fdm["atmosphere/turbulence/milspec/windspeed_at_20ft_AGL-fps"] = 75
+        fdm["atmosphere/turbulence/milspec/severity"] = 6
+
+        wn = []
+        we = []
+        wd = []
+
+        while fdm.get_sim_time() < 0.15:
+            fdm.run()
+            wn.append(fdm['atmosphere/total-wind-north-fps'])
+            we.append(fdm['atmosphere/total-wind-east-fps'])
+            wd.append(fdm['atmosphere/total-wind-down-fps'])
+
+        return (wn, we, wd)
+
+RunTest(TestTurbulenceRandomSeed)

--- a/tests/TestTurbulenceRandomSeed.py
+++ b/tests/TestTurbulenceRandomSeed.py
@@ -1,6 +1,7 @@
 # TestTurbulenceRandomSeed.py
 #
-# Check that turbulence and gusts end their effect when completed or cancelled.
+# Check that identical wind outputs are achieved over multiple runs with the same
+# atmosphere/randomseed.
 #
 # Copyright (c) 2025 Sean McLeod
 #


### PR DESCRIPTION
As per the discussion at https://github.com/JSBSim-Team/jsbsim/discussions/1250 allow the user to specify a separate random seed for the random number generator used by the turbulence code in `FGWinds`.

I've tested this by running `JSBSim.exe` with a script and varying the random seeds and comparing the wind output in the CSV file.

So in this example, running the script twice and toggling ``simulation/randomseed` between 1 and 2 but keeping `atmosphere/randomseed` constant gives the exact same wind output with turbulence enabled.

```xml
  <run start="0" end="15" dt="0.008333">

	  <property value="1"> simulation/randomseed </property>
	  <property value="3"> atmosphere/randomseed </property>
```

As mentioned here - https://github.com/JSBSim-Team/jsbsim/discussions/1250#discussioncomment-12736631 I haven't been able to write a python test case using the test setup we have.