### PR TITLE
Maintenance / Minor changes

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -104,12 +104,10 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   EnginePath = "engine";
   SystemsPath = "systems";
 
-  try {
-    char* num = getenv("JSBSIM_DEBUG");
-    if (num) debug_lvl = atoi(num); // set debug level
-  } catch (...) {                   // if error set to 1
+  if (const char* num = getenv("JSBSIM_DEBUG"); num != nullptr)
+    debug_lvl = strtol(num, nullptr, 0);
+  else
     debug_lvl = 1;
-  }
 
   if (!FDMctr) {
     FDMctr = std::make_shared<unsigned int>(); // Create and initialize the child FDM counter
@@ -130,15 +128,10 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   SGPropertyNode* instanceRoot = Root->getNode("fdm/jsbsim", IdFDM, true);
   instance = std::make_shared<FGPropertyManager>(instanceRoot);
 
-  try {
-    char* num = getenv("JSBSIM_DISPERSE");
-    if (num) {
-      if (atoi(num) != 0) disperse = 1;  // set dispersions on
-    }
-  } catch (...) {                        // if error set to false
-    disperse = 0;
-    FGLogging log(Log, LogLevel::WARN);
-    log << "Could not process JSBSIM_DISPERSIONS environment variable: Assumed NO dispersions." << endl;
+  if (const char* num = getenv("JSBSIM_DISPERSE");
+      num != nullptr && strtol(num, nullptr, 0) != 0)
+  {
+    disperse = 1;  // set dispersions on
   }
 
   Debug(0);

--- a/src/input_output/FGLog.cpp
+++ b/src/input_output/FGLog.cpp
@@ -172,16 +172,16 @@ void FGLogConsole::Flush(void) {
   case LogLevel::BULK:
   case LogLevel::DEBUG:
   case LogLevel::INFO:
-    std::cout << buffer.str();
+    std::cout << buffer;
     std::cout.flush(); // Force the message to be immediately displayed in the console
     break;
   default:
-    std::cerr << buffer.str();
+    std::cerr << buffer;
     std::cerr.flush(); // Force the message to be immediately displayed in the console
     break;
   }
 
-  buffer.str("");
+  buffer.clear();
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -190,29 +190,29 @@ void FGLogConsole::Format(LogFormat format) {
   switch (format)
   {
   case LogFormat::RED:
-    buffer << FGJSBBase::fgred;
+    buffer.append(FGJSBBase::fgred);
     break;
   case LogFormat::BLUE:
-    buffer << FGJSBBase::fgblue;
+    buffer.append(FGJSBBase::fgblue);
     break;
   case LogFormat::BOLD:
-    buffer << FGJSBBase::highint;
+    buffer.append(FGJSBBase::highint);
     break;
   case LogFormat::NORMAL:
-    buffer << FGJSBBase::normint;
+    buffer.append(FGJSBBase::normint);
     break;
   case LogFormat::UNDERLINE_ON:
-    buffer << FGJSBBase::underon;
+    buffer.append(FGJSBBase::underon);
     break;
   case LogFormat::UNDERLINE_OFF:
-    buffer << FGJSBBase::underoff;
+    buffer.append(FGJSBBase::underoff);
     break;
   case LogFormat::DEFAULT:
-    buffer << FGJSBBase::fgdef;
+    buffer.append(FGJSBBase::fgdef);
     break;
   case LogFormat::RESET:
   default:
-    buffer << FGJSBBase::reset;
+    buffer.append(FGJSBBase::reset);
     break;
   }
 }

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -149,17 +149,17 @@ class JSBSIM_API FGLogConsole : public FGLogger
 public:
   void SetMinLevel(LogLevel level) { min_level = level; }
   void FileLocation(const std::string& filename, int line) override
-  { buffer << "\nIn file " << filename << ": line " << line << "\n"; }
+  { buffer.append("\nIn file " + filename + ": line " + std::to_string(line) + "\n"); }
   void Format(LogFormat format) override;
   void Flush(void) override;
 
   void Message(const std::string& message) override {
     if (log_level < min_level) return;
-    buffer << message;
+    buffer.append(message);
   }
 
 private:
-  std::ostringstream buffer;
+  std::string buffer;
   LogLevel min_level = LogLevel::BULK;
 };
 

--- a/src/input_output/FGXMLElement.cpp
+++ b/src/input_output/FGXMLElement.cpp
@@ -657,17 +657,10 @@ double Element::DisperseValue(Element *e, double val, const std::string& supplie
                               const std::string& target_units)
 {
   double value=val;
-
   bool disperse = false;
-  try {
-    char* num = getenv("JSBSIM_DISPERSE");
-    if (num) {
-      disperse = (atoi(num) == 1);  // set dispersions
-    }
-  } catch (...) {                   // if error set to false
-    disperse = false;
-    std::cerr << "Could not process JSBSIM_DISPERSE environment variable: Assumed NO dispersions." << endl;
-  }
+
+  if(char* num = getenv("JSBSIM_DISPERSE"); num != nullptr)
+    disperse = strtol(num, nullptr, 0) == 1;  // set dispersions
 
   if (e->HasAttribute("dispersion") && disperse) {
     double disp = e->GetAttributeValueAsNumber("dispersion");

--- a/src/models/atmosphere/FGStandardAtmosphere.cpp
+++ b/src/models/atmosphere/FGStandardAtmosphere.cpp
@@ -69,7 +69,7 @@ FGStandardAtmosphere::FGStandardAtmosphere(FGFDMExec* fdmex)
 
   // This is the U.S. Standard Atmosphere table for temperature in degrees
   // Rankine, based on geometric altitude. The table values are often given
-  // in literature relative to geopotential altitude. 
+  // in literature relative to geopotential altitude.
   //
   //                        GeoMet Alt    Temp      GeoPot Alt  GeoMet Alt
   //                           (ft)      (deg R)      (km)        (km)
@@ -82,7 +82,7 @@ FGStandardAtmosphere::FGStandardAtmosphere(FGFDMExec* fdmex)
   //                         << 168676.12 << 487.20  //   51.000      51.413
   //                         << 235570.77 << 386.40  //   71.000      71.802
   //                         << 282152.08 << 336.50  //   84.852      86.000
-  //                         << 298556.40 << 336.50; //               91.000 - First layer in high altitude regime 
+  //                         << 298556.40 << 336.50; //               91.000 - First layer in high altitude regime
 
   //                            GeoPot Alt    Temp       GeoPot Alt  GeoMet Alt
   //                               (ft)      (deg R)        (km)        (km)
@@ -452,9 +452,9 @@ void FGStandardAtmosphere::SetTemperatureGradedDelta(double deltemp, double h, e
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 // This function calculates (or recalculates) the lapse rate over an altitude range
-// where the "bh" in this case refers to the index of the base height in the 
-// StdAtmosTemperatureTable table. This function should be called anytime the 
-// temperature table is altered, such as when a gradient is applied across the 
+// where the "bh" in this case refers to the index of the base height in the
+// StdAtmosTemperatureTable table. This function should be called anytime the
+// temperature table is altered, such as when a gradient is applied across the
 // temperature table for a range of altitudes.
 
 void FGStandardAtmosphere::CalculateLapseRates()
@@ -484,7 +484,7 @@ void FGStandardAtmosphere::CalculatePressureBreakpoints(double SLpress)
     double UpperAlt = StdAtmosTemperatureTable(b+2,0);
     double deltaH = UpperAlt - BaseAlt;
     double Tmb = BaseTemp
-                 + TemperatureBias 
+                 + TemperatureBias
                  + (GradientFadeoutAltitude - BaseAlt)*TemperatureDeltaGradient;
     if (LapseRates[b] != 0.00) {
       double Lmb = LapseRates[b];
@@ -623,7 +623,7 @@ void FGStandardAtmosphere::ValidateVaporMassFraction(double h)
 void FGStandardAtmosphere::SetDewPoint(eTemperature unit, double dewpoint)
 {
   double dewPoint_R = ConvertToRankine(dewpoint, unit);
-  constexpr double minDewPoint = -CelsiusToRankine(c) + 1.0;
+  constexpr double minDewPoint = CelsiusToRankine(-c) + 1.0;
 
   if (dewPoint_R <= minDewPoint) {
     FGLogging log(FDMExec->GetLogger(), LogLevel::WARN);
@@ -817,7 +817,7 @@ void FGStandardAtmosphere::Debug(int from)
   }
   if (debug_lvl & 16) { // Sanity checking
   }
-  if (debug_lvl & 128) { // 
+  if (debug_lvl & 128) { //
   }
   if (debug_lvl & 64) {
     if (from == 0) { // Constructor


### PR DESCRIPTION
This PR brings a number of minor changes and fixes:
* Fix the computation of the constant `minDewPoint` in `FGStandardAtmosphere` where the minus sign in the formula was misplaced.
* Remove the exception handlers around `getenv` because [`getenv` has a no throw guarantee](https://cplusplus.com/reference/cstdlib/getenv).
* Use `std::string` for the buffer of  `FGLogConsole`. We do not need all the features of `std::ostringstream`