### PR TITLE
Remove the class `FGPropertyNode`

### DIFF
--- a/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
+++ b/UnrealEngine/Plugins/JSBSimFlightDynamicsModel/Source/JSBSimFlightDynamicsModel/Private/JSBSimMovementComponent.cpp
@@ -109,7 +109,7 @@ void UJSBSimMovementComponent::CommandConsole(FString Property, FString InValue,
 {
 
   //Property name must be alphanumeric and limited to six []-._/ special characters. This check prevents UE5 editor crash when using invalid characters.
-#if WITH_EDITOR 
+#if WITH_EDITOR
   if (!std::regex_match((TCHAR_TO_UTF8(*Property)), std::regex("^[a-zA-Z0-9\\[\\]\\-._/]+$")))
   {
     FMessageLog("PIE").Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(TEXT("%s: JSBSim Command Console Blueprint Node Error: *%s* Property name must be alphanumeric and limited to these []-._/ six characters. Do not use parentheses *(RW)* in your property name"), *this->GetOwner()->GetName(), *Property))));
@@ -118,7 +118,7 @@ void UJSBSimMovementComponent::CommandConsole(FString Property, FString InValue,
   }
 #endif
 
-  FGPropertyNode* node = PropertyManager->GetNode(TCHAR_TO_UTF8(*Property), false);
+  SGPropertyNode* node = PropertyManager->GetNode(TCHAR_TO_UTF8(*Property), false);
   if (node != NULL)
   {
     //we skip setting values by using blank InValue.
@@ -145,7 +145,7 @@ void UJSBSimMovementComponent::CommandConsoleBatch(TArray<FString> Property, TAr
   {
 
     //Property name must be alphanumeric and limited to six []-._/ special characters. This check prevents UE5 editor crash when using invalid characters.
-  #if WITH_EDITOR 
+  #if WITH_EDITOR
     if (!std::regex_match((TCHAR_TO_UTF8(*Property[i])), std::regex("^[a-zA-Z0-9\\[\\]\\-._/]+$")))
     {
       FMessageLog("PIE").Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(TEXT("%s: JSBSim Command Console Blueprint Node Error: *%s* Property name must be alphanumeric and limited to these []-._/ six characters. Do not use parentheses *(RW)* in your property name"), *this->GetOwner()->GetName(), *Property[i]))));
@@ -154,7 +154,7 @@ void UJSBSimMovementComponent::CommandConsoleBatch(TArray<FString> Property, TAr
     }
   #endif
 
-    FGPropertyNode* node = PropertyManager->GetNode(TCHAR_TO_UTF8(*Property[i]), false);
+    SGPropertyNode* node = PropertyManager->GetNode(TCHAR_TO_UTF8(*Property[i]), false);
     if (node != NULL)
     {
       //we skip setting values by using blank InValue.
@@ -229,7 +229,7 @@ void UJSBSimMovementComponent::LoadAircraft(bool ResetToDefaultSettings)
     UE_LOG(LogJSBSim, Display, TEXT("Model %s Loaded successfully !"), *AircraftModel);
   }
 
-  // Do basic sanity checks 
+  // Do basic sanity checks
   if (GroundReactions->GetNumGearUnits() <= 0)
   {
     UE_LOG(LogJSBSim, Error, TEXT("Error - Num Gear Units = %d. This is a very bad thing because with 0 gear units, the ground trimming routine will core dump"), GroundReactions->GetNumGearUnits());
@@ -239,7 +239,7 @@ void UJSBSimMovementComponent::LoadAircraft(bool ResetToDefaultSettings)
 
   UpdateLocalTransforms();
 
-  // The Aircraft model has changed - Reset the Tank and Gear properties that can have been overriden by the user. 
+  // The Aircraft model has changed - Reset the Tank and Gear properties that can have been overriden by the user.
   if (ResetToDefaultSettings)
   {
     InitTankDefaultProperties();
@@ -269,7 +269,7 @@ double UJSBSimMovementComponent::GetAGLevel(const FVector& StartECEFLocation, FV
   // Estimate raycast length - Altitude + 5% of ellipsoid radius in case of negative altitudes
   FVector LineCheckEnd = StartEngineLocation - (AircraftState.AltitudeASLFt * FEET_TO_CENTIMETER + 0.05 * GeoReferencingSystem->GetGeographicEllipsoidMaxRadius()) * Up;
 
-  // Prepare collision query  
+  // Prepare collision query
   FHitResult HitResult = FHitResult();
   static const FName LineTraceSingleName(TEXT("AGLevelLineTrace"));
   FCollisionQueryParams CollisionParams(LineTraceSingleName);
@@ -290,7 +290,7 @@ double UJSBSimMovementComponent::GetAGLevel(const FVector& StartECEFLocation, FV
     //DrawDebugLine(GetWorld(), HitResult.ImpactPoint, HitResult.ImpactPoint + HitResult.ImpactNormal*100.0, FColor::Orange, false, -1, 0, 3);
 
     FVector DirectionToImpact = HitResult.ImpactPoint - StartEngineLocation;
-    HAT = FVector::Dist(StartEngineLocation, HitResult.ImpactPoint) / 100.0 * -FMath::Sign(DirectionToImpact.Dot(Up)); // JSBSim expect a signed distance. Consider that! 
+    HAT = FVector::Dist(StartEngineLocation, HitResult.ImpactPoint) / 100.0 * -FMath::Sign(DirectionToImpact.Dot(Up)); // JSBSim expect a signed distance. Consider that!
     GeoReferencingSystem->EngineToECEF(HitResult.ImpactPoint, ECEFContactPoint);
 
     // Georeferencing don't provide tools to transform a direction, or access the worldToECEF Matrix - Do it by hand
@@ -342,7 +342,7 @@ void UJSBSimMovementComponent::TickComponent(float DeltaTime, ELevelTick TickTyp
         Exec->Run();
       }
 
-      // The CG location in the reference frame can vary over time, for instance when tanks get empty... 
+      // The CG location in the reference frame can vary over time, for instance when tanks get empty...
       // Theoretically, we should update the local transforms. But maybe it's overkill to do it each frame...
       UpdateLocalTransforms();
 
@@ -355,7 +355,7 @@ void UJSBSimMovementComponent::TickComponent(float DeltaTime, ELevelTick TickTyp
         // Computes Rotation in engine frame
         FTransform ENUTransform = GeoReferencingSystem->GetTangentTransformAtECEFLocation(AircraftState.ECEFLocation);
         FRotator LocalUERotation(AircraftState.LocalEulerAngles);
-        LocalUERotation.Yaw = LocalUERotation.Yaw - 90.0; // JSBSim heading is aero heading (0 at north). We have to remove 90 because in UE, 0 is pointing east. 
+        LocalUERotation.Yaw = LocalUERotation.Yaw - 90.0; // JSBSim heading is aero heading (0 at north). We have to remove 90 because in UE, 0 is pointing east.
         FQuat EngineRotationQuat = ENUTransform.TransformRotation(LocalUERotation.Quaternion());
 
         FMatrix EngineRotation;
@@ -412,7 +412,7 @@ void UJSBSimMovementComponent::BeginPlay()
   // Init local variables from Level Objects
   Parent = GetOwner();
 
-  // A GeoReferencingSystem Actor is mandatory! 
+  // A GeoReferencingSystem Actor is mandatory!
   if (!GeoReferencingSystem)
   {
     GeoReferencingSystem = AGeoReferencingSystem::GetGeoReferencingSystem(GetWorld());
@@ -493,7 +493,7 @@ void UJSBSimMovementComponent::InitializeJSBSim()
     // Prepare Initial Conditions
     TrimNeeded = true;
 
-    // Base setup done so far. The other part of initial setup will be done on begin play, in InitJSBSim. 
+    // Base setup done so far. The other part of initial setup will be done on begin play, in InitJSBSim.
     JSBSimInitialized = true;
   }
 }
@@ -725,8 +725,8 @@ void UJSBSimMovementComponent::CopyFromJSBSim()
   // Keep Former Location in ECEF
   FVector FormerECEFLocation = AircraftState.ECEFLocation;
 
-  // Get Aircraft forward vector in local (ECEF tangent) space. 
-  // TODO - IDK if for the horizon indicator I should use the forward vector or the aircraft speed. 
+  // Get Aircraft forward vector in local (ECEF tangent) space.
+  // TODO - IDK if for the horizon indicator I should use the forward vector or the aircraft speed.
   // Maybe the aircraft speed would include some kind of lateral slip ---> May one expert fix it if needed...
   JSBSim::FGColumnVector3 ForwardLocal = Propagate->GetTb2l() * JSBSim::FGColumnVector3(1, 0, 0);
   ECEFForwardHorizontal = FVector(ForwardLocal(2), -ForwardLocal(1), 0);
@@ -875,7 +875,7 @@ void UJSBSimMovementComponent::InitGearDefaultProperties()
 
 void UJSBSimMovementComponent::CopyGearPropertiesToJSBSim()
 {
-  // TODO - What can be changed from the default values? 
+  // TODO - What can be changed from the default values?
   // Maybe the initial extension, but not sure it can be done...
 }
 
@@ -1124,7 +1124,7 @@ void UJSBSimMovementComponent::LogInitialization()
   // Speed
   switch (IC->GetSpeedSet())
   {
-    //typedef enum { setvt, setve, setvg } speedset; ??? 
+    //typedef enum { setvt, setve, setvg } speedset; ???
   case JSBSim::setned: // North East Down
     UE_LOG(LogJSBSim, Display, TEXT("  Vn,Ve,Vd= %f, $f, $f  ft/s"), Propagate->GetVel(JSBSim::FGJSBBase::eNorth), Propagate->GetVel(JSBSim::FGJSBBase::eEast), Propagate->GetVel(JSBSim::FGJSBBase::eDown));
     break;
@@ -1158,7 +1158,7 @@ void UJSBSimMovementComponent::DrawDebugMessage()
   // Commands
   DebugMessage += Commands.GetDebugMessage();
 
-  // Engines 
+  // Engines
   int32 NumEngines = EngineCommands.Num();
   // Engine Commands
   DebugMessage += LINE_TERMINATOR;
@@ -1196,7 +1196,7 @@ void UJSBSimMovementComponent::DrawDebugMessage()
     }
   }
 
-  // Aircraft State 
+  // Aircraft State
   DebugMessage += LINE_TERMINATOR;
   DebugMessage += AircraftState.GetDebugMessage();
 
@@ -1259,7 +1259,7 @@ void UJSBSimMovementComponent::PostEditChangeProperty(FPropertyChangedEvent& Pro
   static const FName NAME_AircraftModel = GET_MEMBER_NAME_CHECKED(UJSBSimMovementComponent, AircraftModel);
   if (PropertyChangedEvent.Property != nullptr && PropertyChangedEvent.Property->GetFName() == NAME_AircraftModel)
   {
-    // Load the aircraft, and make sure we recreate the Component properties for this new one. 
+    // Load the aircraft, and make sure we recreate the Component properties for this new one.
     LoadAircraft(true);
   }
 

--- a/matlab/JSBSimInterface.cpp
+++ b/matlab/JSBSimInterface.cpp
@@ -139,7 +139,7 @@ void JSBSimInterface::Update()
 bool JSBSimInterface::AddInputPropertyNode(std::string property)
 {
 
-	auto node = pm->GetNode(property);
+	SGPropertyNode* node = pm->GetNode(property);
 	if (node == NULL || !node->getAttribute(SGPropertyNode::Attribute::WRITE)) return false;
 
 	inputPort.push_back(node);
@@ -152,7 +152,7 @@ bool JSBSimInterface::AddWeatherPropertyNode(std::string property)
 
 	if (!(property.substr(0, std::string("atmosphere/").size()) == std::string("atmosphere/"))) return false;
 
-	auto node = pm->GetNode(property);
+	SGPropertyNode* node = pm->GetNode(property);
 	if (node == NULL || !node->getAttribute(SGPropertyNode::Attribute::WRITE)) return false;
 
 	weatherPort.push_back(node);
@@ -165,7 +165,7 @@ bool JSBSimInterface::AddOutputPropertyNode(std::string property, const int outp
 
 	if (outputPort >= outputPorts.size()) return false;
 
-	auto node = pm->GetNode(property);
+	SGPropertyNode* node = pm->GetNode(property);
 	if (node == NULL || !node->getAttribute(SGPropertyNode::Attribute::READ)) return false;
 
 	outputPorts.at(outputPort).push_back(node);

--- a/matlab/JSBSimInterface.cpp
+++ b/matlab/JSBSimInterface.cpp
@@ -47,7 +47,7 @@ JSBSimInterface::JSBSimInterface(int numOutputPorts)
 	fcs = fdmExec->GetFCS().get();
 	ic = new FGInitialCondition(fdmExec);
 	for (int i = 0; i < numOutputPorts; i++) {
-		std::vector<FGPropertyNode*> emptyVector;
+		std::vector<SGPropertyNode*> emptyVector;
 		outputPorts.push_back(emptyVector);
 	}
 	//verbosityLevel = JSBSimInterface::eSilent;
@@ -68,7 +68,7 @@ JSBSimInterface::JSBSimInterface(double dt, int numOutputPorts)
 	fcs = fdmExec->GetFCS().get();
 	ic = new FGInitialCondition(fdmExec);
 	for (int i = 0; i < numOutputPorts; i++) {
-		std::vector<FGPropertyNode*> emptyVector;
+		std::vector<SGPropertyNode*> emptyVector;
 		outputPorts.push_back(emptyVector);
 	}
 	//verbosityLevel = JSBSimInterface::eSilent;
@@ -86,7 +86,7 @@ bool JSBSimInterface::OpenAircraft(const std::string& acName)
 
 	if (!fdmExec->GetAircraft()->GetAircraftName().empty()) return false;
 
-    mexPrintf("\tSetting up JSBSim with standard 'aircraft', 'engine', and 'system' paths.\n");  
+    mexPrintf("\tSetting up JSBSim with standard 'aircraft', 'engine', and 'system' paths.\n");
     if (!fdmExec->SetAircraftPath (SGPath("aircraft"))) return false;
     if (!fdmExec->SetEnginePath   (SGPath("engine"))) return false;
     if (!fdmExec->SetSystemsPath  (SGPath("systems"))) return false;
@@ -103,8 +103,8 @@ bool JSBSimInterface::OpenAircraft(const std::string& acName)
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 bool JSBSimInterface::OpenScript(const SGPath& script, double delta_t, const SGPath& initfile)
 {
-    
-    if (!fdmExec->SetAircraftPath (SGPath("aircraft"))) return false;  
+
+    if (!fdmExec->SetAircraftPath (SGPath("aircraft"))) return false;
     if (!fdmExec->SetEnginePath   (SGPath("engine"))) return false;
     if (!fdmExec->SetSystemsPath  (SGPath("systems"))) return false;
 
@@ -119,8 +119,8 @@ bool JSBSimInterface::OpenScript(const SGPath& script, double delta_t, const SGP
 bool JSBSimInterface::LoadIC(SGPath ResetName)
 {
 
-    auto IC = fdmExec->GetIC(); 
-	
+    auto IC = fdmExec->GetIC();
+
     if (!IC->Load(ResetName)) return false;
 
     if (!fdmExec->RunIC()) return false;
@@ -139,8 +139,8 @@ void JSBSimInterface::Update()
 bool JSBSimInterface::AddInputPropertyNode(std::string property)
 {
 
-	FGPropertyNode* node = pm->GetNode(property);
-	if (node == NULL || !node->getAttribute(FGPropertyNode::Attribute::WRITE)) return false;
+	auto node = pm->GetNode(property);
+	if (node == NULL || !node->getAttribute(SGPropertyNode::Attribute::WRITE)) return false;
 
 	inputPort.push_back(node);
 	return true;
@@ -149,11 +149,11 @@ bool JSBSimInterface::AddInputPropertyNode(std::string property)
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 bool JSBSimInterface::AddWeatherPropertyNode(std::string property)
 {
-	
+
 	if (!(property.substr(0, std::string("atmosphere/").size()) == std::string("atmosphere/"))) return false;
 
-	FGPropertyNode* node = pm->GetNode(property);
-	if (node == NULL || !node->getAttribute(FGPropertyNode::Attribute::WRITE)) return false;
+	auto node = pm->GetNode(property);
+	if (node == NULL || !node->getAttribute(SGPropertyNode::Attribute::WRITE)) return false;
 
 	weatherPort.push_back(node);
 	return true;
@@ -162,11 +162,11 @@ bool JSBSimInterface::AddWeatherPropertyNode(std::string property)
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 bool JSBSimInterface::AddOutputPropertyNode(std::string property, const int outputPort)
 {
-	
+
 	if (outputPort >= outputPorts.size()) return false;
 
-	FGPropertyNode* node = pm->GetNode(property);
-	if (node == NULL || !node->getAttribute(FGPropertyNode::Attribute::READ)) return false;
+	auto node = pm->GetNode(property);
+	if (node == NULL || !node->getAttribute(SGPropertyNode::Attribute::READ)) return false;
 
 	outputPorts.at(outputPort).push_back(node);
 	return true;
@@ -174,11 +174,11 @@ bool JSBSimInterface::AddOutputPropertyNode(std::string property, const int outp
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 bool JSBSimInterface::CopyInputControlsToJSBSim(std::vector<double> controls) {
-    // TODO: error handling if controls is not correct size. 
-    
+    // TODO: error handling if controls is not correct size.
+
 	if (!fdmExec) return false;
 
-	FGPropertyNode* node;
+	SGPropertyNode* node;
 	for (int i = 0; i < inputPort.size(); i++) {
 		node = inputPort.at(i);
 		switch (node->getType()) {
@@ -202,16 +202,16 @@ bool JSBSimInterface::CopyInputControlsToJSBSim(std::vector<double> controls) {
 		}
 	}
 
-    return true; 
+    return true;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 bool JSBSimInterface::CopyInputWeatherToJSBSim(std::vector<double> weather) {
-    // TODO: error handling if weather is not correct size. 
-    
+    // TODO: error handling if weather is not correct size.
+
 	if (!fdmExec) return false;
 
-	FGPropertyNode* node;
+	SGPropertyNode* node;
 	for (int i = 0; i < weatherPort.size(); i++) {
 		node = weatherPort.at(i);
 		switch (node->getType()) {
@@ -235,18 +235,18 @@ bool JSBSimInterface::CopyInputWeatherToJSBSim(std::vector<double> weather) {
 		}
 	}
 
-    return true; 
+    return true;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 bool JSBSimInterface::CopyOutputsFromJSBSim(double *stateArray, const int outputPort) {
-	
+
 	if (outputPort >= outputPorts.size()) {
 		mexPrintf("Output port selected is out of bounds.\n");
 	}
 
-	FGPropertyNode* node;
-	std::vector<FGPropertyNode*> port = outputPorts.at(outputPort);
+	SGPropertyNode* node;
+	std::vector<SGPropertyNode*> port = outputPorts.at(outputPort);
 	for (int i = 0; i < port.size(); i++) {
 		node = port.at(i);
 		switch (node->getType()) {

--- a/matlab/JSBSimInterface.cpp
+++ b/matlab/JSBSimInterface.cpp
@@ -140,7 +140,7 @@ bool JSBSimInterface::AddInputPropertyNode(std::string property)
 {
 
 	SGPropertyNode* node = pm->GetNode(property);
-	if (node == NULL || !node->getAttribute(SGPropertyNode::Attribute::WRITE)) return false;
+	if (node == nullptr || !node->getAttribute(SGPropertyNode::Attribute::WRITE)) return false;
 
 	inputPort.push_back(node);
 	return true;
@@ -153,7 +153,7 @@ bool JSBSimInterface::AddWeatherPropertyNode(std::string property)
 	if (!(property.substr(0, std::string("atmosphere/").size()) == std::string("atmosphere/"))) return false;
 
 	SGPropertyNode* node = pm->GetNode(property);
-	if (node == NULL || !node->getAttribute(SGPropertyNode::Attribute::WRITE)) return false;
+	if (node == nullptr || !node->getAttribute(SGPropertyNode::Attribute::WRITE)) return false;
 
 	weatherPort.push_back(node);
 	return true;
@@ -166,7 +166,7 @@ bool JSBSimInterface::AddOutputPropertyNode(std::string property, const int outp
 	if (outputPort >= outputPorts.size()) return false;
 
 	SGPropertyNode* node = pm->GetNode(property);
-	if (node == NULL || !node->getAttribute(SGPropertyNode::Attribute::READ)) return false;
+	if (node == nullptr || !node->getAttribute(SGPropertyNode::Attribute::READ)) return false;
 
 	outputPorts.at(outputPort).push_back(node);
 	return true;

--- a/matlab/JSBSimInterface.h
+++ b/matlab/JSBSimInterface.h
@@ -48,7 +48,7 @@ public:
 	/// Open an aircraft model from Matlab
 	bool OpenAircraft(const std::string& acName);
 
-	/// Script handling 
+	/// Script handling
     bool OpenScript(const SGPath& script, double delta_t, const SGPath& initfile);
 
 	bool LoadIC(SGPath ResetName);
@@ -60,8 +60,8 @@ public:
 	bool AddInputPropertyNode(std::string property);
 	bool AddWeatherPropertyNode(std::string property);
 	bool AddOutputPropertyNode(std::string property, const int outputPort);
-	
-	/// Copy control inputs to JSBSim 
+
+	/// Copy control inputs to JSBSim
     bool CopyInputControlsToJSBSim(std::vector<double> controls);
 
 	/// Copy weather inputs to JSBSim
@@ -69,9 +69,9 @@ public:
 
 	/// Copy the flight state outputs from JSBSim
     bool CopyOutputsFromJSBSim(double *stateArray, const int outputPort);
-    
+
 	bool IsAircraftLoaded(){return _ac_model_loaded;}
-  	
+
 	// Wrapper functions to the FGFDMExec class
 	bool RunFDMExec() {return fdmExec->Run();}
 
@@ -104,9 +104,9 @@ private:
 	FGPropulsion *propulsion;
 	FGFCS *fcs;
 
-	std::vector<std::vector<FGPropertyNode*>> outputPorts;
-	std::vector<FGPropertyNode*> inputPort;
-	std::vector<FGPropertyNode*> weatherPort;
+	std::vector<std::vector<SGPropertyNode*>> outputPorts;
+	std::vector<SGPropertyNode*> inputPort;
+	std::vector<SGPropertyNode*> weatherPort;
 
 	bool _ac_model_loaded;
 

--- a/python/jsbsim.pxd
+++ b/python/jsbsim.pxd
@@ -71,7 +71,6 @@ cdef extern from "simgear/structure/SGSharedPtr.hxx":
         T* ptr() const
 
 cdef extern from "simgear/props/props.hxx" namespace "JSBSim":
-    cdef string GetFullyQualifiedName(const c_SGPropertyNode* node)
     cdef cppclass c_SGPropertyNode "SGPropertyNode":
         c_SGPropertyNode* getNode(const string& path, bool create)
         const string& getNameString() const
@@ -79,6 +78,7 @@ cdef extern from "simgear/props/props.hxx" namespace "JSBSim":
         bool setDoubleValue(double value)
 
 cdef extern from "input_output/FGPropertyManager.h" namespace "JSBSim":
+    cdef string GetFullyQualifiedName(const c_SGPropertyNode* node)
     cdef cppclass c_FGPropertyManager "JSBSim::FGPropertyManager":
         c_FGPropertyManager()
         c_FGPropertyManager(c_SGPropertyNode* root)

--- a/python/jsbsim.pxd
+++ b/python/jsbsim.pxd
@@ -70,20 +70,20 @@ cdef extern from "simgear/structure/SGSharedPtr.hxx":
         SGSharedPtr& operator=[U](U* p)
         T* ptr() const
 
-cdef extern from "input_output/FGPropertyManager.h" namespace "JSBSim":
-    cdef cppclass c_FGPropertyNode "JSBSim::FGPropertyNode":
-        c_FGPropertyNode* GetNode(const string& path, bool create)
-        const string& GetName() const
-        const string& GetFullyQualifiedName() const
+cdef extern from "simgear/props/props.hxx" namespace "JSBSim":
+    cdef string GetFullyQualifiedName(const c_SGPropertyNode* node)
+    cdef cppclass c_SGPropertyNode "SGPropertyNode":
+        c_SGPropertyNode* getNode(const string& path, bool create)
+        const string& getNameString() const
         double getDoubleValue() const
         bool setDoubleValue(double value)
 
 cdef extern from "input_output/FGPropertyManager.h" namespace "JSBSim":
     cdef cppclass c_FGPropertyManager "JSBSim::FGPropertyManager":
         c_FGPropertyManager()
-        c_FGPropertyManager(c_FGPropertyNode* root)
-        c_FGPropertyNode* GetNode()
-        c_FGPropertyNode* GetNode(const string& path, bool create)
+        c_FGPropertyManager(c_SGPropertyNode* root)
+        c_SGPropertyNode* GetNode()
+        c_SGPropertyNode* GetNode(const string& path, bool create)
         bool HasNode(const string& path) except +convertJSBSimToPyExc
 
 cdef extern from "math/FGColumnVector3.h" namespace "JSBSim":

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -136,6 +136,7 @@ cdef class FGPropertyNode:
         return self.thisptr.ptr() is not NULL
 
     def __str__(self) -> str:
+        """Print the fully qualified name of a property and its current value."""
         if self.thisptr.ptr() is not NULL:
             return f"Property '{self.get_fully_qualified_name()}' (value: {self.get_double_value()})"
         return "Uninitialized property"
@@ -153,17 +154,23 @@ cdef class FGPropertyNode:
             return None
 
     def get_name(self) -> str:
-        """@Dox(JSBSim::SGPropertyNode::GetName)"""
+        """Get the name of a node."""
         self.__intercept_invalid_pointer()
         return self.thisptr.ptr().getNameString().decode()
 
     def get_fully_qualified_name(self) -> str:
-        """@Dox(JSBSim::GetFullyQualifiedName)"""
+        """Get the fully qualified name of a node.
+
+           This function is very slow, so is probably useful for debugging only."""
         self.__intercept_invalid_pointer()
         return GetFullyQualifiedName(self.thisptr.ptr()).decode()
 
     def get_node(self, path: str, create: bool = False) -> Optional[SGPropertyNode]:
-        """@Dox(JSBSim::SGPropertyNode::GetNode)"""
+        """Get a property node.
+
+           :param path: The path of the node, relative to root.
+           :param create: True to create the node if it doesn't exist.
+           :return: The node, or None if none exists and none was created."""
         self.__intercept_invalid_pointer()
         node = FGPropertyNode()
         node.thisptr = self.thisptr.ptr().getNode(path.encode(), create)

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -127,9 +127,9 @@ cdef class FGPropagate:
 
 
 cdef class FGPropertyNode:
-    """@Dox(JSBSim::FGPropertyNode)"""
+    """@Dox(JSBSim::SGPropertyNode)"""
 
-    cdef SGSharedPtr[c_FGPropertyNode] thisptr
+    cdef SGSharedPtr[c_SGPropertyNode] thisptr
 
     def __bool__(self) -> bool:
         """Check if the object is initialized."""
@@ -153,20 +153,20 @@ cdef class FGPropertyNode:
             return None
 
     def get_name(self) -> str:
-        """@Dox(JSBSim::FGPropertyNode::GetName)"""
+        """@Dox(JSBSim::SGPropertyNode::GetName)"""
         self.__intercept_invalid_pointer()
-        return self.thisptr.ptr().GetName().decode()
+        return self.thisptr.ptr().getNameString().decode()
 
     def get_fully_qualified_name(self) -> str:
-        """@Dox(JSBSim::FGPropertyNode::GetFullyQualifiedName)"""
+        """@Dox(JSBSim::GetFullyQualifiedName)"""
         self.__intercept_invalid_pointer()
-        return self.thisptr.ptr().GetFullyQualifiedName().decode()
+        return GetFullyQualifiedName(self.thisptr.ptr()).decode()
 
-    def get_node(self, path: str, create: bool = False) -> Optional[FGPropertyNode]:
-        """@Dox(JSBSim::FGPropertyNode::GetNode)"""
+    def get_node(self, path: str, create: bool = False) -> Optional[SGPropertyNode]:
+        """@Dox(JSBSim::SGPropertyNode::GetNode)"""
         self.__intercept_invalid_pointer()
         node = FGPropertyNode()
-        node.thisptr = self.thisptr.ptr().GetNode(path.encode(), create)
+        node.thisptr = self.thisptr.ptr().getNode(path.encode(), create)
         return node.__validate_node_pointer(create)
 
     def get_double_value(self) -> float:
@@ -202,7 +202,7 @@ cdef class FGPropertyManager:
         if not self.thisptr:
             raise MemoryError()
 
-    def get_node(self, path: Optional[str] = None, create: bool = False) -> Optional[FGPropertyNode]:
+    def get_node(self, path: Optional[str] = None, create: bool = False) -> Optional[SGPropertyNode]:
         """@Dox(JSBSim::FGPropertyManager::GetNode)"""
         node = FGPropertyNode()
         if path is None:

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -123,11 +123,11 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   (*FDMctr)++;       // instance. "child" instances are loaded last.
 
   if (root == nullptr)          // Then this is the root FDM
-    Root = new FGPropertyNode();
+    Root = new SGPropertyNode();
   else
     Root = root->GetNode();
 
-  FGPropertyNode* instanceRoot = Root->GetNode("fdm/jsbsim", IdFDM, true);
+  auto instanceRoot = Root->getNode("fdm/jsbsim", IdFDM, true);
   instance = std::make_shared<FGPropertyManager>(instanceRoot);
 
   try {
@@ -1109,7 +1109,7 @@ void FGFDMExec::BuildPropertyCatalog(struct PropertyCatalogStructure* pcs)
       if (pcs->node->getChild(i)->getAttribute(SGPropertyNode::WRITE)) access+="W";
       PropertyCatalog.push_back(pcsNew->base_string+" ("+access+")");
     } else {
-      pcsNew->node = (FGPropertyNode*)pcs->node->getChild(i);
+      pcsNew->node = pcs->node->getChild(i);
       BuildPropertyCatalog(pcsNew.get());
     }
   }

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -127,7 +127,7 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   else
     Root = root->GetNode();
 
-  auto instanceRoot = Root->getNode("fdm/jsbsim", IdFDM, true);
+  SGPropertyNode* instanceRoot = Root->getNode("fdm/jsbsim", IdFDM, true);
   instance = std::make_shared<FGPropertyManager>(instanceRoot);
 
   try {

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -407,13 +407,13 @@ public:
       @param property the name of the property
       @result the value of the specified property */
   double GetPropertyValue(const std::string& property)
-  { return instance->GetNode()->GetDouble(property); }
+  { return instance->GetNode()->getDoubleValue(property.c_str()); }
 
   /** Sets a property value.
       @param property the property to be set
       @param value the value to set the property to */
   void SetPropertyValue(const std::string& property, double value)
-  { instance->GetNode()->SetDouble(property, value); }
+  { instance->GetNode()->setDoubleValue(property.c_str(), value); }
 
   /// Returns the model name.
   const std::string& GetModelName(void) const { return modelName; }
@@ -516,7 +516,7 @@ public:
     /// Name of the property.
     std::string base_string;
     /// The node for the property.
-    FGPropertyNode_ptr node;
+    SGPropertyNode_ptr node;
   };
 
   /** Builds a catalog of properties.
@@ -686,7 +686,7 @@ private:
   std::shared_ptr<FGScript>           Script;
   std::shared_ptr<FGTrim>             Trim;
 
-  FGPropertyNode_ptr Root;
+  SGPropertyNode_ptr Root;
   std::shared_ptr<FGPropertyManager> instance;
 
   bool HoldDown;

--- a/src/input_output/FGInputSocket.cpp
+++ b/src/input_output/FGInputSocket.cpp
@@ -146,7 +146,7 @@ void FGInputSocket::Read(bool Holding)
       }
 
       if (command == "set") {                       // SET PROPERTY
-        FGPropertyNode* node = nullptr;
+        SGPropertyNode* node = nullptr;
 
         if (argument.empty()) {
           socket->Reply("No property argument supplied.\r\n");
@@ -179,7 +179,7 @@ void FGInputSocket::Read(bool Holding)
         socket->Reply("set successful\r\n");
 
       } else if (command == "get") {             // GET PROPERTY
-        FGPropertyNode* node = nullptr;
+        SGPropertyNode* node = nullptr;
 
         if (argument.empty()) {
           socket->Reply("No property argument supplied.\r\n");

--- a/src/input_output/FGOutputType.cpp
+++ b/src/input_output/FGOutputType.cpp
@@ -130,7 +130,7 @@ bool FGOutputType::Load(Element* element)
 
   while (property_element) {
     string property_str = property_element->GetDataLine();
-    FGPropertyNode* node = PropertyManager->GetNode(property_str);
+    auto node = PropertyManager->GetNode(property_str);
     if (!node) {
       FGXMLLogging log(FDMExec->GetLogger(), property_element, LogLevel::ERROR);
       log << LogFormat::RED << LogFormat::BOLD << "  No property by the name "
@@ -220,7 +220,7 @@ double FGOutputType::GetRateHz(void) const
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGOutputType::SetOutputProperties(vector<FGPropertyNode_ptr> & outputProperties)
+void FGOutputType::SetOutputProperties(vector<SGPropertyNode_ptr> & outputProperties)
 {
   for (auto prop: outputProperties)
     OutputParameters.push_back(new FGPropertyValue(prop));

--- a/src/input_output/FGOutputType.cpp
+++ b/src/input_output/FGOutputType.cpp
@@ -130,7 +130,7 @@ bool FGOutputType::Load(Element* element)
 
   while (property_element) {
     string property_str = property_element->GetDataLine();
-    auto node = PropertyManager->GetNode(property_str);
+    SGPropertyNode* node = PropertyManager->GetNode(property_str);
     if (!node) {
       FGXMLLogging log(FDMExec->GetLogger(), property_element, LogLevel::ERROR);
       log << LogFormat::RED << LogFormat::BOLD << "  No property by the name "

--- a/src/input_output/FGOutputType.h
+++ b/src/input_output/FGOutputType.h
@@ -120,7 +120,7 @@ public:
   /** Set the list of properties that should be output for this output instance.
       @param outputProperties list of properties that should be output
   */
-  void SetOutputProperties(std::vector<FGPropertyNode_ptr> & outputProperties);
+  void SetOutputProperties(std::vector<SGPropertyNode_ptr> & outputProperties);
 
   /** Overwrites the name identifier under which the output will be logged.
       This method is taken into account if it is called before

--- a/src/input_output/FGPropertyManager.cpp
+++ b/src/input_output/FGPropertyManager.cpp
@@ -117,7 +117,7 @@ string GetPrintableName(const SGPropertyNode* node)
 string GetFullyQualifiedName(const SGPropertyNode* node)
 {
   string fqname = node->getDisplayName(true);
-  auto parent = node->getParent();
+  const SGPropertyNode* parent = node->getParent();
   if (!parent) return "/";  // node is the root.
 
   while(parent) {

--- a/src/input_output/FGPropertyManager.cpp
+++ b/src/input_output/FGPropertyManager.cpp
@@ -93,42 +93,9 @@ string FGPropertyManager::mkPropertyName(string name, bool lowercase) {
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-FGPropertyNode*
-FGPropertyNode::GetNode (const string &path, bool create)
+string GetPrintableName(const SGPropertyNode* node)
 {
-  SGPropertyNode* node = getNode(path.c_str(), create);
-  if (node == 0) {
-    cerr << "FGPropertyManager::GetNode() No node found for " << path << endl;
-  }
-  return (FGPropertyNode*)node;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-FGPropertyNode*
-FGPropertyNode::GetNode (const string &relpath, int index, bool create)
-{
-  SGPropertyNode* node = getNode(relpath.c_str(), index, create);
-  if (node == 0) {
-    cerr << "FGPropertyManager::GetNode() No node found for " << relpath
-         << "[" << index << "]" << endl;
-  }
-  return (FGPropertyNode*)node;
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-bool FGPropertyNode::HasNode (const string &path)
-{
-  const SGPropertyNode* node = getNode(path.c_str(), false);
-  return (node != 0);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-string FGPropertyNode::GetPrintableName( void ) const
-{
-  string temp_string(getNameString());
+  string temp_string(node->getNameString());
   size_t initial_location=0;
   size_t found_location;
 
@@ -147,155 +114,30 @@ string FGPropertyNode::GetPrintableName( void ) const
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-string FGPropertyNode::GetFullyQualifiedName(void) const
+string GetFullyQualifiedName(const SGPropertyNode* node)
 {
-  string fqname;
-  const SGPropertyNode* node = this;
-  while(node) {
-    fqname = node->getDisplayName(true) + "/" + fqname;
-    node = node->getParent();
+  string fqname = node->getDisplayName(true);
+  auto parent = node->getParent();
+  if (!parent) return "/";  // node is the root.
+
+  while(parent) {
+    fqname = parent->getDisplayName(true) + "/" + fqname;
+    parent = parent->getParent();
   }
 
-  // Remove the trailing slash if the node is not the root.
-  size_t len = std::max<size_t>(1, fqname.size()-1);
-  return fqname.substr(0, len);
+  return fqname;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-string FGPropertyNode::GetRelativeName( const string &path ) const
+string GetRelativeName(const SGPropertyNode* node, const string &path)
 {
-  string temp_string = GetFullyQualifiedName();
+  string temp_string = GetFullyQualifiedName(node);
   size_t len = path.length();
   if ( (len > 0) && (temp_string.substr(0,len) == path) ) {
     temp_string = temp_string.erase(0,len);
   }
   return temp_string;
-}
-
-
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-bool FGPropertyNode::GetBool (const string &name, bool defaultValue) const
-{
-  return getBoolValue(name.c_str(), defaultValue);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-int FGPropertyNode::GetInt (const string &name, int defaultValue ) const
-{
-  return getIntValue(name.c_str(), defaultValue);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-int FGPropertyNode::GetLong (const string &name, long defaultValue ) const
-{
-  return getLongValue(name.c_str(), defaultValue);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-float FGPropertyNode::GetFloat (const string &name, float defaultValue ) const
-{
-  return getFloatValue(name.c_str(), defaultValue);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-double FGPropertyNode::GetDouble (const string &name, double defaultValue ) const
-{
-  return getDoubleValue(name.c_str(), defaultValue);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-string FGPropertyNode::GetString (const string &name, string defaultValue ) const
-{
-  return string(getStringValue(name.c_str(), defaultValue.c_str()));
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-bool FGPropertyNode::SetBool (const string &name, bool val)
-{
-  return setBoolValue(name.c_str(), val);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-bool FGPropertyNode::SetInt (const string &name, int val)
-{
-  return setIntValue(name.c_str(), val);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-bool FGPropertyNode::SetLong (const string &name, long val)
-{
-  return setLongValue(name.c_str(), val);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-bool FGPropertyNode::SetFloat (const string &name, float val)
-{
-  return setFloatValue(name.c_str(), val);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-bool FGPropertyNode::SetDouble (const string &name, double val)
-{
-  return setDoubleValue(name.c_str(), val);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-bool FGPropertyNode::SetString (const string &name, const string &val)
-{
-  return setStringValue(name.c_str(), val.c_str());
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void FGPropertyNode::SetArchivable (const string &name, bool state )
-{
-  SGPropertyNode * node = getNode(name.c_str());
-  if (node == 0)
-    cerr <<
-           "Attempt to set archive flag for non-existent property "
-           << name << endl;
-  else
-    node->setAttribute(SGPropertyNode::ARCHIVE, state);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void FGPropertyNode::SetReadable (const string &name, bool state )
-{
-  SGPropertyNode * node = getNode(name.c_str());
-  if (node == 0)
-    cerr <<
-           "Attempt to set read flag for non-existant property "
-           << name << endl;
-  else
-    node->setAttribute(SGPropertyNode::READ, state);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void FGPropertyNode::SetWritable (const string &name, bool state )
-{
-  SGPropertyNode * node = getNode(name.c_str());
-  if (node == 0)
-    cerr <<
-           "Attempt to set write flag for non-existant property "
-           << name << endl;
-  else
-    node->setAttribute(SGPropertyNode::WRITE, state);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/input_output/FGPropertyManager.h
+++ b/src/input_output/FGPropertyManager.h
@@ -57,9 +57,9 @@ FORWARD DECLARATIONS
 
 namespace JSBSim {
 
-std::string GetPrintableName(const SGPropertyNode* node);
-std::string GetFullyQualifiedName(const SGPropertyNode* node);
-std::string GetRelativeName(const SGPropertyNode* node, const std::string &path);
+JSBSIM_API std::string GetPrintableName(const SGPropertyNode* node);
+JSBSIM_API std::string GetFullyQualifiedName(const SGPropertyNode* node);
+JSBSIM_API std::string GetRelativeName(const SGPropertyNode* node, const std::string &path);
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 CLASS DOCUMENTATION

--- a/src/input_output/FGPropertyManager.h
+++ b/src/input_output/FGPropertyManager.h
@@ -94,8 +94,8 @@ class JSBSIM_API FGPropertyManager
     {
       std::string newPath = path;
       if (newPath[0] == '-') newPath.erase(0,1);
-      auto prop = root->getNode(newPath);
-      return prop;
+      SGPropertyNode* prop = root->getNode(newPath);
+      return prop != nullptr;
     }
 
     /** Property-ify a name

--- a/src/input_output/FGPropertyManager.h
+++ b/src/input_output/FGPropertyManager.h
@@ -57,6 +57,10 @@ FORWARD DECLARATIONS
 
 namespace JSBSim {
 
+std::string GetPrintableName(const SGPropertyNode* node);
+std::string GetFullyQualifiedName(const SGPropertyNode* node);
+std::string GetRelativeName(const SGPropertyNode* node, const std::string &path);
+
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 CLASS DOCUMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
@@ -69,331 +73,29 @@ CLASS DOCUMENTATION
 CLASS DECLARATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class JSBSIM_API FGPropertyNode : public SGPropertyNode
-{
-  public:
-    /// Destructor
-    virtual ~FGPropertyNode(void) {}
-
-    /**
-     * Get a property node.
-     *
-     * @param path The path of the node, relative to root.
-     * @param create true to create the node if it doesn't exist.
-     * @return The node, or 0 if none exists and none was created.
-     */
-    FGPropertyNode*
-    GetNode (const std::string &path, bool create = false);
-
-    FGPropertyNode*
-    GetNode (const std::string &relpath, int index, bool create = false);
-
-    /**
-     * Test whether a given node exists.
-     *
-     * @param path The path of the node, relative to root.
-     * @return true if the node exists, false otherwise.
-     */
-    bool HasNode (const std::string &path);
-
-    /**
-     * Get the name of a node
-     */
-    const std::string& GetName( void ) const { return getNameString(); }
-
-    /**
-     * Get the name of a node without underscores, etc.
-     */
-    std::string GetPrintableName( void ) const;
-
-    /**
-     * Get the fully qualified name of a node
-     * This function is very slow, so is probably useful for debugging only.
-     */
-    std::string GetFullyQualifiedName(void) const;
-
-    /**
-     * Get the qualified name of a node relative to given base path,
-     * otherwise the fully qualified name.
-     * This function is very slow, so is probably useful for debugging only.
-     *
-     * @param path The path to strip off, if found.
-     */
-    std::string GetRelativeName( const std::string &path = "/fdm/jsbsim/" ) const;
-
-    /**
-     * Get a bool value for a property.
-     *
-     * This method is convenient but inefficient.  It should be used
-     * infrequently (i.e. for initializing, loading, saving, etc.),
-     * not in the main loop.  If you need to get a value frequently,
-     * it is better to look up the node itself using GetNode and then
-     * use the node's getBoolValue() method, to avoid the lookup overhead.
-     *
-     * @param name The property name.
-     * @param defaultValue The default value to return if the property
-     *        does not exist.
-     * @return The property's value as a bool, or the default value provided.
-     */
-    bool GetBool (const std::string &name, bool defaultValue = false) const;
-
-
-    /**
-     * Get an int value for a property.
-     *
-     * This method is convenient but inefficient.  It should be used
-     * infrequently (i.e. for initializing, loading, saving, etc.),
-     * not in the main loop.  If you need to get a value frequently,
-     * it is better to look up the node itself using GetNode and then
-     * use the node's getIntValue() method, to avoid the lookup overhead.
-     *
-     * @param name The property name.
-     * @param defaultValue The default value to return if the property
-     *        does not exist.
-     * @return The property's value as an int, or the default value provided.
-     */
-    int GetInt (const std::string &name, int defaultValue = 0) const;
-
-
-    /**
-     * Get a long value for a property.
-     *
-     * This method is convenient but inefficient.  It should be used
-     * infrequently (i.e. for initializing, loading, saving, etc.),
-     * not in the main loop.  If you need to get a value frequently,
-     * it is better to look up the node itself using GetNode and then
-     * use the node's getLongValue() method, to avoid the lookup overhead.
-     *
-     * @param name The property name.
-     * @param defaultValue The default value to return if the property
-     *        does not exist.
-     * @return The property's value as a long, or the default value provided.
-     */
-    int GetLong (const std::string &name, long defaultValue = 0L) const;
-
-
-    /**
-     * Get a float value for a property.
-     *
-     * This method is convenient but inefficient.  It should be used
-     * infrequently (i.e. for initializing, loading, saving, etc.),
-     * not in the main loop.  If you need to get a value frequently,
-     * it is better to look up the node itself using GetNode and then
-     * use the node's getFloatValue() method, to avoid the lookup overhead.
-     *
-     * @param name The property name.
-     * @param defaultValue The default value to return if the property
-     *        does not exist.
-     * @return The property's value as a float, or the default value provided.
-     */
-    float GetFloat (const std::string &name, float defaultValue = 0.0) const;
-
-
-    /**
-     * Get a double value for a property.
-     *
-     * This method is convenient but inefficient.  It should be used
-     * infrequently (i.e. for initializing, loading, saving, etc.),
-     * not in the main loop.  If you need to get a value frequently,
-     * it is better to look up the node itself using GetNode and then
-     * use the node's getDoubleValue() method, to avoid the lookup overhead.
-     *
-     * @param name The property name.
-     * @param defaultValue The default value to return if the property
-     *        does not exist.
-     * @return The property's value as a double, or the default value provided.
-     */
-    double GetDouble (const std::string &name, double defaultValue = 0.0) const;
-
-
-    /**
-     * Get a string value for a property.
-     *
-     * This method is convenient but inefficient.  It should be used
-     * infrequently (i.e. for initializing, loading, saving, etc.),
-     * not in the main loop.  If you need to get a value frequently,
-     * it is better to look up the node itself using GetNode and then
-     * use the node's getStringValue() method, to avoid the lookup overhead.
-     *
-     * @param name The property name.
-     * @param defaultValue The default value to return if the property
-     *        does not exist.
-     * @return The property's value as a string, or the default value provided.
-     */
-    std::string GetString (const std::string &name, std::string defaultValue = "") const;
-
-
-    /**
-     * Set a bool value for a property.
-     *
-     * Assign a bool value to a property.  If the property does not
-     * yet exist, it will be created and its type will be set to
-     * BOOL; if it has a type of UNKNOWN, the type will also be set to
-     * BOOL; otherwise, the value type will be converted to the property's
-     * type.
-     *
-     * @param name The property name.
-     * @param val The new value for the property.
-     * @return true if the assignment succeeded, false otherwise.
-     */
-    bool SetBool (const std::string &name, bool val);
-
-
-    /**
-     * Set an int value for a property.
-     *
-     * Assign an int value to a property.  If the property does not
-     * yet exist, it will be created and its type will be set to
-     * INT; if it has a type of UNKNOWN, the type will also be set to
-     * INT; otherwise, the value type will be converted to the property's
-     * type.
-     *
-     * @param name The property name.
-     * @param val The new value for the property.
-     * @return true if the assignment succeeded, false otherwise.
-     */
-    bool SetInt (const std::string &name, int val);
-
-
-    /**
-     * Set a long value for a property.
-     *
-     * Assign a long value to a property.  If the property does not
-     * yet exist, it will be created and its type will be set to
-     * LONG; if it has a type of UNKNOWN, the type will also be set to
-     * LONG; otherwise, the value type will be converted to the property's
-     * type.
-     *
-     * @param name The property name.
-     * @param val The new value for the property.
-     * @return true if the assignment succeeded, false otherwise.
-     */
-    bool SetLong (const std::string &name, long val);
-
-
-    /**
-     * Set a float value for a property.
-     *
-     * Assign a float value to a property.  If the property does not
-     * yet exist, it will be created and its type will be set to
-     * FLOAT; if it has a type of UNKNOWN, the type will also be set to
-     * FLOAT; otherwise, the value type will be converted to the property's
-     * type.
-     *
-     * @param name The property name.
-     * @param val The new value for the property.
-     * @return true if the assignment succeeded, false otherwise.
-     */
-    bool SetFloat (const std::string &name, float val);
-
-
-    /**
-     * Set a double value for a property.
-     *
-     * Assign a double value to a property.  If the property does not
-     * yet exist, it will be created and its type will be set to
-     * DOUBLE; if it has a type of UNKNOWN, the type will also be set to
-     * DOUBLE; otherwise, the double value will be converted to the property's
-     * type.
-     *
-     * @param name The property name.
-     * @param val The new value for the property.
-     * @return true if the assignment succeeded, false otherwise.
-     */
-    bool SetDouble (const std::string &name, double val);
-
-
-    /**
-     * Set a string value for a property.
-     *
-     * Assign a string value to a property.  If the property does not
-     * yet exist, it will be created and its type will be set to
-     * STRING; if it has a type of UNKNOWN, the type will also be set to
-     * STRING; otherwise, the string value will be converted to the property's
-     * type.
-     *
-     * @param name The property name.
-     * @param val The new value for the property.
-     * @return true if the assignment succeeded, false otherwise.
-     */
-    bool SetString (const std::string &name, const std::string &val);
-
-
-    ////////////////////////////////////////////////////////////////////////
-    // Convenience functions for setting property attributes.
-    ////////////////////////////////////////////////////////////////////////
-
-
-    /**
-     * Set the state of the archive attribute for a property.
-     *
-     * If the archive attribute is true, the property will be written
-     * when a flight is saved; if it is false, the property will be
-     * skipped.
-     *
-     * A warning message will be printed if the property does not exist.
-     *
-     * @param name The property name.
-     * @param state The state of the archive attribute (defaults to true).
-     */
-    void SetArchivable (const std::string &name, bool state = true);
-
-
-    /**
-     * Set the state of the read attribute for a property.
-     *
-     * If the read attribute is true, the property value will be readable;
-     * if it is false, the property value will always be the default value
-     * for its type.
-     *
-     * A warning message will be printed if the property does not exist.
-     *
-     * @param name The property name.
-     * @param state The state of the read attribute (defaults to true).
-     */
-    void SetReadable (const std::string &name, bool state = true);
-
-
-    /**
-     * Set the state of the write attribute for a property.
-     *
-     * If the write attribute is true, the property value may be modified
-     * (depending on how it is tied); if the write attribute is false, the
-     * property value may not be modified.
-     *
-     * A warning message will be printed if the property does not exist.
-     *
-     * @param name The property name.
-     * @param state The state of the write attribute (defaults to true).
-     */
-    void SetWritable (const std::string &name, bool state = true);
-};
-
-typedef SGSharedPtr<FGPropertyNode> FGPropertyNode_ptr;
-typedef SGSharedPtr<const FGPropertyNode> FGConstPropertyNode_ptr;
-
 class JSBSIM_API FGPropertyManager
 {
   public:
     /// Default constructor
-    FGPropertyManager(void) { root = new FGPropertyNode; }
+    FGPropertyManager(void) { root = new SGPropertyNode; }
 
     /// Constructor
-    explicit FGPropertyManager(FGPropertyNode* _root) : root(_root) {};
+    explicit FGPropertyManager(SGPropertyNode* _root) : root(_root) {};
 
     /// Destructor
     virtual ~FGPropertyManager(void) { Unbind(); }
 
-    FGPropertyNode* GetNode(void) const { return root; }
-    FGPropertyNode* GetNode(const std::string &path, bool create = false)
-    { return root->GetNode(path, create); }
-    FGPropertyNode* GetNode(const std::string &relpath, int index, bool create = false)
-    { return root->GetNode(relpath, index, create); }
+    SGPropertyNode* GetNode(void) const { return root; }
+    SGPropertyNode* GetNode(const std::string &path, bool create = false)
+    { return root->getNode(path, create); }
+    SGPropertyNode* GetNode(const std::string &relpath, int index, bool create = false)
+    { return root->getNode(relpath, index, create); }
     bool HasNode(const std::string& path) const
     {
       std::string newPath = path;
       if (newPath[0] == '-') newPath.erase(0,1);
-      return root->HasNode(newPath);
+      auto prop = root->getNode(newPath);
+      return prop;
     }
 
     /** Property-ify a name
@@ -644,7 +346,7 @@ class JSBSIM_API FGPropertyManager
       }
     };
     std::list<PropertyState> tied_properties;
-    FGPropertyNode_ptr root;
+    SGPropertyNode_ptr root;
 };
 }
 #endif // FGPROPERTYMANAGER_H

--- a/src/input_output/FGPropertyReader.h
+++ b/src/input_output/FGPropertyReader.h
@@ -71,9 +71,9 @@ public:
     explicit const_iterator(const std::map<SGPropertyNode_ptr, double>::const_iterator &it) : prop_it(it) {}
     const_iterator& operator++() { ++prop_it; return *this; }
     bool operator!=(const const_iterator& it) const { return prop_it != it.prop_it; }
-    FGPropertyNode* operator*() {
+    SGPropertyNode* operator*() {
       SGPropertyNode* node = prop_it->first;
-      return static_cast<FGPropertyNode*>(node);
+      return node;
     }
 
   private:

--- a/src/input_output/FGPropertyReader.h
+++ b/src/input_output/FGPropertyReader.h
@@ -71,10 +71,7 @@ public:
     explicit const_iterator(const std::map<SGPropertyNode_ptr, double>::const_iterator &it) : prop_it(it) {}
     const_iterator& operator++() { ++prop_it; return *this; }
     bool operator!=(const const_iterator& it) const { return prop_it != it.prop_it; }
-    SGPropertyNode* operator*() {
-      SGPropertyNode* node = prop_it->first;
-      return node;
-    }
+    SGPropertyNode* operator*() { return prop_it->first; }
 
   private:
     std::map<SGPropertyNode_ptr, double>::const_iterator prop_it;

--- a/src/input_output/FGScript.cpp
+++ b/src/input_output/FGScript.cpp
@@ -573,7 +573,7 @@ void FGScript::Debug(int from)
       cout << endl;
 
       for (auto node: LocalProperties) {
-        cout << "Local property: " << node->GetName()
+        cout << "Local property: " << node->getNameString()
              << " = " << node->getDoubleValue()
              << endl;
       }
@@ -613,7 +613,7 @@ void FGScript::Debug(int from)
               }
             } else {
               cout << endl << "      set "
-                   << Events[i].SetParam[j]->GetRelativeName("/fdm/jsbsim/")
+                   << GetRelativeName(Events[i].SetParam[j], "/fdm/jsbsim/")
                    << " to function value";
             }
           } else {
@@ -630,7 +630,7 @@ void FGScript::Debug(int from)
               }
             } else {
               cout << endl << "      set "
-                   << Events[i].SetParam[j]->GetRelativeName("/fdm/jsbsim/")
+                   << GetRelativeName(Events[i].SetParam[j], "/fdm/jsbsim/")
                    << " to " << Events[i].SetValue[j];
             }
           }

--- a/src/input_output/FGScript.h
+++ b/src/input_output/FGScript.h
@@ -220,7 +220,7 @@ private:
     double           TimeSpan;
     std::string           Name;
     std::string           Description;
-    std::vector <FGPropertyNode_ptr>  SetParam;
+    std::vector <SGPropertyNode_ptr>  SetParam;
     std::vector <std::string>  SetParamName;
     std::vector <FGPropertyValue*>  NotifyProperties;
     std::vector <std::string>              DisplayString;

--- a/src/input_output/FGUDPInputSocket.cpp
+++ b/src/input_output/FGUDPInputSocket.cpp
@@ -72,7 +72,7 @@ bool FGUDPInputSocket::Load(Element* el)
 
   while (property_element) {
     string property_str = property_element->GetDataLine();
-    auto node = PropertyManager->GetNode(property_str);
+    SGPropertyNode* node = PropertyManager->GetNode(property_str);
     if (!node) {
       FGXMLLogging log(FDMExec->GetLogger(), property_element, LogLevel::ERROR);
       log << LogFormat::RED << LogFormat::BOLD << "\n  No property by the name "

--- a/src/input_output/FGUDPInputSocket.cpp
+++ b/src/input_output/FGUDPInputSocket.cpp
@@ -72,7 +72,7 @@ bool FGUDPInputSocket::Load(Element* el)
 
   while (property_element) {
     string property_str = property_element->GetDataLine();
-    FGPropertyNode* node = PropertyManager->GetNode(property_str);
+    auto node = PropertyManager->GetNode(property_str);
     if (!node) {
       FGXMLLogging log(FDMExec->GetLogger(), property_element, LogLevel::ERROR);
       log << LogFormat::RED << LogFormat::BOLD << "\n  No property by the name "

--- a/src/input_output/FGUDPInputSocket.h
+++ b/src/input_output/FGUDPInputSocket.h
@@ -50,7 +50,7 @@ namespace JSBSim {
 CLASS DOCUMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-/** Implements a UDP input socket. 
+/** Implements a UDP input socket.
  */
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -75,7 +75,7 @@ protected:
 
   int rate;
   double oldTimeStamp;
-  std::vector<FGPropertyNode_ptr> InputProperties;
+  std::vector<SGPropertyNode_ptr> InputProperties;
 };
 }
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -899,7 +899,7 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
 
       if (p && p->IsConstant()) {
         double constant = p->GetValue();
-        auto node = p->pNode;
+        SGPropertyNode_ptr node = p->pNode;
         string pName = p->GetName();
 
         Parameters.pop_back();

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -899,7 +899,7 @@ void FGFunction::Load(Element* el, FGPropertyValue* var, FGFDMExec* fdmex,
 
       if (p && p->IsConstant()) {
         double constant = p->GetValue();
-        FGPropertyNode_ptr node = p->pNode;
+        auto node = p->pNode;
         string pName = p->GetName();
 
         Parameters.pop_back();

--- a/src/math/FGFunction.h
+++ b/src/math/FGFunction.h
@@ -290,7 +290,7 @@ refers to one or more instances of a property, value, or table.
 - @b log2, calculates the log base 2 value of the immediate child element:
     @code
     <log2>
-      {property, value, table, or other function element} 
+      {property, value, table, or other function element}
     </log2>
 
     Example:
@@ -302,7 +302,7 @@ refers to one or more instances of a property, value, or table.
     <ln>
       {property, value, table, or other function element}
     </ln>
-    
+
     Example: ln(128)
 
     <ln> <v> 200 </v> </ln>
@@ -417,7 +417,7 @@ refers to one or more instances of a property, value, or table.
     <min>
       {properties, values, tables, or other function elements}
     </min>
-    
+
     Example: returns the lesser of velocity and 2500
 
     <min>
@@ -430,7 +430,7 @@ refers to one or more instances of a property, value, or table.
     <max>
       {properties, values, tables, or other function elements}
     </max>
-    
+
     Example: returns the greater of velocity and 15000
 
     <max>
@@ -441,7 +441,7 @@ refers to one or more instances of a property, value, or table.
 - @b avg returns the average value of all the immediate child elements
     @code
     <avg>
-      {properties, values, tables, or other function elements} 
+      {properties, values, tables, or other function elements}
     </avg>
 
     Example: returns the average of the four numbers below, evaluates to 0.50.
@@ -586,7 +586,7 @@ refers to one or more instances of a property, value, or table.
       <v> 10000.0 </v>
     </ge>
     @endcode
-- @b eq returns a 1 if the value of the first immediate child element is 
+- @b eq returns a 1 if the value of the first immediate child element is
         equal to the second immediate child element, returns 0
         otherwise
     @code
@@ -652,7 +652,7 @@ refers to one or more instances of a property, value, or table.
           element (e.g., returns 1 if supplied a 0)
     @code
     <not>
-      {property, value, table, or other function element} 
+      {property, value, table, or other function element}
     </not>
 
     Example: returns 0 if the value of the supplied flag is 1
@@ -700,7 +700,7 @@ refers to one or more instances of a property, value, or table.
      </switch>
      @endcode
 - @b random Returns a normal distributed random number.
-            The function, without parameters, returns a normal distributed 
+            The function, without parameters, returns a normal distributed
             random value with a distribution defined by the parameters
             mean = 0.0 and standard deviation (stddev) = 1.0
             The Mean of the distribution (its expected value, μ).
@@ -709,15 +709,15 @@ refers to one or more instances of a property, value, or table.
             representing the dispersion of values from the distribution mean.
             This shall be a positive value (σ>0).
     @code
-    <random/> 
+    <random/>
     <random seed="1234"/>
     <random seed="time_now"/>
     <random seed="time_now" mean="0.0" stddev="1.0"/>
     @endcode
 - @b urandom Returns a uniformly distributed random number.
-             The function, without parameters, returns a random value 
+             The function, without parameters, returns a random value
              between the minimum value -1.0 and the maximum value of 1.0
-             The two maximum and minimum values can be modified using the 
+             The two maximum and minimum values can be modified using the
              lower and upper parameters.
     @code
     <urandom/>
@@ -829,7 +829,7 @@ protected:
   double cachedValue;
   std::vector <FGParameter_ptr> Parameters;
   std::shared_ptr<FGPropertyManager> PropertyManager;
-  FGPropertyNode_ptr pNode;
+  SGPropertyNode_ptr pNode;
 
   void Load(Element* element, FGPropertyValue* var, FGFDMExec* fdmex,
             const std::string& prefix="");
@@ -841,7 +841,7 @@ protected:
 
 private:
   std::string Name;
-  FGPropertyNode_ptr pCopyTo; // Property node for CopyTo property string
+  SGPropertyNode_ptr pCopyTo; // Property node for CopyTo property string
 
   void Debug(int from);
 };

--- a/src/math/FGFunctionValue.h
+++ b/src/math/FGFunctionValue.h
@@ -58,7 +58,7 @@ class FGFunctionValue : public FGPropertyValue
 {
 public:
 
-  FGFunctionValue(FGPropertyNode* propNode, FGTemplateFunc_ptr f)
+  FGFunctionValue(SGPropertyNode* propNode, FGTemplateFunc_ptr f)
     :FGPropertyValue(propNode), function(f) {}
   FGFunctionValue(std::string propName, std::shared_ptr<FGPropertyManager> propertyManager,
                   FGTemplateFunc_ptr f, Element* el)

--- a/src/math/FGPropertyValue.cpp
+++ b/src/math/FGPropertyValue.cpp
@@ -61,7 +61,7 @@ FGPropertyValue::FGPropertyValue(const std::string& propName,
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-FGPropertyNode* FGPropertyValue::GetNode(void) const
+SGPropertyNode* FGPropertyValue::GetNode(void) const
 {
   if (PropertyNode) return PropertyNode;
 
@@ -102,7 +102,7 @@ void FGPropertyValue::SetValue(double value)
 std::string FGPropertyValue::GetName(void) const
 {
   if (PropertyNode)
-    return PropertyNode->GetName();
+    return PropertyNode->getNameString();
   else
     return PropertyName;
 }
@@ -125,7 +125,7 @@ std::string FGPropertyValue::GetNameWithSign(void) const
 std::string FGPropertyValue::GetFullyQualifiedName(void) const
 {
   if (PropertyNode)
-    return PropertyNode->GetFullyQualifiedName();
+    return JSBSim::GetFullyQualifiedName(PropertyNode);
   else
     return PropertyName;
 }
@@ -135,7 +135,7 @@ std::string FGPropertyValue::GetFullyQualifiedName(void) const
 std::string FGPropertyValue::GetPrintableName(void) const
 {
   if (PropertyNode)
-    return PropertyNode->GetPrintableName();
+    return JSBSim::GetPrintableName(PropertyNode);
   else
     return PropertyName;
 }

--- a/src/math/FGPropertyValue.h
+++ b/src/math/FGPropertyValue.h
@@ -63,7 +63,7 @@ class JSBSIM_API FGPropertyValue : public FGParameter
 {
 public:
 
-  explicit FGPropertyValue(FGPropertyNode* propNode)
+  explicit FGPropertyValue(SGPropertyNode* propNode)
     : PropertyManager(nullptr), PropertyNode(propNode), Sign(1.0) {}
   FGPropertyValue(const std::string& propName,
                   std::shared_ptr<FGPropertyManager> propertyManager, Element* el);
@@ -73,7 +73,7 @@ public:
     return PropertyNode && (!PropertyNode->isTied()
                          && !PropertyNode->getAttribute(SGPropertyNode::WRITE));
   }
-  void SetNode(FGPropertyNode* node) {PropertyNode = node;}
+  void SetNode(SGPropertyNode* node) {PropertyNode = node;}
   void SetValue(double value);
   bool IsLateBound(void) const { return PropertyNode == nullptr; }
 
@@ -83,11 +83,11 @@ public:
   virtual std::string GetPrintableName(void) const;
 
 protected:
-  FGPropertyNode* GetNode(void) const;
+  SGPropertyNode* GetNode(void) const;
 
 private:
   std::shared_ptr<FGPropertyManager> PropertyManager; // Property root used to do late binding.
-  mutable FGPropertyNode_ptr PropertyNode;
+  mutable SGPropertyNode_ptr PropertyNode;
   mutable Element_ptr XML_def;
   std::string PropertyName;
   double Sign;

--- a/src/math/FGTable.cpp
+++ b/src/math/FGTable.cpp
@@ -439,7 +439,7 @@ FGTable::~FGTable()
   // instance of FGTable after the destruction is completed.
   if (!Name.empty() && !internal) {
     string tmp = PropertyManager->mkPropertyName(Name, false);
-    FGPropertyNode* node = PropertyManager->GetNode(tmp);
+    auto node = PropertyManager->GetNode(tmp);
     if (node && node->isTied())
       PropertyManager->Untie(node);
   }
@@ -702,7 +702,7 @@ void FGTable::bind(Element* el, const string& Prefix)
     string tmp = PropertyManager->mkPropertyName(Name, false);
 
     if (PropertyManager->HasNode(tmp)) {
-      FGPropertyNode* _property = PropertyManager->GetNode(tmp);
+      auto _property = PropertyManager->GetNode(tmp);
       if (_property->isTied()) {
         cerr << el->ReadFrom()
              << "Property " << tmp << " has already been successfully bound (late)." << endl;

--- a/src/math/FGTable.cpp
+++ b/src/math/FGTable.cpp
@@ -439,7 +439,7 @@ FGTable::~FGTable()
   // instance of FGTable after the destruction is completed.
   if (!Name.empty() && !internal) {
     string tmp = PropertyManager->mkPropertyName(Name, false);
-    auto node = PropertyManager->GetNode(tmp);
+    SGPropertyNode* node = PropertyManager->GetNode(tmp);
     if (node && node->isTied())
       PropertyManager->Untie(node);
   }
@@ -702,7 +702,7 @@ void FGTable::bind(Element* el, const string& Prefix)
     string tmp = PropertyManager->mkPropertyName(Name, false);
 
     if (PropertyManager->HasNode(tmp)) {
-      auto _property = PropertyManager->GetNode(tmp);
+      SGPropertyNode* _property = PropertyManager->GetNode(tmp);
       if (_property->isTied()) {
         cerr << el->ReadFrom()
              << "Property " << tmp << " has already been successfully bound (late)." << endl;

--- a/src/math/FGTable.h
+++ b/src/math/FGTable.h
@@ -302,9 +302,9 @@ public:
   double operator()(unsigned int r, unsigned int c) const
   { return GetElement(r, c); }
 
-  void SetRowIndexProperty(FGPropertyNode *node)
+  void SetRowIndexProperty(SGPropertyNode *node)
   { lookupProperty[eRow] = new FGPropertyValue(node); }
-  void SetColumnIndexProperty(FGPropertyNode *node)
+  void SetColumnIndexProperty(SGPropertyNode *node)
   { lookupProperty[eColumn] = new FGPropertyValue(node); }
 
   unsigned int GetNumRows() const {return nRows;}

--- a/src/math/FGTemplateFunc.h
+++ b/src/math/FGTemplateFunc.h
@@ -59,7 +59,7 @@ public:
 
   FGTemplateFunc(FGFDMExec* fdmex, Element* element);
 
-  double GetValue(FGPropertyNode* node) {
+  double GetValue(SGPropertyNode* node) {
     var->SetNode(node);
     return FGFunction::GetValue();
   }

--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -141,7 +141,7 @@ double FGAtmosphere::ValidateTemperature(double t, const string& msg, bool quiet
 
 void FGAtmosphere::Calculate(double altitude)
 {
-  auto node = PropertyManager->GetNode();
+  SGPropertyNode* node = PropertyManager->GetNode();
   double t =0.0;
   if (!PropertyManager->HasNode("atmosphere/override/temperature"))
     t = GetTemperature(altitude);

--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -141,25 +141,25 @@ double FGAtmosphere::ValidateTemperature(double t, const string& msg, bool quiet
 
 void FGAtmosphere::Calculate(double altitude)
 {
-  FGPropertyNode* node = PropertyManager->GetNode();
+  auto node = PropertyManager->GetNode();
   double t =0.0;
   if (!PropertyManager->HasNode("atmosphere/override/temperature"))
     t = GetTemperature(altitude);
   else
-    t = node->GetDouble("atmosphere/override/temperature");
+    t = node->getDoubleValue("atmosphere/override/temperature");
   Temperature = ValidateTemperature(t, "", true);
 
   double p = 0.0;
   if (!PropertyManager->HasNode("atmosphere/override/pressure"))
     p = GetPressure(altitude);
   else
-    p = node->GetDouble("atmosphere/override/pressure");
+    p = node->getDoubleValue("atmosphere/override/pressure");
   Pressure = ValidatePressure(p, "", true);
 
   if (!PropertyManager->HasNode("atmosphere/override/density"))
     Density = Pressure/(Reng*Temperature);
   else
-    Density = node->GetDouble("atmosphere/override/density");
+    Density = node->getDoubleValue("atmosphere/override/density");
 
   Soundspeed  = sqrt(SHRatio*Reng*Temperature);
   PressureAltitude = CalculatePressureAltitude(Pressure, altitude);

--- a/src/models/FGExternalForce.cpp
+++ b/src/models/FGExternalForce.cpp
@@ -134,7 +134,7 @@ FGParameter* FGExternalForce::bind(Element *el, const string& magName,
     return new FGFunction(fdmex, function_element);
   } else {
     auto pm = fdmex->GetPropertyManager();
-    SGPropertyNode*node = pm->GetNode(magName, true);
+    SGPropertyNode* node = pm->GetNode(magName, true);
     return new FGPropertyValue(node);
   }
 }

--- a/src/models/FGExternalForce.cpp
+++ b/src/models/FGExternalForce.cpp
@@ -134,7 +134,7 @@ FGParameter* FGExternalForce::bind(Element *el, const string& magName,
     return new FGFunction(fdmex, function_element);
   } else {
     auto pm = fdmex->GetPropertyManager();
-    FGPropertyNode* node = pm->GetNode(magName, true);
+    auto node = pm->GetNode(magName, true);
     return new FGPropertyValue(node);
   }
 }

--- a/src/models/FGExternalForce.cpp
+++ b/src/models/FGExternalForce.cpp
@@ -134,7 +134,7 @@ FGParameter* FGExternalForce::bind(Element *el, const string& magName,
     return new FGFunction(fdmex, function_element);
   } else {
     auto pm = fdmex->GetPropertyManager();
-    auto node = pm->GetNode(magName, true);
+    SGPropertyNode*node = pm->GetNode(magName, true);
     return new FGPropertyValue(node);
   }
 }

--- a/src/models/FGExternalForce.h
+++ b/src/models/FGExternalForce.h
@@ -83,7 +83,7 @@ public:
   }
 
 private:
-  FGPropertyNode_ptr data[3];
+  SGPropertyNode_ptr data[3];
 };
 
 inline FGColumnVector3 operator*(double a, const FGPropertyVector3& v) {
@@ -123,7 +123,7 @@ CLASS DOCUMENTATION
 
       [<function> ... </function>]
 
-      <location unit="{IN | M}"> 
+      <location unit="{IN | M}">
         <x> {number} </x>
         <y> {number} </y>
         <z> {number} </z>

--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -514,7 +514,7 @@ bool FGFCS::Load(Element* document)
       ChannelRate = 1;
 
     if (sOnOffProperty.length() > 0) {
-      FGPropertyNode* OnOffPropertyNode = PropertyManager->GetNode(sOnOffProperty);
+      auto OnOffPropertyNode = PropertyManager->GetNode(sOnOffProperty);
       if (OnOffPropertyNode == nullptr) {
         XMLLogException err(FDMExec->GetLogger(), channel_element);
         err << LogFormat::BOLD << LogFormat::RED

--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -514,7 +514,7 @@ bool FGFCS::Load(Element* document)
       ChannelRate = 1;
 
     if (sOnOffProperty.length() > 0) {
-      auto OnOffPropertyNode = PropertyManager->GetNode(sOnOffProperty);
+      SGPropertyNode* OnOffPropertyNode = PropertyManager->GetNode(sOnOffProperty);
       if (OnOffPropertyNode == nullptr) {
         XMLLogException err(FDMExec->GetLogger(), channel_element);
         err << LogFormat::BOLD << LogFormat::RED

--- a/src/models/FGFCSChannel.h
+++ b/src/models/FGFCSChannel.h
@@ -73,7 +73,7 @@ class FGFCSChannel {
 public:
   /// Constructor
   FGFCSChannel(FGFCS* FCS, const std::string &name, int execRate,
-               FGPropertyNode* node=0)
+               SGPropertyNode* node=nullptr)
     : fcs(FCS), OnOffNode(node), Name(name)
   {
     ExecRate = execRate < 1 ? 1 : execRate;
@@ -142,7 +142,7 @@ public:
   private:
     FGFCS* fcs;
     FCSCompVec FCSComponents;
-    FGConstPropertyNode_ptr OnOffNode;
+    SGConstPropertyNode_ptr OnOffNode;
     std::string Name;
 
     int ExecRate;        // rate at which this system executes, 0 or 1 every frame, 2 every second frame etc..

--- a/src/models/FGGasCell.cpp
+++ b/src/models/FGGasCell.cpp
@@ -197,7 +197,7 @@ FGGasCell::FGGasCell(FGFDMExec* exec, Element* el, unsigned int num,
 
   property_name = base_property_name + "/max_volume-ft3";
   PropertyManager->Tie( property_name.c_str(), &MaxVolume);
-  PropertyManager->GetNode()->SetWritable( property_name, false );
+  PropertyManager->GetNode(property_name)->setAttribute( SGPropertyNode::WRITE, false );
   property_name = base_property_name + "/temp-R";
   PropertyManager->Tie( property_name.c_str(), &Temperature);
   property_name = base_property_name + "/pressure-psf";
@@ -629,7 +629,7 @@ FGBallonet::FGBallonet(FGFDMExec* exec, Element* el, unsigned int num,
 
   property_name = base_property_name + "/max_volume-ft3";
   PropertyManager->Tie( property_name, &MaxVolume);
-  PropertyManager->GetNode()->SetWritable( property_name, false );
+  PropertyManager->GetNode(property_name)->setAttribute( SGPropertyNode::WRITE, false );
 
   property_name = base_property_name + "/temp-R";
   PropertyManager->Tie( property_name, &Temperature);

--- a/src/models/FGOutput.cpp
+++ b/src/models/FGOutput.cpp
@@ -194,7 +194,7 @@ bool FGOutput::SetDirectivesFile(const SGPath& fname)
 
 bool FGOutput::Load(int subSystems, std::string protocol, std::string type,
                     std::string port, std::string name, double outRate,
-                    std::vector<FGPropertyNode_ptr> & outputProperties)
+                    std::vector<SGPropertyNode_ptr> & outputProperties)
 {
   size_t idx = OutputTypes.size();
   FGOutputType* Output = 0;

--- a/src/models/FGOutput.h
+++ b/src/models/FGOutput.h
@@ -210,7 +210,7 @@ public:
       @result true if the execution succeeded. */
   bool Load(int subSystems, std::string protocol, std::string type,
             std::string port, std::string name, double outRate,
-            std::vector<FGPropertyNode_ptr> & outputProperties);
+            std::vector<SGPropertyNode_ptr> & outputProperties);
   /** Get the name identifier to which the output will be directed.
       @param idx ID of the output instance from which the name identifier must
                  be obtained

--- a/src/models/flight_control/FGActuator.cpp
+++ b/src/models/flight_control/FGActuator.cpp
@@ -343,7 +343,7 @@ void FGActuator::Debug(int from)
 
       if (!OutputNodes.empty()) {
         for (auto node: OutputNodes)
-          log << "      OUTPUT: " << node->GetName() << "\n";
+          log << "      OUTPUT: " << node->getNameString() << "\n";
       }
       if (bias != 0.0) log << "      Bias: " << bias << "\n";
       if (rate_limit_incr != 0) {

--- a/src/models/flight_control/FGAngles.h
+++ b/src/models/flight_control/FGAngles.h
@@ -83,8 +83,8 @@ public:
   bool Run(void) override;
 
 private:
-  FGPropertyNode_ptr target_angle_pNode;
-  FGPropertyNode_ptr source_angle_pNode;
+  SGPropertyNode_ptr target_angle_pNode;
+  SGPropertyNode_ptr source_angle_pNode;
   double target_angle;
   double source_angle;
   double target_angle_unit;

--- a/src/models/flight_control/FGFCSComponent.cpp
+++ b/src/models/flight_control/FGFCSComponent.cpp
@@ -130,7 +130,7 @@ FGFCSComponent::FGFCSComponent(FGFCS* _fcs, Element* element) : fcs(_fcs)
   while (out_elem) {
     string output_node_name = out_elem->GetDataLine();
     bool node_exists = PropertyManager->HasNode(output_node_name);
-    FGPropertyNode* OutputNode = PropertyManager->GetNode( output_node_name, true );
+    auto OutputNode = PropertyManager->GetNode( output_node_name, true );
     if (!OutputNode) {
       XMLLogException err(fcs->GetExec()->GetLogger(), out_elem);
       err << "  Unable to process property: " << output_node_name << "\n";
@@ -309,7 +309,7 @@ void FGFCSComponent::bind(Element* el, FGPropertyManager* PropertyManager)
     tmp = Name;
 
   bool node_exists = PropertyManager->HasNode(tmp);
-  FGPropertyNode* node = PropertyManager->GetNode(tmp, true);
+  auto node = PropertyManager->GetNode(tmp, true);
 
   if (node) {
     OutputNodes.push_back(node);

--- a/src/models/flight_control/FGFCSComponent.cpp
+++ b/src/models/flight_control/FGFCSComponent.cpp
@@ -130,7 +130,7 @@ FGFCSComponent::FGFCSComponent(FGFCS* _fcs, Element* element) : fcs(_fcs)
   while (out_elem) {
     string output_node_name = out_elem->GetDataLine();
     bool node_exists = PropertyManager->HasNode(output_node_name);
-    auto OutputNode = PropertyManager->GetNode( output_node_name, true );
+    SGPropertyNode* OutputNode = PropertyManager->GetNode( output_node_name, true );
     if (!OutputNode) {
       XMLLogException err(fcs->GetExec()->GetLogger(), out_elem);
       err << "  Unable to process property: " << output_node_name << "\n";
@@ -309,7 +309,7 @@ void FGFCSComponent::bind(Element* el, FGPropertyManager* PropertyManager)
     tmp = Name;
 
   bool node_exists = PropertyManager->HasNode(tmp);
-  auto node = PropertyManager->GetNode(tmp, true);
+  SGPropertyNode* node = PropertyManager->GetNode(tmp, true);
 
   if (node) {
     OutputNodes.push_back(node);

--- a/src/models/flight_control/FGFCSComponent.h
+++ b/src/models/flight_control/FGFCSComponent.h
@@ -99,7 +99,7 @@ public:
 
 protected:
   FGFCS* fcs;
-  std::vector <FGPropertyNode_ptr> OutputNodes;
+  std::vector <SGPropertyNode_ptr> OutputNodes;
   FGParameter_ptr ClipMin, ClipMax;
   std::vector <FGPropertyValue_ptr> InitNodes;
   std::vector <FGPropertyValue_ptr> InputNodes;

--- a/src/models/flight_control/FGLinearActuator.cpp
+++ b/src/models/flight_control/FGLinearActuator.cpp
@@ -261,7 +261,7 @@ void FGLinearActuator::Debug(int from)
       log << "        set: " << set << "\n";
       log << "      reset: " << reset << "\n";
       for (auto node: OutputNodes)
-        log << "     OUTPUT: " << node->GetName() << "\n";
+        log << "     OUTPUT: " << node->getNameString() << "\n";
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification

--- a/src/models/flight_control/FGSensor.cpp
+++ b/src/models/flight_control/FGSensor.cpp
@@ -270,7 +270,7 @@ void FGSensor::bind(Element* el, FGPropertyManager* PropertyManager)
   if (!quant_property.empty()) {
     if (quant_property.find("/") == string::npos) { // not found
       string qprop = "fcs/" + PropertyManager->mkPropertyName(quant_property, true);
-      FGPropertyNode* node = PropertyManager->GetNode(qprop, true);
+      auto node = PropertyManager->GetNode(qprop, true);
       if (node->isTied()) {
         XMLLogException err(fcs->GetExec()->GetLogger(), el);
         err << "Property " << tmp << " has already been successfully bound (late).\n";

--- a/src/models/flight_control/FGSensor.cpp
+++ b/src/models/flight_control/FGSensor.cpp
@@ -270,7 +270,7 @@ void FGSensor::bind(Element* el, FGPropertyManager* PropertyManager)
   if (!quant_property.empty()) {
     if (quant_property.find("/") == string::npos) { // not found
       string qprop = "fcs/" + PropertyManager->mkPropertyName(quant_property, true);
-      auto node = PropertyManager->GetNode(qprop, true);
+      SGPropertyNode* node = PropertyManager->GetNode(qprop, true);
       if (node->isTied()) {
         XMLLogException err(fcs->GetExec()->GetLogger(), el);
         err << "Property " << tmp << " has already been successfully bound (late).\n";

--- a/src/models/flight_control/FGSummer.cpp
+++ b/src/models/flight_control/FGSummer.cpp
@@ -116,7 +116,7 @@ void FGSummer::Debug(int from)
         log << "       " << node->GetNameWithSign() << "\n";
       if (Bias != 0.0) log << "       Bias: " << Bias << "\n";
       for (auto node: OutputNodes)
-        log << "      OUTPUT: " << node->GetName() << "\n";
+        log << "      OUTPUT: " << node->getNameString() << "\n";
     }
   }
   if (debug_lvl & 2 ) { // Instantiation/Destruction notification

--- a/src/models/propulsion/FGRotor.h
+++ b/src/models/propulsion/FGRotor.h
@@ -149,7 +149,7 @@ CLASS DOCUMENTATION
            <tt>propulsion/engine[x]/collective-ctrl-rad</tt>. See below for tail rotor</li>
       <li> The lateral cyclic input. Read from
            <tt>propulsion/engine[x]/lateral-ctrl-rad</tt>.</li>
-      <li> The longitudinal cyclic input. Read from 
+      <li> The longitudinal cyclic input. Read from
            <tt>propulsion/engine[x]/longitudinal-ctrl-rad</tt>.</li>
       <li> The tail rotor collective (aka antitorque, aka pedal) control input. Read from
            <tt>propulsion/engine[x]/antitorque-ctrl-rad</tt> or
@@ -165,7 +165,7 @@ CLASS DOCUMENTATION
     collective input from <tt>propulsion/engine[1]/antitorque-ctrl-rad</tt>
     (The TAIL-map ignores lateral and longitudinal input). The rotor needs to be
     attached to a dummy engine, e.g. an 1HP electrical engine.
-    A tandem rotor is setup analogous. 
+    A tandem rotor is setup analogous.
 
   <h4>- Sense -</h4>
 
@@ -205,11 +205,11 @@ CLASS DOCUMENTATION
     Setting <tt>\<ExternalRPM> -1 \</ExternalRPM></tt> the rotor's RPM is controlled  by
     the <tt>propulsion/engine[x]/x-rpm-dict</tt> property. This feature can be useful
     when developing a FDM.
-  
+
 
 <h3>References:</h3>
 
-    <dl>    
+    <dl>
     <dt>/SH79/</dt><dd>Shaugnessy, J. D., Deaux, Thomas N., and Yenni, Kenneth R.,
               "Development and Validation of a Piloted Simulation of a
               Helicopter and External Sling Load",  NASA TP-1285, 1979.</dd>
@@ -219,7 +219,7 @@ CLASS DOCUMENTATION
               Comparison With Flight Measurements", NACA TN-2136, 1950.</dd>
     <dt>/TA77/</dt><dd>Talbot, Peter D., Corliss, Lloyd D., "A Mathematical Force and Moment
               Model of a UH-1H Helicopter for Flight Dynamics Simulations", NASA TM-73,254, 1977.</dd>
-    <dt>/GE49/</dt><dd>Gessow, Alfred, Amer, Kenneth B. "An Introduction to the Physical 
+    <dt>/GE49/</dt><dd>Gessow, Alfred, Amer, Kenneth B. "An Introduction to the Physical
               Aspects of Helicopter Stability", NACA TN-1982, 1949.</dd>
     </dl>
 
@@ -257,7 +257,7 @@ public:
   /// Retrieves the RPMs of the rotor.
   double GetRPM(void) const { return RPM; }
   void   SetRPM(double rpm) { RPM = rpm; }
-  
+
   /// Retrieves the RPMs of the Engine, as seen from this rotor.
   double GetEngineRPM(void) const {return EngineRPM;} //{ return GearRatio*RPM; }
   void SetEngineRPM(double rpm) {EngineRPM = rpm;} //{ RPM = rpm/GearRatio; }
@@ -266,7 +266,7 @@ public:
   /// Retrieves the thrust of the rotor.
   double GetThrust(void) const { return Thrust; }
 
-  /// Retrieves the rotor's coning angle 
+  /// Retrieves the rotor's coning angle
   double GetA0(void) const { return a0; }
   /// Retrieves the longitudinal flapping angle with respect to the rotor shaft
   double GetA1(void) const { return a1s; }
@@ -285,7 +285,7 @@ public:
   double GetCT(void) const { return C_T; }
   /// Retrieves the torque
   double GetTorque(void) const { return Torque; }
-  
+
   /// Downwash angle - positive values point forward (given a horizontal spinning rotor)
   double GetThetaDW(void) const { return theta_downwash; }
   /// Downwash angle - positive values point leftward (given a horizontal spinning rotor)
@@ -317,7 +317,7 @@ public:
 private:
 
   // assist in parameter retrieval
-  double ConfigValueConv( Element* e, const std::string& ename, double default_val=0.0, 
+  double ConfigValueConv( Element* e, const std::string& ename, double default_val=0.0,
                                       const std::string& unit = "", bool tell=false);
 
   double ConfigValue( Element* e, const std::string& ename, double default_val=0.0,
@@ -336,7 +336,7 @@ private:
   void calc_downwash_angles();
 
   // transformations
-  FGColumnVector3 hub_vel_body2ca( const FGColumnVector3 &uvw, const FGColumnVector3 &pqr, 
+  FGColumnVector3 hub_vel_body2ca( const FGColumnVector3 &uvw, const FGColumnVector3 &pqr,
                                    double a_ic = 0.0 , double b_ic = 0.0 );
   FGColumnVector3 fus_angvel_body2ca( const FGColumnVector3 &pqr);
   FGColumnVector3 body_forces(double a_ic = 0.0 , double b_ic = 0.0 );
@@ -362,7 +362,7 @@ private:
   double MaximalRPM;
   int    ExternalRPM;
   int    RPMdefinition;
-  FGPropertyNode_ptr ExtRPMsource;
+  SGPropertyNode_ptr ExtRPMsource;
   double SourceGearRatio;
 
   // 'real' rotor parameters
@@ -396,7 +396,7 @@ private:
 
   // dynamic values
   double RPM;
-  double Omega;          // must be > 0 
+  double Omega;          // must be > 0
   double beta_orient;    // rotor orientation angle (rad)
   double a0;             // coning angle (rad)
   double a_1, b_1, a_dw; // flapping angles
@@ -406,7 +406,7 @@ private:
   double Torque;
   double C_T;        // rotor thrust coefficient
   double lambda;     // inflow ratio
-  double mu;         // tip-speed ratio 
+  double mu;         // tip-speed ratio
   double nu;         // induced inflow ratio
   double v_induced;  // induced velocity, usually positive [ft/s]
 

--- a/tests/unit_tests/FGPropertyManagerTest.h
+++ b/tests/unit_tests/FGPropertyManagerTest.h
@@ -13,7 +13,7 @@ public:
     auto pm = std::make_shared<FGPropertyManager>();
     auto root = pm->GetNode();
 
-    TS_ASSERT_EQUALS(root->GetName(), "");
-    TS_ASSERT_EQUALS(root->GetFullyQualifiedName(), "/");
+    TS_ASSERT_EQUALS(root->getNameString(), "");
+    TS_ASSERT_EQUALS(GetFullyQualifiedName(root), "/");
   }
 };

--- a/tests/unit_tests/FGPropertyValueTest.h
+++ b/tests/unit_tests/FGPropertyValueTest.h
@@ -8,7 +8,7 @@ class FGPropertyValueTest : public CxxTest::TestSuite
 public:
   void testConstructorFromNode() {
     SGPropertyNode root;
-    auto node = root.getNode("x", true);
+    SGPropertyNode_ptr node = root.getNode("x", true);
     FGPropertyValue property(node);
 
     TS_ASSERT_EQUALS(property.GetValue(), 0.0);
@@ -22,7 +22,7 @@ public:
 
   void testSetValue() {
     SGPropertyNode root;
-    auto node = root.getNode("x", true);
+    SGPropertyNode_ptr node = root.getNode("x", true);
     FGPropertyValue property(node);
 
     TS_ASSERT_EQUALS(node->getDoubleValue(), 0.0);
@@ -33,8 +33,8 @@ public:
 
   void testSetNode() {
     SGPropertyNode root;
-    auto node_x = root.getNode("x", true);
-    auto node_y = root.getNode("y", true);
+    SGPropertyNode_ptr node_x = root.getNode("x", true);
+    SGPropertyNode_ptr node_y = root.getNode("y", true);
     FGPropertyValue property(node_x);
 
     node_y->setDoubleValue(-1.547);
@@ -47,7 +47,7 @@ public:
 
   void testConstant_ness() {
     auto pm = std::make_shared<FGPropertyManager>();
-    auto node = pm->GetNode("x", true);
+    SGPropertyNode_ptr node = pm->GetNode("x", true);
     FGPropertyValue property(node);
 
     TS_ASSERT(!property.IsConstant());
@@ -60,7 +60,7 @@ public:
     // property is set to READ ONLY.
     auto pm = std::make_shared<FGPropertyManager>();
     double value = 0.0;
-    auto node = pm->GetNode("x", true);
+    SGPropertyNode_ptr node = pm->GetNode("x", true);
     FGPropertyValue property(node);
 
     node->setAttribute(SGPropertyNode::WRITE, false);

--- a/tests/unit_tests/FGPropertyValueTest.h
+++ b/tests/unit_tests/FGPropertyValueTest.h
@@ -7,8 +7,8 @@ class FGPropertyValueTest : public CxxTest::TestSuite
 {
 public:
   void testConstructorFromNode() {
-    FGPropertyNode root;
-    FGPropertyNode_ptr node = root.GetNode("x", true);
+    SGPropertyNode root;
+    auto node = root.getNode("x", true);
     FGPropertyValue property(node);
 
     TS_ASSERT_EQUALS(property.GetValue(), 0.0);
@@ -21,8 +21,8 @@ public:
   }
 
   void testSetValue() {
-    FGPropertyNode root;
-    FGPropertyNode_ptr node = root.GetNode("x", true);
+    SGPropertyNode root;
+    auto node = root.getNode("x", true);
     FGPropertyValue property(node);
 
     TS_ASSERT_EQUALS(node->getDoubleValue(), 0.0);
@@ -32,9 +32,9 @@ public:
   }
 
   void testSetNode() {
-    FGPropertyNode root;
-    FGPropertyNode_ptr node_x = root.GetNode("x", true);
-    FGPropertyNode_ptr node_y = root.GetNode("y", true);
+    SGPropertyNode root;
+    auto node_x = root.getNode("x", true);
+    auto node_y = root.getNode("y", true);
     FGPropertyValue property(node_x);
 
     node_y->setDoubleValue(-1.547);
@@ -47,7 +47,7 @@ public:
 
   void testConstant_ness() {
     auto pm = std::make_shared<FGPropertyManager>();
-    FGPropertyNode_ptr node = pm->GetNode("x", true);
+    auto node = pm->GetNode("x", true);
     FGPropertyValue property(node);
 
     TS_ASSERT(!property.IsConstant());
@@ -60,7 +60,7 @@ public:
     // property is set to READ ONLY.
     auto pm = std::make_shared<FGPropertyManager>();
     double value = 0.0;
-    FGPropertyNode_ptr node = pm->GetNode("x", true);
+    auto node = pm->GetNode("x", true);
     FGPropertyValue property(node);
 
     node->setAttribute(SGPropertyNode::WRITE, false);


### PR DESCRIPTION
As per the issue reported in https://github.com/JSBSim-Team/jsbsim/issues/834#issuecomment-2774035954 and the discussion that followed, this PR removes the class `FGPropertyNode` from JSBSim.

Direct calls to `SGPropertyNode` allow to avoid the dubious conversion from `SGPropertyNode*` to `FGPropertyNode*` in methods such as the one below:
https://github.com/JSBSim-Team/jsbsim/blob/e1ea4e85524e209037ec868f5a1383ec2ef3c7a1/src/input_output/FGPropertyManager.cpp#L109-L117

Note that this PR does not remove `FGPropertyNode` from the Python module which keeps its methods unchanged including `FGPropertyNode.get_fully_qualified_name()`. Not sure if renaming it to `SGPropertyNode` and making `get_fully_qualified_name()` a function is a better option ?