### PR TITLE
Logging redesign - part 5

### DIFF
--- a/src/initialization/FGLinearization.cpp
+++ b/src/initialization/FGLinearization.cpp
@@ -18,6 +18,7 @@
 
 #include "FGInitialCondition.h"
 #include "FGLinearization.h"
+#include "input_output/FGLog.h"
 
 
 namespace JSBSim {
@@ -45,7 +46,8 @@ FGLinearization::FGLinearization(FGFDMExec * fdm)
         if (numEngines>2) ss.x.add(new FGStateSpace::Rpm2);
         if (numEngines>3) ss.x.add(new FGStateSpace::Rpm3);
         if (numEngines>4) {
-            std::cerr << "more than 4 engines not currently handled" << std::endl;
+            FGLogging log(fdm->GetLogger(), LogLevel::ERROR);
+            log << "More than 4 engines not currently handled\n";
         }
     }
     ss.x.add(new FGStateSpace::Beta);

--- a/src/initialization/FGSimplexTrim.cpp
+++ b/src/initialization/FGSimplexTrim.cpp
@@ -16,9 +16,11 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <ctime>
+
 #include "FGTrim.h"
 #include "FGSimplexTrim.h"
-#include <ctime>
+#include "input_output/FGLog.h"
 
 namespace JSBSim {
 
@@ -30,7 +32,8 @@ FGSimplexTrim::FGSimplexTrim(FGFDMExec * fdm, TrimMode mode)
     FGTrimmer::Constraints constraints;
 
     if (fdm->GetDebugLevel() > 0) {
-        std::cout << "\n-----Performing Simplex Based Trim --------------\n" << std::endl;
+        FGLogging log(fdm->GetLogger(), LogLevel::DEBUG);
+        log << "\n-----Performing Simplex Based Trim --------------\n";
     }
 
     // defaults
@@ -48,7 +51,7 @@ FGSimplexTrim::FGSimplexTrim(FGFDMExec * fdm, TrimMode mode)
     // flight conditions
     double phi = fdm->GetIC()->GetPhiRadIC();
     double theta = fdm->GetIC()->GetThetaRadIC();
-    double gd = fdm->GetInertial()->gravity();
+    double gd = fdm->GetInertial()->GetGravity().Magnitude();
 
     constraints.velocity = fdm->GetIC()->GetVtrueFpsIC();
     constraints.altitude = fdm->GetIC()->GetAltitudeASLFtIC();
@@ -104,9 +107,10 @@ FGSimplexTrim::FGSimplexTrim(FGFDMExec * fdm, TrimMode mode)
 
     // output
     if (fdm->GetDebugLevel() > 0) {
-        trimmer->printSolution(std::cout,solver->getSolution());
-        std::cout << "\nfinal cost: " << std::scientific << std::setw(10) << trimmer->eval(solver->getSolution()) << std::endl;
-        std::cout << "\ntrim computation time: " << (time_trimDone - time_start)/double(CLOCKS_PER_SEC) << "s \n" << std::endl;
+        FGLogging log(fdm->GetLogger(), LogLevel::DEBUG);
+        trimmer->printSolution(solver->getSolution());
+        log << "\nfinal cost: " << std::scientific << std::setw(10) << trimmer->eval(solver->getSolution()) << "\n";
+        log << "\ntrim computation time: " << (time_trimDone - time_start)/double(CLOCKS_PER_SEC) << "s \n\n";
     }
 
     delete solver;

--- a/src/initialization/FGSimplexTrim.h
+++ b/src/initialization/FGSimplexTrim.h
@@ -52,12 +52,12 @@ private:
     }
 
     class Callback : public JSBSim::FGNelderMead::Callback
-    {   
+    {
     private:
         std::ofstream _outputFile;
         JSBSim::FGTrimmer * _trimmer;
     public:
-        Callback(std::string fileName, JSBSim::FGTrimmer * trimmer) : 
+        Callback(std::string fileName, JSBSim::FGTrimmer * trimmer) :
             _outputFile((fileName + std::string("_simplexTrim.log")).c_str()),
             _trimmer(trimmer) {
         }
@@ -66,10 +66,11 @@ private:
         }
         void eval(const std::vector<double> &v)
         {
-            _outputFile << _trimmer->eval(v) << std::endl;;
-            //std::cout << "v: ";
-            //for (int i=0;i<v.size();i++) std::cout << v[i] << " ";
-            //std::cout << std::endl;
+            _outputFile << _trimmer->eval(v) << std::endl;
+            // FGLogging log(_trimmer->getFdm()->GetLogger(), LogLevel::INFO);
+            //log << "v: ";
+            //for (int i=0;i<v.size();i++) log << v[i] << " ";
+            //log << std::endl;
         }
     };
 };

--- a/src/initialization/FGTrimAnalysis.cpp
+++ b/src/initialization/FGTrimAnalysis.cpp
@@ -61,6 +61,7 @@ INCLUDES
 
 #include "input_output/FGPropertyManager.h"
 #include "input_output/FGXMLParse.h"
+#include "input_output/FGLog.h"
 
 #include "models/propulsion/FGPiston.h"
 #include "models/propulsion/FGPropeller.h"
@@ -220,12 +221,14 @@ Objective::Objective(FGFDMExec* fdmex, FGTrimAnalysis* ta, double x) : _x(x), Tr
 void Objective::CostFunctionFull(long vars, Vector<double> &v, double & f)
 {
   if (vars != 7) {
-      cerr << "\nError: (Cost function for taFull mode) Dimension must be 7 !!\n";
-      exit(1);
+    LogException err(FDMExec->GetLogger());
+    err << "\nError: (Cost function for taFull mode) Dimension must be 7 !!\n";
+    throw err;
   }
   if (TrimAnalysis->GetMode()!=taFull){
-      cerr << "\nError: must be taFull mode !!\n";
-      exit(1);
+    LogException err(FDMExec->GetLogger());
+    err << "\nError: must be taFull mode !!\n";
+    throw err;
   }
 
   f = myCostFunctionFull(v);
@@ -235,12 +238,14 @@ void Objective::CostFunctionFull(long vars, Vector<double> &v, double & f)
 void Objective::CostFunctionFullWingsLevel(long vars, Vector<double> &v, double & f)
 {
   if (vars != 6) {
-      cerr << "\nError: (Cost function for taFullWingsLevel mode) Dimension must be 6 !!\n";
-      exit(1);
+    LogException err(FDMExec->GetLogger());
+    err << "\nError: (Cost function for taFullWingsLevel mode) Dimension must be 6 !!\n";
+    throw err;
   }
   if (TrimAnalysis->GetMode()!=taFullWingsLevel){
-      cerr << "\nError: must be taFull mode !!\n";
-      exit(1);
+    LogException err(FDMExec->GetLogger());
+    err << "\nError: must be taFull mode !!\n";
+    throw err;
   }
 
   f = myCostFunctionFullWingsLevel(v);
@@ -250,12 +255,14 @@ void Objective::CostFunctionFullWingsLevel(long vars, Vector<double> &v, double 
 void Objective::CostFunctionLongitudinal(long vars, Vector<double> &v, double & f)
 {
   if (vars != 3) {
-      cerr << "\nError: (Cost function for taLongitudinal mode) Dimension must be 3 !!\n";
-      exit(1);
+      LogException err(FDMExec->GetLogger());
+      err << "\nError: (Cost function for taLongitudinal mode) Dimension must be 3 !!\n";
+      throw err;
   }
   if (TrimAnalysis->GetMode()!=taLongitudinal){
-      cerr << "\nError: trim mode must be taLongitudinal mode !!\n";
-      exit(1);
+      LogException err(FDMExec->GetLogger());
+      err << "\nError: trim mode must be taLongitudinal mode !!\n";
+      throw err;
   }
 
   f = myCostFunctionLongitudinal(v);
@@ -265,12 +272,14 @@ void Objective::CostFunctionLongitudinal(long vars, Vector<double> &v, double & 
 void Objective::CostFunctionFullCoordinatedTurn(long vars, Vector<double> &v, double & f)
 {
   if (vars != 5) {
-      cerr << "\nError: (Cost function for taTurn mode) Dimension must be 5 !!\n";
-      exit(1);
+      LogException err(FDMExec->GetLogger());
+      err << "\nError: (Cost function for taTurn mode) Dimension must be 5 !!\n";
+      throw err;
   }
   if (TrimAnalysis->GetMode()!=taTurn){
-      cerr << "\nError: trim mode must be taTurn mode !!\n";
-      exit(1);
+      LogException err(FDMExec->GetLogger());
+      err << "\nError: trim mode must be taTurn mode !!\n";
+      throw err;
   }
 
   f = myCostFunctionFullCoordinatedTurn(v);
@@ -280,12 +289,14 @@ void Objective::CostFunctionFullCoordinatedTurn(long vars, Vector<double> &v, do
 void Objective::CostFunctionFullTurn(long vars, Vector<double> &v, double & f)
 {
   if (vars != 6) {
-      cerr << "\nError: (Cost function for taTurn mode) Dimension must be 6 !!\n";
-      exit(1);
+      LogException err(FDMExec->GetLogger());
+      err << "\nError: (Cost function for taTurn mode) Dimension must be 6 !!\n";
+      throw err;
   }
   if (TrimAnalysis->GetMode()!=taTurnFull){
-      cerr << "\nError: trim mode must be taTurnFull ("<< (int)taTurnFull << ") mode !!\n";
-      exit(1);
+      LogException err(FDMExec->GetLogger());
+      err << "\nError: trim mode must be taTurnFull ("<< (int)taTurnFull << ") mode !!\n";
+      throw err;
   }
 
   f = myCostFunctionFullTurn(v);
@@ -295,12 +306,14 @@ void Objective::CostFunctionFullTurn(long vars, Vector<double> &v, double & f)
 void Objective::CostFunctionPullUp(long vars, Vector<double> &v, double & f)
 {
   if (vars != 5) {
-      cerr << "\nError: (Cost function for taPullup mode) Dimension must be 5 !!\n";
-      exit(1);
+    LogException err(FDMExec->GetLogger());
+    err << "\nError: (Cost function for taPullup mode) Dimension must be 5 !!\n";
+    throw err;
   }
   if (TrimAnalysis->GetMode()!=taPullup){
-      cerr << "\nError: trim mode must be taPullup mode !!\n";
-      exit(1);
+    LogException err(FDMExec->GetLogger());
+    err << "\nError: trim mode must be taPullup mode !!\n";
+    throw err;
   }
 
   f = myCostFunctionPullUp(v);
@@ -468,7 +481,8 @@ bool FGTrimAnalysis::Load(string fname, bool useStoredPath)
 
     trimCfg = document->FindElement("trim_config");
     if (!trimCfg) {
-        cerr << "File: " << trimDef << " does not contain a trim configuration tag" << endl;
+        FGLogging log(fdmex->GetLogger(), document, LogLevel::ERROR);
+        log << "File: " << trimDef << " does not contain a trim configuration tag\n";
         return false;
     }
 
@@ -479,7 +493,8 @@ bool FGTrimAnalysis::Load(string fname, bool useStoredPath)
 
     search_element = trimCfg->FindElement("search");
     if (!search_element) {
-        cerr << "Using the Nelder-Mead search algorithm (default)." << endl;
+        FGXMLLogging log(fdmex->GetLogger(), trimCfg, LogLevel::ERROR);
+        log << "Using the Nelder-Mead search algorithm (default).\n";
     } else {
         type = search_element->GetAttributeValue("type");
         if (type.size() > 0) search_type = type; // if search type is not set, default is already Nelder-Mead
@@ -521,7 +536,7 @@ bool FGTrimAnalysis::Load(string fname, bool useStoredPath)
 
     element = trimCfg->FindElement("theta");
     InitializeTrimControl(fgic->GetThetaRadIC(), element, "RAD", JSBSim::taTheta);
-    
+
     element = trimCfg->FindElement("psi");
     InitializeTrimControl(fgic->GetPsiRadIC(), element, "RAD", JSBSim::taHeading);
 
@@ -552,10 +567,13 @@ bool FGTrimAnalysis::Load(string fname, bool useStoredPath)
     if (output_element) {
         rf_name = output_element->GetAttributeValue("name");
         if (rf_name.empty()) {
-            cerr << "name must be specified in output_file \"name\" attribute."<< endl;
+            FGXMLLogging log(fdmex->GetLogger(), output_element, LogLevel::ERROR);
+            log << "name must be specified in output_file \"name\" attribute.\n";
         } else {
-            if ( !SetResultsFile(rf_name) )
-                cerr << "Unable to use output file "<< rf_name << endl;
+            if ( !SetResultsFile(rf_name) ) {
+                FGXMLLogging log(fdmex->GetLogger(), output_element, LogLevel::ERROR);
+                log << "Unable to use output file "<< rf_name << "\n";
+            }
         }
     }
     return true;
@@ -601,49 +619,50 @@ bool FGTrimAnalysis::InitializeTrimControl(double default_value, Element* el,
 
 void FGTrimAnalysis::TrimStats() {
   int run_sum=0;
-  cout << endl << "  Trim Statistics: " << endl;
-  cout << "    Total Iterations: " << total_its << endl;
+  FGLogging log(fdmex->GetLogger(), LogLevel::INFO);
+  log << "\n  Trim Statistics:\n";
+  log << "    Total Iterations: " << total_its << "\n";
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGTrimAnalysis::Report(void) {
+    FGLogging log(fdmex->GetLogger(), LogLevel::INFO);
+    log << "---------------------------------------------------------------------\n";
 
-    cout << "---------------------------------------------------------------------\n";
+    log << "Trim report:\n";
+      log << "\tTrim algorithm terminated with the following values:\n";
+      log << "\tu, v, w        (ft/s): " << _u <<", "<< _v <<", "<< _w << "\n"
+           << "\tp, q, r       (rad/s): " << _p <<", "<< _q <<", "<< _r << "\n"
+           << "\talpha, beta     (deg): " << _alpha*57.3 <<", "<< _beta*57.3 << "\n"
+           << "\tphi, theta, psi (deg): " << _phi*57.3 <<", "<< _theta*57.3 << ", " << _psi*57.3 << "\n"
+           << "\tCost function value  : " << cost_function_value << "\n"
+           << "\tCycles executed      : " << total_its << "\n\n";
 
-    cout << "Trim report: " << endl;
-      cout << "\tTrim algorithm terminated with the following values:" << endl;
-      cout << "\tu, v, w        (ft/s): " << _u <<", "<< _v <<", "<< _w << endl
-           << "\tp, q, r       (rad/s): " << _p <<", "<< _q <<", "<< _r << endl
-           << "\talpha, beta     (deg): " << _alpha*57.3 <<", "<< _beta*57.3 << endl
-           << "\tphi, theta, psi (deg): " << _phi*57.3 <<", "<< _theta*57.3 << ", " << _psi*57.3 << endl
-           << "\tCost function value  : " << cost_function_value << endl
-           << "\tCycles executed      : " << total_its << endl << endl;
-
-      cout << "\tTrim variables adjusted:" << endl;
+      log << "\tTrim variables adjusted:\n";
       for (unsigned int i=0; i<vTrimAnalysisControls.size();i++){
-          cout << "\t\t" << vTrimAnalysisControls[i]->GetControlName() <<": ";
-          cout << vTrimAnalysisControls[i]->GetControl() << endl;
+          log << "\t\t" << vTrimAnalysisControls[i]->GetControlName() <<": ";
+          log << vTrimAnalysisControls[i]->GetControl() << "\n";
       }
       //...
 
-      cout << endl;
+      log << "\n";
 
-      cout << "\t** Initial -> Final Conditions **" << endl;
-      cout << "\tAlpha IC: " << fgic->GetAlphaDegIC() << " Degrees" << endl;
-      cout << "\t   Final: " << Auxiliary->Getalpha()*57.3 << " Degrees" << endl;
-      cout << "\tBeta  IC: " << fgic->GetBetaDegIC() << " Degrees" << endl;
-      cout << "\t   Final: " << Auxiliary->Getbeta()*57.3 << " Degrees" << endl;
-      cout << "\tGamma IC: " << fgic->GetFlightPathAngleDegIC() << " Degrees" << endl;
-      cout << "\t   Final: " << Auxiliary->GetGamma()*57.3 << " Degrees" << endl;
-      cout << "\tPhi IC  : " << fgic->GetPhiDegIC() << " Degrees" << endl;
-      cout << "\t   Final: " << fdmex->GetPropagate()->GetEuler(1)*57.3 << " Degrees" << endl;
-      cout << "\tTheta IC: " << fgic->GetThetaDegIC() << " Degrees" << endl;
-      cout << "\t   Final: " << fdmex->GetPropagate()->GetEuler(2)*57.3 << " Degrees" << endl;
-      cout << "\tPsi IC  : " << fgic->GetPsiDegIC() << " Degrees" << endl;
-      cout << "\t   Final: " << fdmex->GetPropagate()->GetEuler(3)*57.3 << " Degrees" << endl;
-      cout << endl;
-      cout << "--------------------------------------------------------------------- \n\n";
+      log << "\t** Initial -> Final Conditions **\n";
+      log << "\tAlpha IC: " << fgic->GetAlphaDegIC() << " Degrees\n";
+      log << "\t   Final: " << Auxiliary->Getalpha()*57.3 << " Degrees\n";
+      log << "\tBeta  IC: " << fgic->GetBetaDegIC() << " Degrees\n";
+      log << "\t   Final: " << Auxiliary->Getbeta()*57.3 << " Degrees\n";
+      log << "\tGamma IC: " << fgic->GetFlightPathAngleDegIC() << " Degrees\n";
+      log << "\t   Final: " << Auxiliary->GetGamma()*57.3 << " Degrees\n";
+      log << "\tPhi IC  : " << fgic->GetPhiDegIC() << " Degrees\n";
+      log << "\t   Final: " << fdmex->GetPropagate()->GetEuler(1)*57.3 << " Degrees\n";
+      log << "\tTheta IC: " << fgic->GetThetaDegIC() << " Degrees\n";
+      log << "\t   Final: " << fdmex->GetPropagate()->GetEuler(2)*57.3 << " Degrees\n";
+      log << "\tPsi IC  : " << fgic->GetPsiDegIC() << " Degrees\n";
+      log << "\t   Final: " << fdmex->GetPropagate()->GetEuler(3)*57.3 << " Degrees\n";
+      log << "\n";
+      log << "--------------------------------------------------------------------- \n\n";
 
       fdmex->EnableOutput();
 }
@@ -697,7 +716,7 @@ bool FGTrimAnalysis::RemoveControl( TaControl control ) {
   bool result=false;
 
   mode = taCustom;
-  
+
   #error TODO: Iterator is used after erase(). See GH issue #309
   vector <FGTrimAnalysisControl*>::iterator iControls = vTrimAnalysisControls.begin();
   while (iControls != vTrimAnalysisControls.end()) {
@@ -739,11 +758,12 @@ bool FGTrimAnalysis::EditState( TaControl new_control, double new_initvalue, dou
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGTrimAnalysis::setupPullup() {
+  FGLogging log(fdmex->GetLogger(), LogLevel::INFO);
   double g,q,cgamma;
   g=fdmex->GetInertial()->gravity();
   cgamma=cos(fgic->GetFlightPathAngleRadIC());
   q=g*(_targetNlf-cgamma)/fgic->GetVtrueFpsIC();
-  cout << _targetNlf << ", " << q << endl;
+  log << _targetNlf << ", " << q << "\n";
   fgic->SetQRadpsIC(q);
   updateRates();
 
@@ -997,21 +1017,27 @@ void FGTrimAnalysis::setDebug(void) {
 void FGTrimAnalysis::SetMode(TrimAnalysisMode tt) {
 
     ClearControls();
-
-    cout << "---------------------------------------------------------------------" << endl;
-    cout << "Trim analysis performed: ";
+    {
+        FGLogging log(fdmex->GetLogger(), LogLevel::INFO);
+        log << "---------------------------------------------------------------------\n";
+        log << "Trim analysis performed: ";
+    }
     mode=tt;
     switch(tt) {
       case taLongitudinal:
-        if (debug_lvl > 0)
-          cout << "  Longitudinal Trim" << endl;
+        if (debug_lvl > 0) {
+          FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+          log << "  Longitudinal Trim\n";
+        }
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taThrottle ));
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taElevator )); // TODO: taPitchTrim
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taTheta ));
         break;
       case taFull:
-        if (debug_lvl > 0)
-          cout << "  Full Trim" << endl;
+        if (debug_lvl > 0) {
+          FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+          log << "  Full Trim\n";
+        }
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taThrottle ));
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taElevator )); // TODO: taPitchTrim
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taAileron ));  // TODO: taRollTrim
@@ -1021,8 +1047,10 @@ void FGTrimAnalysis::SetMode(TrimAnalysisMode tt) {
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taHeading ));
         break;
       case taFullWingsLevel:
-        if (debug_lvl > 0)
-          cout << "  Full Trim, Wings-Level" << endl;
+        if (debug_lvl > 0) {
+          FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+          log << "  Full Trim, Wings-Level\n";
+        }
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taThrottle ));
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taElevator )); // TODO: taPitchTrim
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taAileron ));  // TODO: taRollTrim
@@ -1033,8 +1061,10 @@ void FGTrimAnalysis::SetMode(TrimAnalysisMode tt) {
       case taTurn:
           // ToDo: set target NLF here !!!
           // ToDo: assign psiDot here !!
-        if (debug_lvl > 0)
-          cout << "  Full Trim, Coordinated turn" << endl;
+        if (debug_lvl > 0) {
+          FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+          log << "  Full Trim, Coordinated turn\n";
+        }
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taThrottle ));
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taElevator )); // TODO: taPitchTrim
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taAileron ));  // TODO: taRollTrim
@@ -1044,8 +1074,10 @@ void FGTrimAnalysis::SetMode(TrimAnalysisMode tt) {
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taHeading ));
         break;
       case taTurnFull:
-        if (debug_lvl > 0)
-          cout << "  Non-coordinated Turn Trim" << endl;
+        if (debug_lvl > 0) {
+          FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+          log << "  Non-coordinated Turn Trim\n";
+        }
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taThrottle ));
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taElevator )); // TODO: taPitchTrim
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taAileron ));  // TODO: taRollTrim
@@ -1058,8 +1090,10 @@ void FGTrimAnalysis::SetMode(TrimAnalysisMode tt) {
       case taPullup:
           // ToDo: set target NLF here !!!
           // ToDo: assign qDot here !!
-        if (debug_lvl > 0)
-          cout << "  Full Trim, Pullup" << endl;
+        if (debug_lvl > 0) {
+          FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+          log << "  Full Trim, Pullup\n";
+        }
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taThrottle ));
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taElevator )); // TODO: taPitchTrim
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taAileron ));
@@ -1069,8 +1103,10 @@ void FGTrimAnalysis::SetMode(TrimAnalysisMode tt) {
         //vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taHeading ));
         break;
       case taGround:
-        if (debug_lvl > 0)
-          cout << "  Ground Trim" << endl;
+        if (debug_lvl > 0) {
+          FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+          log << "  Ground Trim\n";
+        }
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taAltAGL ));
         vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taTheta ));
         //vTrimAnalysisControls.push_back(new FGTrimAnalysisControl(fdmex,fgic,taPhi ));
@@ -1093,10 +1129,11 @@ bool FGTrimAnalysis::SetResultsFile(string name)
     rf_name = name;
     rf.open(rf_name.c_str(), ios::out);
     if ( !rf.is_open() ) {
-       cerr << "Unable to open " << rf_name << endl;
+       FGLogging log(fdmex->GetLogger(), LogLevel::ERROR);
+       log << "Unable to open " << rf_name << "\n";
        return false;
     }
-    //rf << "# ... complete this " << endl;
+    //rf << "# ... complete this\n";
     //rf << "# iteration, CostFunc, size, dT, dE, dA, dR, Psi (rad), Theta (rad), Phi (rad)\n";
     return true;
 }
@@ -1278,7 +1315,8 @@ bool FGTrimAnalysis::DoTrim(void) {
     // retrieve initial conditions
     fdmex->RunIC();
 
-    cout << endl << "Numerical trim algorithm: constrained optimization of a cost function" << endl;
+    FGLogging log(fdmex->GetLogger(), LogLevel::INFO);
+    log << "\nNumerical trim algorithm: constrained optimization of a cost function\n";
 
     Objective* obj_ptr = new Objective(this->fdmex, this, 999.0);
 
@@ -1378,8 +1416,7 @@ bool FGTrimAnalysis::DoTrim(void) {
   // write trim results on file, rf=results file
   if ( rf.is_open() )
     rf <<
-      "# iteration, costf, dT, dE, dA, dR, Phi (rad), Theta (rad), Psi (rad), uDot (fps2), vDot (fps2), wDot (fps2), pDot (rad/s2), qDot (rad/s2), rDot (rad/s2), u (fps), v (fps), w (fps), p (rad/s), q (rad/s), r (rad/s), alpha (rad), beta (rad), alphaDot (rad/s), betaDot (rad/s), Thrust"
-      << endl;
+      "# iteration, costf, dT, dE, dA, dR, Phi (rad), Theta (rad), Psi (rad), uDot (fps2), vDot (fps2), wDot (fps2), pDot (rad/s2), qDot (rad/s2), rDot (rad/s2), u (fps), v (fps), w (fps), p (rad/s), q (rad/s), r (rad/s), alpha (rad), beta (rad), alphaDot (rad/s), betaDot (rad/s), Thrust\n";
 
   long n = vTrimAnalysisControls.size();  // number of variables (dimension of the search)
 
@@ -1695,11 +1732,14 @@ bool FGTrimAnalysis::DoTrim(void) {
 
   if( !trim_failed ) {
     if (debug_lvl > 0) {
-      cout << endl << "  Trim successful. (Cost function value: " << cost_function_value << ")" << endl;
+        FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+        log << "\n  Trim successful. (Cost function value: " << cost_function_value << ")\n";
     }
   } else {
-    if (debug_lvl > 0)
-        cout << endl << "  Trim failed" << endl;
+    if (debug_lvl > 0) {
+        FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+        log << "\n  Trim failed\n";
+    }
   }
 
 
@@ -1867,7 +1907,7 @@ double Objective::myCostFunctionFull(Vector<double> & x) // x variations come fr
 
         TrimAnalysis->SetCostFunctionValue(f);
     }
- 
+
     return f;
 }
 
@@ -2509,7 +2549,7 @@ double Objective::myCostFunctionFullTurn(Vector<double> & x)
             << FDMExec->GetAuxiliary()->Getadot() << ", "           // 24
             << FDMExec->GetAuxiliary()->Getbdot() << ", "           // 25
 
-            << FDMExec->GetPropulsion()->GetEngine(0)->GetThrust() << "\n";  // 
+            << FDMExec->GetPropulsion()->GetEngine(0)->GetThrust() << "\n";  //
 
         FDMExec->GetPropagate()->SetVState( VState ); // ?? is this really necessary
 
@@ -3015,7 +3055,11 @@ void Objective::calculateDottedStates(double delta_cmd_T, double delta_cmd_E, do
     const FGMatrix33& Jinv = FDMExec->GetMassBalance()->GetJinv();            // inertia matrix inverse
 
     double rd = FDMExec->GetPropagate()->GetRadius();                         // radius
-    if (rd == 0.0) {cerr << "radius = 0 !" << endl; rd = 1e-16;}              // radius check
+    if (rd == 0.0) {
+        FGLogging log(FDMExec->GetLogger(), LogLevel::WARN);
+        log << "radius = 0 !\n";
+        rd = 1e-16;
+    }              // radius check
 
     double rdInv = 1.0/rd;
     FGColumnVector3 gAccel( 0.0, 0.0, FDMExec->GetInertial()->GetGAccel(rd) );

--- a/src/initialization/FGTrimAnalysis.h
+++ b/src/initialization/FGTrimAnalysis.h
@@ -111,7 +111,7 @@ CLASS DOCUMENTATION
     fgic->SetAltitudeFtIC(1000);
     fgic->SetClimbRate(500);
     if( !fgta.DoTrim() ) {
-      cout << "Trim Failed" << endl;
+      std::cout << "Trim Failed" << std::endl;
     }
     fgta.Report();
     @endcode

--- a/src/initialization/FGTrimAxis.cpp
+++ b/src/initialization/FGTrimAxis.cpp
@@ -39,6 +39,7 @@ INCLUDES
 #include <string>
 #include <cstdlib>
 #include <iomanip>
+
 #include "FGFDMExec.h"
 #include "models/FGAtmosphere.h"
 #include "FGInitialCondition.h"
@@ -51,6 +52,7 @@ INCLUDES
 #include "models/FGGroundReactions.h"
 #include "models/FGPropagate.h"
 #include "models/FGAccelerations.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -247,7 +249,8 @@ void FGTrimAxis::Run(void) {
   double last_state_value;
   int i;
   setControl();
-  //cout << "FGTrimAxis::Run: " << control_value << endl;
+  //FGLogging log(fdmex->GetLogger(), LogLevel::INFO);
+  //log << "FGTrimAxis::Run: " << control_value << "\n";
   i=0;
   bool stable=false;
   while(!stable) {
@@ -289,24 +292,17 @@ void FGTrimAxis::setThrottlesPct(void) {
 /*****************************************************************************/
 
 void FGTrimAxis::AxisReport(void) {
-  // Save original cout format characteristics
-  std::ios_base::fmtflags originalFormat = cout.flags();
-  std::streamsize originalPrecision = cout.precision();
-  std::streamsize originalWidth = cout.width();
-  cout << "  " << left << setw(20) << GetControlName() << ": ";
-  cout << setw(6) << setprecision(2) << GetControl()*control_convert << ' ';
-  cout << setw(5) << GetStateName() << ": ";
-  cout << setw(9) << setprecision(2) << scientific << GetState()+state_target;
-  cout << " Tolerance: " << setw(3) << setprecision(0) << scientific << GetTolerance();
+  FGLogging log(fdmex->GetLogger(), LogLevel::INFO);
+  log << "  " << left << setw(20) << GetControlName() << ": ";
+  log << setw(6) << setprecision(2) << GetControl()*control_convert << ' ';
+  log << setw(5) << GetStateName() << ": ";
+  log << setw(9) << setprecision(2) << scientific << GetState()+state_target;
+  log << " Tolerance: " << setw(3) << setprecision(0) << scientific << GetTolerance();
 
   if( fabs(GetState()+state_target) < fabs(GetTolerance()) )
-     cout << "  Passed" << endl;
+     log << "  Passed\n";
   else
-     cout << "  Failed" << endl;
-  // Restore original cout format characteristics
-  cout.flags(originalFormat);
-  cout.precision(originalPrecision);
-  cout.width(originalWidth);
+     log << "  Failed\n";
 }
 
 /*****************************************************************************/
@@ -347,8 +343,9 @@ void FGTrimAxis::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGTrimAxis" << endl;
-    if (from == 1) cout << "Destroyed:    FGTrimAxis" << endl;
+    FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGTrimAxis\n";
+    if (from == 1) log << "Destroyed:    FGTrimAxis\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/initialization/FGTrimmer.h
+++ b/src/initialization/FGTrimmer.h
@@ -44,8 +44,8 @@ public:
     FGTrimmer(FGFDMExec * fdm, Constraints * constraints);
     ~FGTrimmer();
     std::vector<double> constrain(const std::vector<double> & v);
-    void printSolution(std::ostream & stream, const std::vector<double> & v);
-    void printState(std::ostream & stream);
+    void printSolution(const std::vector<double> & v);
+    void printState();
     double compute_cost();
     double eval(const std::vector<double> & v);
     static void limit(double min, double max, double &val)
@@ -54,6 +54,7 @@ public:
         else if (val>max) val=max;
     }
     void setFdm(FGFDMExec * fdm) {m_fdm = fdm; }
+    FGFDMExec* getFdm() { return m_fdm; }
 private:
     FGFDMExec * m_fdm;
     Constraints * m_constraints;

--- a/src/input_output/FGInputSocket.cpp
+++ b/src/input_output/FGInputSocket.cpp
@@ -38,16 +38,12 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <cstring>
-#include <cstdlib>
-#include <sstream>
-#include <iomanip>
-
 #include "FGInputSocket.h"
 #include "FGFDMExec.h"
 #include "models/FGAircraft.h"
-#include "input_output/FGXMLElement.h"
-#include "input_output/string_utilities.h"
+#include "FGXMLElement.h"
+#include "string_utilities.h"
+#include "FGLog.h"
 
 using namespace std;
 
@@ -80,7 +76,8 @@ bool FGInputSocket::Load(Element* el)
   SockPort = atoi(el->GetAttributeValue("port").c_str());
 
   if (SockPort == 0) {
-    cerr << endl << "No port assigned in input element" << endl;
+    FGXMLLogging log(FDMExec->GetLogger(), el, LogLevel::ERROR);
+    log << "No port assigned in input element\n";
     return false;
   }
 

--- a/src/input_output/FGInputType.cpp
+++ b/src/input_output/FGInputType.cpp
@@ -38,6 +38,8 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include "FGInputType.h"
+#include "FGLog.h"
+#include "FGFDMExec.h"
 
 using namespace std;
 
@@ -140,8 +142,9 @@ void FGInputType::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGInputType" << endl;
-    if (from == 1) cout << "Destroyed:    FGInputType" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGInputType\n";
+    if (from == 1) log << "Destroyed:    FGInputType\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -116,6 +116,9 @@ public:
   virtual ~FGLogging() { Flush(); }
   FGLogging& operator<<(const char* message) { buffer << message ; return *this; }
   FGLogging& operator<<(const std::string& message) { buffer << message ; return *this; }
+  // Operator for ints and anonymous enums
+  FGLogging& operator<<(int value) { buffer << value; return *this; }
+  // Operator for other numerical types
   template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
     FGLogging& operator<<(T value) { buffer << value; return *this; }
   FGLogging& operator<<(std::ostream& (*manipulator)(std::ostream&)) { buffer << manipulator; return *this; }

--- a/src/input_output/FGOutputFG.cpp
+++ b/src/input_output/FGOutputFG.cpp
@@ -49,6 +49,7 @@ INCLUDES
 #include "models/propulsion/FGPiston.h"
 #include "models/propulsion/FGElectric.h"
 #include "models/propulsion/FGTank.h"
+#include "FGLog.h"
 
 #if defined(WIN32) && !defined(__CYGWIN__)
 #  include <windows.h>
@@ -120,23 +121,24 @@ FGOutputFG::FGOutputFG(FGFDMExec* fdmex) :
   memset(&fgSockBuf, 0x0, sizeof(fgSockBuf));
 
   if (fdmex->GetDebugLevel() > 0) {
+    FGLogging log(fdmex->GetLogger(), LogLevel::ERROR);
     // Engine status
     if (Propulsion->GetNumEngines() > FGNetFDM::FG_MAX_ENGINES)
-      cerr << "This vehicle has " << Propulsion->GetNumEngines() << " engines, but the current " << endl
-           << "version of FlightGear's FGNetFDM only supports " << FGNetFDM::FG_MAX_ENGINES << " engines." << endl
-           << "Only the first " << FGNetFDM::FG_MAX_ENGINES << " engines will be used." << endl;
+      log << "This vehicle has " << Propulsion->GetNumEngines() << " engines, but the current \n"
+          << "version of FlightGear's FGNetFDM only supports " << FGNetFDM::FG_MAX_ENGINES << " engines.\n"
+          << "Only the first " << FGNetFDM::FG_MAX_ENGINES << " engines will be used.\n";
 
     // Consumables
     if (Propulsion->GetNumTanks() > FGNetFDM::FG_MAX_TANKS)
-      cerr << "This vehicle has " << Propulsion->GetNumTanks() << " tanks, but the current " << endl
-           << "version of FlightGear's FGNetFDM only supports " << FGNetFDM::FG_MAX_TANKS << " tanks." << endl
-           << "Only the first " << FGNetFDM::FG_MAX_TANKS << " tanks will be used." << endl;
+      log << "This vehicle has " << Propulsion->GetNumTanks() << " tanks, but the current \n"
+          << "version of FlightGear's FGNetFDM only supports " << FGNetFDM::FG_MAX_TANKS << " tanks.\n"
+          << "Only the first " << FGNetFDM::FG_MAX_TANKS << " tanks will be used.\n";
 
     // Gear status
     if (GroundReactions->GetNumGearUnits() > FGNetFDM::FG_MAX_WHEELS)
-      cerr << "This vehicle has " << GroundReactions->GetNumGearUnits() << " bogeys, but the current " << endl
-           << "version of FlightGear's FGNetFDM only supports " << FGNetFDM::FG_MAX_WHEELS << " bogeys." << endl
-           << "Only the first " << FGNetFDM::FG_MAX_WHEELS << " bogeys will be used." << endl;
+      log << "This vehicle has " << GroundReactions->GetNumGearUnits() << " bogeys, but the current \n"
+          << "version of FlightGear's FGNetFDM only supports " << FGNetFDM::FG_MAX_WHEELS << " bogeys.\n"
+          << "Only the first " << FGNetFDM::FG_MAX_WHEELS << " bogeys will be used.\n";
   }
 }
 

--- a/src/input_output/FGOutputTextFile.cpp
+++ b/src/input_output/FGOutputTextFile.cpp
@@ -38,8 +38,6 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <iomanip>
-
 #include "FGOutputTextFile.h"
 #include "models/FGAerodynamics.h"
 #include "models/FGAccelerations.h"
@@ -51,8 +49,9 @@ INCLUDES
 #include "models/FGBuoyantForces.h"
 #include "models/FGFCS.h"
 #include "models/atmosphere/FGWinds.h"
-#include "input_output/FGXMLElement.h"
-#include "input_output/string_utilities.h"
+#include "FGXMLElement.h"
+#include "string_utilities.h"
+#include "FGLog.h"
 
 using namespace std;
 
@@ -87,10 +86,11 @@ bool FGOutputTextFile::OpenFile(void)
   datafile.clear();
   datafile.open(Filename);
   if (!datafile) {
-    cerr << endl << fgred << highint << "ERROR: unable to open the file "
-         << reset << Filename.c_str() << endl
-         << fgred << highint << "       => Output to this file is disabled."
-         << reset << endl << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+    log << LogFormat::RED << LogFormat::BOLD << "\nERROR: unable to open the file "
+        << LogFormat::RESET << Filename.c_str()
+        << LogFormat::RED << LogFormat::BOLD << "\n       => Output to this file is disabled.\n\n"
+        << LogFormat::RESET;
     Disable();
     return false;
   }

--- a/src/input_output/FGOutputType.cpp
+++ b/src/input_output/FGOutputType.cpp
@@ -37,14 +37,13 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <ostream>
-
 #include "FGFDMExec.h"
 #include "FGOutputType.h"
-#include "input_output/FGXMLElement.h"
-#include "input_output/FGPropertyManager.h"
+#include "FGXMLElement.h"
+#include "FGPropertyManager.h"
 #include "math/FGTemplateFunc.h"
 #include "math/FGFunctionValue.h"
+#include "FGLog.h"
 
 using namespace std;
 
@@ -133,11 +132,11 @@ bool FGOutputType::Load(Element* element)
     string property_str = property_element->GetDataLine();
     FGPropertyNode* node = PropertyManager->GetNode(property_str);
     if (!node) {
-      cerr << property_element->ReadFrom()
-           << fgred << highint << endl << "  No property by the name "
-           << property_str << " has been defined. This property will " << endl
-           << "  not be logged. You should check your configuration file."
-           << reset << endl;
+      FGXMLLogging log(FDMExec->GetLogger(), property_element, LogLevel::ERROR);
+      log << LogFormat::RED << LogFormat::BOLD << "  No property by the name "
+          << property_str << " has been defined. This property will "
+          << "not be logged. You should check your configuration file.\n"
+          << LogFormat::RESET;
     } else {
       if (property_element->HasAttribute("apply")) {
         string function_str = property_element->GetAttributeValue("apply");
@@ -145,11 +144,11 @@ bool FGOutputType::Load(Element* element)
         if (f)
           OutputParameters.push_back(new FGFunctionValue(node, f));
         else {
-          cerr << property_element->ReadFrom()
-               << fgred << highint << "  No function by the name "
+          FGXMLLogging log(FDMExec->GetLogger(), property_element, LogLevel::ERROR);
+          log << LogFormat::RED << LogFormat::BOLD << "  No function by the name "
                << function_str << " has been defined. This property will "
-               << "not be logged. You should check your configuration file."
-               << reset << endl;
+               << "not be logged. You should check your configuration file.\n"
+               << LogFormat::RESET;
         }
       }
       else
@@ -255,27 +254,29 @@ void FGOutputType::Debug(int from)
     if (from == 0) { // Constructor
     }
     if (from == 2) {
-      if (SubSystems & ssSimulation)      cout << "    Simulation parameters logged" << endl;
-      if (SubSystems & ssAerosurfaces)    cout << "    Aerosurface parameters logged" << endl;
-      if (SubSystems & ssRates)           cout << "    Rate parameters logged" << endl;
-      if (SubSystems & ssVelocities)      cout << "    Velocity parameters logged" << endl;
-      if (SubSystems & ssForces)          cout << "    Force parameters logged" << endl;
-      if (SubSystems & ssMoments)         cout << "    Moments parameters logged" << endl;
-      if (SubSystems & ssAtmosphere)      cout << "    Atmosphere parameters logged" << endl;
-      if (SubSystems & ssMassProps)       cout << "    Mass parameters logged" << endl;
-      if (SubSystems & ssAeroFunctions)   cout << "    Coefficient parameters logged" << endl;
-      if (SubSystems & ssPropagate)       cout << "    Propagate parameters logged" << endl;
-      if (SubSystems & ssGroundReactions) cout << "    Ground parameters logged" << endl;
-      if (SubSystems & ssFCS)             cout << "    FCS parameters logged" << endl;
-      if (SubSystems & ssPropulsion)      cout << "    Propulsion parameters logged" << endl;
-      if (!OutputParameters.empty())      cout << "    Properties logged:" << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+      if (SubSystems & ssSimulation)      log << "    Simulation parameters logged\n";
+      if (SubSystems & ssAerosurfaces)    log << "    Aerosurface parameters logged\n";
+      if (SubSystems & ssRates)           log << "    Rate parameters logged\n";
+      if (SubSystems & ssVelocities)      log << "    Velocity parameters logged\n";
+      if (SubSystems & ssForces)          log << "    Force parameters logged\n";
+      if (SubSystems & ssMoments)         log << "    Moments parameters logged\n";
+      if (SubSystems & ssAtmosphere)      log << "    Atmosphere parameters logged\n";
+      if (SubSystems & ssMassProps)       log << "    Mass parameters logged\n";
+      if (SubSystems & ssAeroFunctions)   log << "    Coefficient parameters logged\n";
+      if (SubSystems & ssPropagate)       log << "    Propagate parameters logged\n";
+      if (SubSystems & ssGroundReactions) log << "    Ground parameters logged\n";
+      if (SubSystems & ssFCS)             log << "    FCS parameters logged\n";
+      if (SubSystems & ssPropulsion)      log << "    Propulsion parameters logged\n";
+      if (!OutputParameters.empty())      log << "    Properties logged:\n";
       for (auto param: OutputParameters)
-        cout << "      - " << param->GetName() << endl;
+        log << "      - " << param->GetName() << "\n";
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGOutputType" << endl;
-    if (from == 1) cout << "Destroyed:    FGOutputType" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGOutputType\n";
+    if (from == 1) log << "Destroyed:    FGOutputType\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/input_output/FGUDPInputSocket.cpp
+++ b/src/input_output/FGUDPInputSocket.cpp
@@ -37,14 +37,11 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <cstring>
-#include <cstdlib>
-#include <sstream>
-
 #include "FGUDPInputSocket.h"
 #include "FGFDMExec.h"
-#include "input_output/FGXMLElement.h"
-#include "input_output/string_utilities.h"
+#include "FGXMLElement.h"
+#include "string_utilities.h"
+#include "FGLog.h"
 
 using namespace std;
 
@@ -77,8 +74,9 @@ bool FGUDPInputSocket::Load(Element* el)
     string property_str = property_element->GetDataLine();
     FGPropertyNode* node = PropertyManager->GetNode(property_str);
     if (!node) {
-      cerr << fgred << highint << endl << "  No property by the name "
-           << property_str << " can be found." << reset << endl;
+      FGXMLLogging log(FDMExec->GetLogger(), property_element, LogLevel::ERROR);
+      log << LogFormat::RED << LogFormat::BOLD << "\n  No property by the name "
+          << property_str << " can be found.\n" << LogFormat::RESET;
     } else {
       InputProperties.push_back(node);
     }
@@ -111,7 +109,8 @@ void FGUDPInputSocket::Read(bool Holding)
       for (string& token : tokens)
         values.push_back(atof_locale_c(token));
     } catch(InvalidNumber& e) {
-      cerr << e.what() << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+      log << e.what() << "\n";
       return;
     }
 
@@ -123,7 +122,8 @@ void FGUDPInputSocket::Read(bool Holding)
 
     // the zeroeth value is the time stamp
     if ((values.size() - 1) != InputProperties.size()) {
-      cerr << endl << "Mismatch between UDP input property and value counts." << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
+      log << "\nMismatch between UDP input property and value counts.\n";
       return;
     }
 

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -457,12 +457,13 @@ void FGPropagate::Integrate( FGQuaternion& Integrand,
       double J = C2p*qk + C3p*qdotk - C4*Cp;
       double K = C2p*pk + C3p*pdotk - C4*Dp;
 
-      cout << "q:       " << q << endl;
+      FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
+      log << "q:       " << q << "\n";
 
       // Warning! In the paper of Barker et al. the quaternion components are not
       // ordered the same way as in JSBSim (see equations (2) and (3) of ref. [7]
       // as well as the comment just below equation (3))
-      cout << "FORTRAN: " << H << " , " << K << " , " << J << " , " << -G << endl;*/
+      log << "FORTRAN: " << H << " , " << K << " , " << J << " , " << -G << "\n";*/
     }
     break; // The quaternion q is not normal so the normalization needs to be done.
   case eNone: // do nothing, freeze rotational rate
@@ -707,35 +708,35 @@ FGColumnVector3 FGPropagate::GetEulerDeg(void) const
 void FGPropagate::DumpState(void)
 {
   FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
-  log << endl;
+  log << "\n";
   log << LogFormat::BLUE
-      << "------------------------------------------------------------------" << LogFormat::RESET << endl;
+      << "------------------------------------------------------------------" << LogFormat::RESET << "\n";
   log << LogFormat::BOLD << fixed
-      << "State Report at sim time: " << FDMExec->GetSimTime() << " seconds" << LogFormat::RESET << endl;
+      << "State Report at sim time: " << FDMExec->GetSimTime() << " seconds" << LogFormat::RESET << "\n";
   log << "  " << LogFormat::UNDERLINE_ON
-      << "Position" << LogFormat::UNDERLINE_OFF << endl;
-  log << "    ECI:   " << VState.vInertialPosition.Dump(", ") << " (x,y,z, in ft)" << endl;
-  log << "    ECEF:  " << VState.vLocation << " (x,y,z, in ft)" << endl;
+      << "Position" << LogFormat::UNDERLINE_OFF << "\n";
+  log << "    ECI:   " << VState.vInertialPosition.Dump(", ") << " (x,y,z, in ft)\n";
+  log << "    ECEF:  " << VState.vLocation << " (x,y,z, in ft)\n";
   log << "    Local: " << VState.vLocation.GetGeodLatitudeDeg()
                        << ", " << VState.vLocation.GetLongitudeDeg()
-                       << ", " << GetAltitudeASL() << " (geodetic lat, lon, alt ASL in deg and ft)" << endl;
+                       << ", " << GetAltitudeASL() << " (geodetic lat, lon, alt ASL in deg and ft)\n";
 
-  log << endl << "  " << LogFormat::UNDERLINE_ON
-      << "Orientation" << LogFormat::UNDERLINE_OFF << endl;
-  log << "    ECI:   " << VState.qAttitudeECI.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
-  log << "    Local: " << VState.qAttitudeLocal.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)" << endl;
+  log << "\n  " << LogFormat::UNDERLINE_ON
+      << "Orientation" << LogFormat::UNDERLINE_OFF << "\n";
+  log << "    ECI:   " << VState.qAttitudeECI.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)\n";
+  log << "    Local: " << VState.qAttitudeLocal.GetEulerDeg().Dump(", ") << " (phi, theta, psi in deg)\n";
 
-  log << endl << "  " << LogFormat::UNDERLINE_ON
-      << "Velocity" << LogFormat::UNDERLINE_OFF << endl;
-  log << "    ECI:   " << VState.vInertialVelocity.Dump(", ") << " (x,y,z in ft/s)" << endl;
-  log << "    ECEF:  " << (Tb2ec * VState.vUVW).Dump(", ") << " (x,y,z in ft/s)" << endl;
-  log << "    Local: " << GetVel() << " (n,e,d in ft/sec)" << endl;
-  log << "    Body:  " << GetUVW() << " (u,v,w in ft/sec)" << endl;
+  log << "\n  " << LogFormat::UNDERLINE_ON
+      << "Velocity" << LogFormat::UNDERLINE_OFF << "\n";
+  log << "    ECI:   " << VState.vInertialVelocity.Dump(", ") << " (x,y,z in ft/s)\n";
+  log << "    ECEF:  " << (Tb2ec * VState.vUVW).Dump(", ") << " (x,y,z in ft/s)\n";
+  log << "    Local: " << GetVel() << " (n,e,d in ft/sec)\n";
+  log << "    Body:  " << GetUVW() << " (u,v,w in ft/sec)\n";
 
-  log << endl << "  " << LogFormat::UNDERLINE_ON
-      << "Body Rates (relative to given frame, expressed in body frame)" << LogFormat::UNDERLINE_OFF << endl;
-  log << "    ECI:   " << (VState.vPQRi * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
-  log << "    ECEF:  " << (VState.vPQR * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << endl;
+  log << "\n" << "  " << LogFormat::UNDERLINE_ON
+      << "Body Rates (relative to given frame, expressed in body frame)" << LogFormat::UNDERLINE_OFF << "\n";
+  log << "    ECI:   " << (VState.vPQRi * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << "\n";
+  log << "    ECEF:  " << (VState.vPQR * radtodeg).Dump(", ") << " (p,q,r in deg/s)" << "\n";
 }
 
 //******************************************************************************
@@ -758,66 +759,66 @@ void FGPropagate::WriteStateFile(int num)
   case 1:
     outfile.open(path);
     if (outfile.is_open()) {
-      outfile << "<?xml version=\"1.0\"?>" << endl;
-      outfile << "<initialize name=\"reset00\">" << endl;
-      outfile << "  <ubody unit=\"FT/SEC\"> " << VState.vUVW(eU) << " </ubody> " << endl;
-      outfile << "  <vbody unit=\"FT/SEC\"> " << VState.vUVW(eV) << " </vbody> " << endl;
-      outfile << "  <wbody unit=\"FT/SEC\"> " << VState.vUVW(eW) << " </wbody> " << endl;
-      outfile << "  <phi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePhi)*radtodeg << " </phi>" << endl;
-      outfile << "  <theta unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(eTht)*radtodeg << " </theta>" << endl;
-      outfile << "  <psi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePsi)*radtodeg << " </psi>" << endl;
-      outfile << "  <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
-      outfile << "  <latitude unit=\"DEG\"> " << VState.vLocation.GetLatitudeDeg() << " </latitude>" << endl;
-      outfile << "  <altitude unit=\"FT\"> " << GetDistanceAGL() << " </altitude>" << endl;
-      outfile << "</initialize>" << endl;
+      outfile << "<?xml version=\"1.0\"?>\n";
+      outfile << "<initialize name=\"reset00\">\n";
+      outfile << "  <ubody unit=\"FT/SEC\"> " << VState.vUVW(eU) << " </ubody> \n";
+      outfile << "  <vbody unit=\"FT/SEC\"> " << VState.vUVW(eV) << " </vbody> \n";
+      outfile << "  <wbody unit=\"FT/SEC\"> " << VState.vUVW(eW) << " </wbody> \n";
+      outfile << "  <phi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePhi)*radtodeg << " </phi>\n";
+      outfile << "  <theta unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(eTht)*radtodeg << " </theta>\n";
+      outfile << "  <psi unit=\"DEG\"> " << VState.qAttitudeLocal.GetEuler(ePsi)*radtodeg << " </psi>\n";
+      outfile << "  <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>\n";
+      outfile << "  <latitude unit=\"DEG\"> " << VState.vLocation.GetLatitudeDeg() << " </latitude>\n";
+      outfile << "  <altitude unit=\"FT\"> " << GetDistanceAGL() << " </altitude>\n";
+      outfile << "</initialize>\n";
       outfile.close();
     } else {
       FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
       log << "Could not open and/or write the state to the initial conditions file: "
-          << path << endl;
+          << path << "\n";
     }
     break;
   case 2:
     outfile.open(path);
     if (outfile.is_open()) {
-      outfile << "<?xml version=\"1.0\"?>" << endl;
-      outfile << "<initialize name=\"IC File\" version=\"2.0\">" << endl;
-      outfile << "" << endl;
-      outfile << "  <position frame=\"ECEF\">" << endl;
-      outfile << "    <latitude unit=\"DEG\" type=\"geodetic\"> " << VState.vLocation.GetGeodLatitudeDeg() << " </latitude>" << endl;
-      outfile << "    <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>" << endl;
-      outfile << "    <altitudeMSL unit=\"FT\"> " << GetAltitudeASL() << " </altitudeMSL>" << endl;
-      outfile << "  </position>" << endl;
-      outfile << "" << endl;
-      outfile << "  <orientation unit=\"DEG\" frame=\"LOCAL\">" << endl;
-      outfile << "    <yaw> " << VState.qAttitudeLocal.GetEulerDeg(eYaw) << " </yaw>" << endl;
-      outfile << "    <pitch> " << VState.qAttitudeLocal.GetEulerDeg(ePitch) << " </pitch>" << endl;
-      outfile << "    <roll> " << VState.qAttitudeLocal.GetEulerDeg(eRoll) << " </roll>" << endl;
-      outfile << "  </orientation>" << endl;
-      outfile << "" << endl;
-      outfile << "  <velocity unit=\"FT/SEC\" frame=\"LOCAL\">" << endl;
-      outfile << "    <x> " << GetVel(eNorth) << " </x>" << endl;
-      outfile << "    <y> " << GetVel(eEast) << " </y>" << endl;
-      outfile << "    <z> " << GetVel(eDown) << " </z>" << endl;
-      outfile << "  </velocity>" << endl;
-      outfile << "" << endl;
-      outfile << "  <attitude_rate unit=\"DEG/SEC\" frame=\"BODY\">" << endl;
-      outfile << "    <roll> " << (VState.vPQR*radtodeg)(eRoll) << " </roll>" << endl;
-      outfile << "    <pitch> " << (VState.vPQR*radtodeg)(ePitch) << " </pitch>" << endl;
-      outfile << "    <yaw> " << (VState.vPQR*radtodeg)(eYaw) << " </yaw>" << endl;
-      outfile << "  </attitude_rate>" << endl;
-      outfile << "" << endl;
-      outfile << "</initialize>" << endl;
+      outfile << "<?xml version=\"1.0\"?>\n";
+      outfile << "<initialize name=\"IC File\" version=\"2.0\">\n";
+      outfile << "\n";
+      outfile << "  <position frame=\"ECEF\">\n";
+      outfile << "    <latitude unit=\"DEG\" type=\"geodetic\"> " << VState.vLocation.GetGeodLatitudeDeg() << " </latitude>\n";
+      outfile << "    <longitude unit=\"DEG\"> " << VState.vLocation.GetLongitudeDeg() << " </longitude>\n";
+      outfile << "    <altitudeMSL unit=\"FT\"> " << GetAltitudeASL() << " </altitudeMSL>\n";
+      outfile << "  </position>\n";
+      outfile << "\n";
+      outfile << "  <orientation unit=\"DEG\" frame=\"LOCAL\">\n";
+      outfile << "    <yaw> " << VState.qAttitudeLocal.GetEulerDeg(eYaw) << " </yaw>\n";
+      outfile << "    <pitch> " << VState.qAttitudeLocal.GetEulerDeg(ePitch) << " </pitch>\n";
+      outfile << "    <roll> " << VState.qAttitudeLocal.GetEulerDeg(eRoll) << " </roll>\n";
+      outfile << "  </orientation>\n";
+      outfile << "\n";
+      outfile << "  <velocity unit=\"FT/SEC\" frame=\"LOCAL\">\n";
+      outfile << "    <x> " << GetVel(eNorth) << " </x>\n";
+      outfile << "    <y> " << GetVel(eEast) << " </y>\n";
+      outfile << "    <z> " << GetVel(eDown) << " </z>\n";
+      outfile << "  </velocity>\n";
+      outfile << "\n";
+      outfile << "  <attitude_rate unit=\"DEG/SEC\" frame=\"BODY\">\n";
+      outfile << "    <roll> " << (VState.vPQR*radtodeg)(eRoll) << " </roll>\n";
+      outfile << "    <pitch> " << (VState.vPQR*radtodeg)(ePitch) << " </pitch>\n";
+      outfile << "    <yaw> " << (VState.vPQR*radtodeg)(eYaw) << " </yaw>\n";
+      outfile << "  </attitude_rate>\n";
+      outfile << "\n";
+      outfile << "</initialize>\n";
       outfile.close();
     } else {
       FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
       log << "Could not open and/or write the state to the initial conditions file: "
-          << path << endl;
+          << path << "\n";
     }
     break;
   default:
     FGLogging log(FDMExec->GetLogger(), LogLevel::ERROR);
-    log << "When writing a state file, the supplied value must be 1 or 2 for the version number of the resulting IC file" << endl;
+    log << "When writing a state file, the supplied value must be 1 or 2 for the version number of the resulting IC file\n";
   }
 }
 
@@ -941,100 +942,98 @@ void FGPropagate::Debug(int from)
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
     FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-    if (from == 0) log << "Instantiated: FGPropagate" << endl;
-    if (from == 1) log << "Destroyed:    FGPropagate" << endl;
+    if (from == 0) log << "Instantiated: FGPropagate\n";
+    if (from == 1) log << "Destroyed:    FGPropagate\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }
   if (debug_lvl & 8 && from == 2) { // Runtime state variables
     FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
-    log << endl << LogFormat::BLUE << LogFormat::BOLD << left << fixed
+    log << "\n" << LogFormat::BLUE << LogFormat::BOLD << left << fixed
         << "  Propagation Report (English units: ft, degrees) at simulation time " << FDMExec->GetSimTime() << " seconds"
-        << LogFormat::RESET << endl;
-    log << endl;
+        << LogFormat::RESET << "\n\n";
     log << LogFormat::BOLD << "  Earth Position Angle (deg): " << setw(8) << setprecision(3) << LogFormat::RESET
-        << GetEarthPositionAngleDeg() << endl;
-    log << endl;
-    log << LogFormat::BOLD << "  Body velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vUVW << endl;
-    log << LogFormat::BOLD << "  Local velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << vVel << endl;
-    log << LogFormat::BOLD << "  Inertial velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vInertialVelocity << endl;
-    log << LogFormat::BOLD << "  Inertial Position (ft): " << setw(10) << setprecision(3) << LogFormat::RESET << VState.vInertialPosition << endl;
-    log << LogFormat::BOLD << "  Latitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLatitudeDeg() << endl;
-    log << LogFormat::BOLD << "  Longitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLongitudeDeg() << endl;
-    log << LogFormat::BOLD << "  Altitude ASL (ft): " << setw(8) << setprecision(3) << LogFormat::RESET << GetAltitudeASL() << endl;
-    //    log << LogFormat::BOLD << "  Acceleration (NED, ft/sec^2): " << setw(8) << setprecision(3) << LogFormat::RESET << Tb2l*GetUVWdot() << endl;
-    log << endl;
-    log << LogFormat::BOLD << "  Matrix ECEF to Body (Orientation of Body with respect to ECEF): "
-        << LogFormat::RESET << endl << Tec2b.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+        << GetEarthPositionAngleDeg() << "\n\n";
+    log << LogFormat::BOLD << "  Body velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vUVW << "\n";
+    log << LogFormat::BOLD << "  Local velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << vVel << "\n";
+    log << LogFormat::BOLD << "  Inertial velocity (ft/sec): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vInertialVelocity << "\n";
+    log << LogFormat::BOLD << "  Inertial Position (ft): " << setw(10) << setprecision(3) << LogFormat::RESET << VState.vInertialPosition << "\n";
+    log << LogFormat::BOLD << "  Latitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLatitudeDeg() << "\n";
+    log << LogFormat::BOLD << "  Longitude (deg): " << setw(8) << setprecision(3) << LogFormat::RESET << VState.vLocation.GetLongitudeDeg() << "\n";
+    log << LogFormat::BOLD << "  Altitude ASL (ft): " << setw(8) << setprecision(3) << LogFormat::RESET << GetAltitudeASL() << "\n";
+    //    log << LogFormat::BOLD << "  Acceleration (NED, ft/sec^2): " << setw(8) << setprecision(3) << LogFormat::RESET << Tb2l*GetUVWdot() << "\n";
+    log << "\n";
+    log << LogFormat::BOLD << "  Matrix ECEF to Body (Orientation of Body with respect to ECEF): \n"
+        << LogFormat::RESET << Tec2b.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tec2b.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix Body to ECEF (Orientation of ECEF with respect to Body):"
-        << LogFormat::RESET << endl << Tb2ec.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix Body to ECEF (Orientation of ECEF with respect to Body):\n"
+        << LogFormat::RESET << Tb2ec.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tb2ec.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix Local to Body (Orientation of Body with respect to Local):"
-        << LogFormat::RESET << endl << Tl2b.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix Local to Body (Orientation of Body with respect to Local):\n"
+        << LogFormat::RESET << Tl2b.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tl2b.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix Body to Local (Orientation of Local with respect to Body):"
-        << LogFormat::RESET << endl << Tb2l.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix Body to Local (Orientation of Local with respect to Body):\n"
+        << LogFormat::RESET << Tb2l.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tb2l.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix Local to ECEF (Orientation of ECEF with respect to Local):"
-        << LogFormat::RESET << endl << Tl2ec.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix Local to ECEF (Orientation of ECEF with respect to Local):\n"
+        << LogFormat::RESET << Tl2ec.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tl2ec.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix ECEF to Local (Orientation of Local with respect to ECEF):"
-        << LogFormat::RESET << endl << Tec2l.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix ECEF to Local (Orientation of Local with respect to ECEF):\n"
+        << LogFormat::RESET << Tec2l.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tec2l.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix ECEF to Inertial (Orientation of Inertial with respect to ECEF):"
-        << LogFormat::RESET << endl << Tec2i.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix ECEF to Inertial (Orientation of Inertial with respect to ECEF):\n"
+        << LogFormat::RESET << Tec2i.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tec2i.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix Inertial to ECEF (Orientation of ECEF with respect to Inertial):"
-        << LogFormat::RESET << endl << Ti2ec.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix Inertial to ECEF (Orientation of ECEF with respect to Inertial):\n"
+        << LogFormat::RESET << Ti2ec.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Ti2ec.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix Inertial to Body (Orientation of Body with respect to Inertial):"
-        << LogFormat::RESET << endl << Ti2b.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix Inertial to Body (Orientation of Body with respect to Inertial):\n"
+        << LogFormat::RESET << Ti2b.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Ti2b.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix Body to Inertial (Orientation of Inertial with respect to Body):"
-        << LogFormat::RESET << endl << Tb2i.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix Body to Inertial (Orientation of Inertial with respect to Body):\n"
+        << LogFormat::RESET << Tb2i.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tb2i.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix Inertial to Local (Orientation of Local with respect to Inertial):"
-        << LogFormat::RESET << endl << Ti2l.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix Inertial to Local (Orientation of Local with respect to Inertial):\n"
+        << LogFormat::RESET << Ti2l.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Ti2l.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
 
-    log << LogFormat::BOLD << "  Matrix Local to Inertial (Orientation of Inertial with respect to Local):"
-        << LogFormat::RESET << endl << Tl2i.Dump("\t", "    ") << endl;
-    log << LogFormat::BOLD << "    Associated Euler angles (deg): " << setw(8)
+    log << LogFormat::BOLD << "  Matrix Local to Inertial (Orientation of Inertial with respect to Local):\n"
+        << LogFormat::RESET << Tl2i.Dump("\t", "    ");
+    log << LogFormat::BOLD << "\n    Associated Euler angles (deg): " << setw(8)
         << setprecision(3) << LogFormat::RESET << (Tl2i.GetQuaternion().GetEuler()*radtodeg)
-                  << endl << endl;
+                  << "\n\n";
   }
   if (debug_lvl & 16) { // Sanity checking
     if (from == 2) { // State sanity checking

--- a/src/models/atmosphere/FGMars.cpp
+++ b/src/models/atmosphere/FGMars.cpp
@@ -41,8 +41,11 @@ COMMENTS, REFERENCES,  and NOTES
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include "FGMars.h"
 #include <iostream>
+
+#include "FGMars.h"
+#include "FGFDMExec.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -78,7 +81,8 @@ void FGMars::Calculate(double altitude)
   Pressure = 14.62*exp(-0.00003*altitude); // psf - 14.62 psf =~ 7 millibars
   Density = Pressure/(Reng*Temperature); // slugs/ft^3 (needs deg R. as input
 
-  //cout << "Atmosphere:  h=" << altitude << " rho= " << intDensity << endl;
+  //FGLogging log(FDMExec->GetLogger(), LogLevel::INFO);
+  //log << "Atmosphere:  h=" << altitude << " rho= " << intDensity << "\n";
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -109,8 +113,9 @@ void FGMars::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGMars" << endl;
-    if (from == 1) cout << "Destroyed:    FGMars" << endl;
+    FGLogging log(FDMExec->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGMars\n";
+    if (from == 1) log << "Destroyed:    FGMars\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/propulsion/FGForce.cpp
+++ b/src/models/propulsion/FGForce.cpp
@@ -42,6 +42,7 @@ moments due to the difference between the point of application and the cg.
 #include "FGForce.h"
 #include "FGFDMExec.h"
 #include "models/FGAuxiliary.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -108,9 +109,9 @@ const FGMatrix33& FGForce::Transform(void) const
     return mT;
   default:
     {
-      const string s("Unrecognized tranform requested from FGForce::Transform()");
-      cout << s << endl;
-      throw BaseException(s);
+      LogException err(fdmex->GetLogger());
+      err << "Unrecognized tranform requested from FGForce::Transform()\n";
+      throw err;
     }
   }
 }
@@ -181,12 +182,12 @@ void FGForce::Debug(int from)
 
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 0) { // Constructor
-
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGForce" << endl;
-    if (from == 1) cout << "Destroyed:    FGForce" << endl;
+    FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGForce\n";
+    if (from == 1) log << "Destroyed:    FGForce\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/propulsion/FGNozzle.cpp
+++ b/src/models/propulsion/FGNozzle.cpp
@@ -35,12 +35,10 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <iostream>
-#include <sstream>
-#include <cstdlib>
-
 #include "FGNozzle.h"
+#include "FGFDMExec.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -52,14 +50,14 @@ CLASS IMPLEMENTATION
 
 
 FGNozzle::FGNozzle(FGFDMExec* FDMExec, Element* nozzle_element, int num)
-                    : FGThruster(FDMExec, nozzle_element, num)
+  : FGThruster(FDMExec, nozzle_element, num)
 {
   if (nozzle_element->FindElement("area"))
     Area = nozzle_element->FindElementValueAsNumberConvertTo("area", "FT2");
   else {
-    const string s("Fatal Error: Nozzle exit area must be given in nozzle config file.");
-    cerr << s << endl;
-    throw BaseException(s);
+    XMLLogException err(fdmex->GetLogger(), nozzle_element);
+    err << "Fatal Error: Nozzle exit area must be given in nozzle config file.\n";
+    throw err;
   }
 
   Thrust = 0;
@@ -133,13 +131,15 @@ void FGNozzle::Debug(int from)
 
   if (debug_lvl & 1) { // Standard console startup message output
     if (from == 0) { // Constructor
-      cout << "      Nozzle Name: " << Name << endl;
-      cout << "      Nozzle Exit Area = " << Area << endl;
+      FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+      log << "      Nozzle Name: " << Name << "\n";
+      log << "      Nozzle Exit Area = " << Area << "\n";
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGNozzle" << endl;
-    if (from == 1) cout << "Destroyed:    FGNozzle" << endl;
+    FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGNozzle\n";
+    if (from == 1) log << "Destroyed:    FGNozzle\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }

--- a/src/models/propulsion/FGThruster.cpp
+++ b/src/models/propulsion/FGThruster.cpp
@@ -35,13 +35,11 @@ HISTORY
 INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-#include <iostream>
-#include <sstream>
-
 #include "FGFDMExec.h"
 #include "input_output/FGPropertyManager.h"
 #include "FGThruster.h"
 #include "input_output/FGXMLElement.h"
+#include "input_output/FGLog.h"
 
 using namespace std;
 
@@ -72,7 +70,11 @@ FGThruster::FGThruster(FGFDMExec *FDMExec, Element *el, int num ): FGForce(FDMEx
 
   element = thruster_element->FindElement("location");
   if (element)  location = element->FindElementTripletConvertTo("IN");
-  else          cerr << fgred << "      No thruster location found." << reset << endl;
+  else {
+    FGXMLLogging log(FDMExec->GetLogger(), thruster_element, LogLevel::ERROR);
+    log << LogFormat::RED << "      No thruster location found."
+        << LogFormat::RESET << "\n";
+  }
 
   SetLocation(location);
 
@@ -196,8 +198,9 @@ void FGThruster::Debug(int from)
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification
-    if (from == 0) cout << "Instantiated: FGThruster" << endl;
-    if (from == 1) cout << "Destroyed:    FGThruster" << endl;
+    FGLogging log(fdmex->GetLogger(), LogLevel::DEBUG);
+    if (from == 0) log << "Instantiated: FGThruster\n";
+    if (from == 1) log << "Destroyed:    FGThruster\n";
   }
   if (debug_lvl & 4 ) { // Run() method entry print for FGModel-derived objects
   }


### PR DESCRIPTION
Following the PR #1176, this PR continues the migration to the new logging system.

This PR is migrating the complete folder `src/initialization`, the thrusters in `src/models/propulsion` and some further files in `src/input_output`. All these files have a local copy of the `FGFDMExec` instance which makes very easy the access to the logger through the method `FGFDMExec::GetLogger`.

Please note that I have converted some files in `src/initialization` that are no longer compiled in JSBSim (`FGTrimAnalysis*.*` and `FGTrimmer`). I have done that to remove as many occurrences as I could of `cout` and `cerr` so that they no longer appear in the search filters that I am using. I have not tested if these files are compiling after their change because most likely they did not compile before since they are using outdated APIs.