### PR TITLE
Improvements to the Python module

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,5 +1,6 @@
 from ._jsbsim import (
     __version__,
+    Attribute,
     BaseError,
     FGAerodynamics,
     FGAircraft,

--- a/python/jsbsim.pxd
+++ b/python/jsbsim.pxd
@@ -107,6 +107,7 @@ cdef extern from "models/FGAerodynamics.h" namespace "JSBSim":
 cdef extern from "models/FGAircraft.h" namespace "JSBSim":
     cdef cppclass c_FGAircraft "JSBSim::FGAircraft":
         c_FGAircraft(c_FGFDMExec* fdmex) except +
+        const string GetAircraftName() const
         c_FGColumnVector3& GetXYZrp()
 
 cdef extern from "models/FGAtmosphere.h" namespace "JSBSim":

--- a/python/jsbsim.pxd
+++ b/python/jsbsim.pxd
@@ -71,11 +71,18 @@ cdef extern from "simgear/structure/SGSharedPtr.hxx":
         T* ptr() const
 
 cdef extern from "simgear/props/props.hxx" namespace "JSBSim":
+    cdef enum c_Attribute "SGPropertyNode::Attribute":
+        NO_ATTR = 0,
+        READ = 1,
+        WRITE = 2
+
     cdef cppclass c_SGPropertyNode "SGPropertyNode":
         c_SGPropertyNode* getNode(const string& path, bool create)
         const string& getNameString() const
         double getDoubleValue() const
         bool setDoubleValue(double value)
+        bool getAttribute(c_Attribute attr) const
+        void setAttribute(c_Attribute attr, bool state)
 
 cdef extern from "input_output/FGPropertyManager.h" namespace "JSBSim":
     cdef string GetFullyQualifiedName(const c_SGPropertyNode* node)

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -159,6 +159,10 @@ cdef class FGPropertyNode:
                 raise MemoryError()
             return None
 
+    def __eq__(self, other:FGPropertyNode) -> bool:
+        """Check if the 2 nodes are pointing to the same property."""
+        return self.thisptr.ptr() == other.thisptr.ptr()
+
     def get_name(self) -> str:
         """Get the node's simple name as a string."""
         self.__intercept_invalid_pointer()

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -126,8 +126,14 @@ cdef class FGPropagate:
         return _convertToNumpyVec(deref(self.thisptr).GetUVW())
 
 
+class Attribute(enum.Enum):
+    NO_ATTR = 0
+    READ = 1
+    WRITE = 2
+
+
 cdef class FGPropertyNode:
-    """@Dox(JSBSim::SGPropertyNode)"""
+    """@Dox(SGPropertyNode)"""
 
     cdef SGSharedPtr[c_SGPropertyNode] thisptr
 
@@ -154,7 +160,7 @@ cdef class FGPropertyNode:
             return None
 
     def get_name(self) -> str:
-        """Get the name of a node."""
+        """Get the node's simple name as a string."""
         self.__intercept_invalid_pointer()
         return self.thisptr.ptr().getNameString().decode()
 
@@ -166,11 +172,11 @@ cdef class FGPropertyNode:
         return GetFullyQualifiedName(self.thisptr.ptr()).decode()
 
     def get_node(self, path: str, create: bool = False) -> Optional[SGPropertyNode]:
-        """Get a property node.
+        """Get a pointer to another node by relative path.
 
-           :param path: The path of the node, relative to root.
+           :param path: The relative path from the node.
            :param create: True to create the node if it doesn't exist.
-           :return: The node, or None if none exists and none was created."""
+           :return: The node, or None if it does not exist."""
         self.__intercept_invalid_pointer()
         node = FGPropertyNode()
         node.thisptr = self.thisptr.ptr().getNode(path.encode(), create)
@@ -190,6 +196,17 @@ cdef class FGPropertyNode:
            :return: True if the assignment succeeded, False otherwise."""
         self.__intercept_invalid_pointer()
         return self.thisptr.ptr().setDoubleValue(value)
+
+    def get_attribute(self, attr: Attribute) -> bool:
+        """Check a single mode attribute for the property node."""
+        self.__intercept_invalid_pointer()
+        return self.thisptr.ptr().getAttribute(attr.value)
+
+    def set_attribute(self, attr: Attribute, state: bool) -> None:
+        """Set a single mode attribute for the property node."""
+        self.__intercept_invalid_pointer()
+        self.thisptr.ptr().setAttribute(attr.value ,state)
+
 
 cdef class FGPropertyManager:
     """@Dox(JSBSim::FGPropertyManager)"""

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -381,6 +381,11 @@ cdef class FGAircraft:
         if not self.thisptr:
             raise BaseError("Object is not initialized")
 
+    def get_aircraft_name(self) -> str:
+        """@Dox(JSBSim::FGAircraft::GetAircraftName)"""
+        self.__intercept_invalid_pointer()
+        return deref(self.thisptr).GetAircraftName().decode('utf-8')
+
     def get_xyz_rp(self) -> numpy.ndarray:
         """@Dox(JSBSim::FGAircraft::GetXYZrp)"""
         self.__intercept_invalid_pointer()

--- a/tests/CheckAircrafts.py
+++ b/tests/CheckAircrafts.py
@@ -56,4 +56,11 @@ class CheckAircrafts(JSBSimTestCase):
                     except RuntimeError:
                         self.fail('Failed to run IC %s for aircraft %s' % (f, d))
 
+    def test_aircraft_name(self):
+        fdm = self.create_fdm()
+        fdm.load_model('c172x')
+        aircraft = fdm.get_aircraft()
+        self.assertEqual(aircraft.get_aircraft_name(), "Cessna C-172 Skyhawk II")
+
+
 RunTest(CheckAircrafts)

--- a/tests/TestMiscellaneous.py
+++ b/tests/TestMiscellaneous.py
@@ -335,5 +335,12 @@ class TestMiscellaneous(JSBSimTestCase):
         self.assertTrue(root_node.get_attribute(jsbsim.Attribute.READ))
         self.assertTrue(root_node.get_attribute(jsbsim.Attribute.WRITE))
 
+    def test_property_node_equality(self):
+        pm = jsbsim.FGPropertyManager()
+        root_node = pm.get_node("root", True)
+        root_node2 = pm.get_node("root", False)
+        self.assertIsNot(root_node, root_node2)  # The nodes are 2 different Python objects
+        self.assertEqual(root_node, root_node2)  # but they are pointing to the same property node.
+
 
 RunTest(TestMiscellaneous)

--- a/tests/TestMiscellaneous.py
+++ b/tests/TestMiscellaneous.py
@@ -297,5 +297,43 @@ class TestMiscellaneous(JSBSimTestCase):
             fdm_c172.run()
             self.assertEqual(fdm_S23["simulation/sim-time-sec"], 0.0)
 
+    def test_get_set_attributes(self):
+        pm = jsbsim.FGPropertyManager()
+        root_node = pm.get_node("root", True)
+        # Check default values
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.NO_ATTR))
+        self.assertTrue(root_node.get_attribute(jsbsim.Attribute.READ))
+        self.assertTrue(root_node.get_attribute(jsbsim.Attribute.WRITE))
+        # Check that set No_ATTR is a no op.
+        root_node.set_attribute(jsbsim.Attribute.NO_ATTR, True)
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.NO_ATTR))
+        self.assertTrue(root_node.get_attribute(jsbsim.Attribute.READ))
+        self.assertTrue(root_node.get_attribute(jsbsim.Attribute.WRITE))
+        #Check READ unset
+        root_node.set_attribute(jsbsim.Attribute.READ, False)
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.NO_ATTR))
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.READ))
+        self.assertTrue(root_node.get_attribute(jsbsim.Attribute.WRITE))
+        #Check WRITE unset
+        root_node.set_attribute(jsbsim.Attribute.WRITE, False)
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.NO_ATTR))
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.READ))
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.WRITE))
+        # Check that set No_ATTR is a no op.
+        root_node.set_attribute(jsbsim.Attribute.NO_ATTR, True)
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.NO_ATTR))
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.READ))
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.WRITE))
+        #Check READ set
+        root_node.set_attribute(jsbsim.Attribute.READ, True)
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.NO_ATTR))
+        self.assertTrue(root_node.get_attribute(jsbsim.Attribute.READ))
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.WRITE))
+        #Check WRITE set
+        root_node.set_attribute(jsbsim.Attribute.WRITE, True)
+        self.assertFalse(root_node.get_attribute(jsbsim.Attribute.NO_ATTR))
+        self.assertTrue(root_node.get_attribute(jsbsim.Attribute.READ))
+        self.assertTrue(root_node.get_attribute(jsbsim.Attribute.WRITE))
+
 
 RunTest(TestMiscellaneous)


### PR DESCRIPTION
A number of improvements to the Python module:
* Add the methods `get_attribute()` and `set_attribute()` to the Python class `FGPropertyNode` to give access to the C++ methods `SGPropertyNode::setAttribute()` and `SGPropertyNode::getAttribute()`. These methods are useful to check the property access to a property: either R/W or read-only or write-only.
* Add the method `get_aircraft_name()` to the Python class `FGAircraft` which allows to get the full aircraft name (the one specified in the XML element `<fdm_config name="..."/>`).
* Add an equality operator between instances of `FGPropertyNode`. Currently the only way to check equality between two property nodes instances is to compare their fully qualified names (via `FGPropertyNode.get_fully_qualified_name()` which neither fast nor convenient). This is allowing to check if a node is contained in a list of nodes and that kind of things.