### PR TITLE
`FGTurbine` does not update the thruster inputs before calling `FGThruster::Calculate`

### DIFF
--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -163,6 +163,7 @@ void FGTurbine::Calculate(void)
     default: thrust = Off();
   }
 
+  LoadThrusterInputs();
   Thruster->Calculate(thrust); // allow thruster to modify thrust (i.e. reversing)
 
   RunPostFunctions();


### PR DESCRIPTION
As the title says, the bug is silently triggered by the C130 model which has a creative combination of `FGTurbine` engines with `FGPropeller`.
https://github.com/JSBSim-Team/jsbsim/blob/13008f3045a0c1bf858ec4f5346c09403ed5dd28/aircraft/C130/C130.xml#L114-L116
Currently since `FGTurbine` does not call `FGEngine::LoadThrusterInputs` then `FGThruster::in::SoundSpeed` is not initialized.
https://github.com/JSBSim-Team/jsbsim/blob/13008f3045a0c1bf858ec4f5346c09403ed5dd28/src/models/propulsion/FGEngine.cpp#L135-L144
So when the variable `HelicalTipMach` is computed `in.SoundSpeed` contains garbage and is potentially zero which raises a numerical exception.
https://github.com/JSBSim-Team/jsbsim/blob/13008f3045a0c1bf858ec4f5346c09403ed5dd28/src/models/propulsion/FGPropeller.cpp#L225
Fortunately, the C130 model do not use the tables `CP_MACH` and `CT_MACH` hence the bug has no further consequences.

I have found the bug by chance while running the debugger which was halting at the line of code that computes `HelicalTipMach` and was complaining that a numerical exception was occurring. The bug fix is trivial: it just adds a call to `FGEngine::LoadThrusterInputs` before the call to `FGThruster::Calculate`.