### PR TITLE
Ensure engine set-running works for piston engines

### DIFF
--- a/src/models/FGPropulsion.cpp
+++ b/src/models/FGPropulsion.cpp
@@ -59,6 +59,7 @@ INCLUDES
 #include "models/propulsion/FGTurboProp.h"
 #include "models/propulsion/FGTank.h"
 #include "models/propulsion/FGBrushLessDCMotor.h"
+#include "models/FGFCS.h"
 
 
 using namespace std;
@@ -323,22 +324,27 @@ void FGPropulsion::InitRunning(int n)
       throw err;
     }
 
-    in.ThrottleCmd[n] = in.ThrottlePos[n] = 1; // Set the throttle command and position
-    in.MixtureCmd[n] = in.MixturePos[n] = 1;   // Set the mixture command and position
-
-    GetEngine(n)->InitRunning();
-    GetSteadyState();
+    SetEngineRunning(n);
 
   } else if (n < 0) { // -1 refers to "All Engines"
 
     for (unsigned int i=0; i<GetNumEngines(); i++) {
-      in.ThrottleCmd[i] = in.ThrottlePos[i] = 1; // Set the throttle command and position
-      in.MixtureCmd[i] = in.MixturePos[i] = 1;   // Set the mixture command and position
-      GetEngine(i)->InitRunning();
+      SetEngineRunning(i);
     }
-
-    GetSteadyState();
   }
+
+  GetSteadyState();
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+void FGPropulsion::SetEngineRunning(int engineIndex)
+{
+  in.ThrottleCmd[engineIndex] = in.ThrottlePos[engineIndex] = 1; // Set the throttle command and position
+  in.MixtureCmd[engineIndex] = in.MixturePos[engineIndex] = 1;   // Set the mixture command and position
+  FDMExec->GetFCS()->SetMixturePos(engineIndex, 1);    // Also set FCS values     
+  FDMExec->GetFCS()->SetMixtureCmd(engineIndex, 1);
+  GetEngine(engineIndex)->InitRunning();
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGPropulsion.h
+++ b/src/models/FGPropulsion.h
@@ -151,6 +151,7 @@ public:
 
   /** Sets up the engines as running */
   void InitRunning(int n);
+  void SetEngineRunning(int index);
 
   std::string GetPropulsionStrings(const std::string& delimiter) const;
   std::string GetPropulsionValues(const std::string& delimiter) const;


### PR DESCRIPTION
Ensure that if a mixture command isn't specified directly or via a system function a piston engine will start via a running command.

See discussion https://github.com/JSBSim-Team/jsbsim/discussions/1264 for more details.