### PR TITLE
Fix the docs generation for the Python module

### DIFF
--- a/doc/JSBSim.dox.in
+++ b/doc/JSBSim.dox.in
@@ -793,7 +793,8 @@ INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/src/ \
                          @CMAKE_CURRENT_SOURCE_DIR@/src/models/flight_control \
                          @CMAKE_CURRENT_SOURCE_DIR@/src/models/atmosphere \
                          @CMAKE_CURRENT_SOURCE_DIR@/src/models/propulsion \
-                         @CMAKE_CURRENT_SOURCE_DIR@/src/math
+                         @CMAKE_CURRENT_SOURCE_DIR@/src/math \
+                         @CMAKE_CURRENT_SOURCE_DIR@/src/simgear/props/props.hxx
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1178,15 +1179,6 @@ HTML_COLORSTYLE_SAT    = 128
 
 HTML_COLORSTYLE_GAMMA  = 140
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to YES can help to show when doxygen was last run and thus if the
-# documentation is up to date.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = YES
-
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
 # page has loaded.
@@ -1456,17 +1448,6 @@ EXT_LINKS_IN_WINDOW    = NO
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 FORMULA_FONTSIZE       = 14
-
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
-# generated for formulas are transparent PNGs. Transparent PNGs are not
-# supported properly for IE 6.0, but are supported on all modern browsers.
-#
-# Note that when changing this option you need to delete any form_*.png files in
-# the HTML output directory before the changes have effect.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-FORMULA_TRANSPARENT    = YES
 
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
 # http://www.mathjax.org) which uses client side Javascript for the rendering
@@ -1746,16 +1727,6 @@ LATEX_BATCHMODE        = NO
 
 LATEX_HIDE_INDICES     = NO
 
-# If the LATEX_SOURCE_CODE tag is set to YES then doxygen will include source
-# code with syntax highlighting in the LaTeX output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_SOURCE_CODE      = NO
-
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
 # http://en.wikipedia.org/wiki/BibTeX and \cite for more info.
@@ -1763,14 +1734,6 @@ LATEX_SOURCE_CODE      = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
-
-# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_TIMESTAMP        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the RTF output
@@ -1827,16 +1790,6 @@ RTF_STYLESHEET_FILE    =
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
 RTF_EXTENSIONS_FILE    =
-
-# If the RTF_SOURCE_CODE tag is set to YES then doxygen will include source code
-# with syntax highlighting in the RTF output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_RTF is set to YES.
-
-RTF_SOURCE_CODE        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
@@ -1926,15 +1879,6 @@ GENERATE_DOCBOOK       = NO
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
 DOCBOOK_OUTPUT         = docbook
-
-# If the DOCBOOK_PROGRAMLISTING tag is set to YES, doxygen will include the
-# program listings (including syntax highlighting and cross-referencing
-# information) to the DOCBOOK output. Note that enabling this will significantly
-# increase the size of the DOCBOOK output.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_DOCBOOK is set to YES.
-
-DOCBOOK_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
@@ -2114,15 +2058,6 @@ EXTERNAL_PAGES         = YES
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 
-# If the CLASS_DIAGRAMS tag is set to YES, doxygen will generate a class diagram
-# (in HTML and LaTeX) for classes with base or super classes. Setting the tag to
-# NO turns the diagrams off. Note that this option also works with HAVE_DOT
-# disabled, but it is recommended to install and use dot, since it yields more
-# powerful graphs.
-# The default value is: YES.
-
-CLASS_DIAGRAMS         = YES
-
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
 # DIA_PATH tag allows you to specify the directory where the dia binary resides.
@@ -2154,23 +2089,6 @@ HAVE_DOT               = YES
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_NUM_THREADS        = 0
-
-# When you want a differently looking font in the dot files that doxygen
-# generates you can specify the font name using DOT_FONTNAME. You need to make
-# sure dot is able to find the font, which can be done by putting it in a
-# standard location or by setting the DOTFONTPATH environment variable or by
-# setting DOT_FONTPATH to the directory containing the font.
-# The default value is: Helvetica.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTNAME           = Helvetica
-
-# The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
-# dot graphs.
-# Minimum value: 4, maximum value: 24, default value: 10.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2383,18 +2301,6 @@ DOT_GRAPH_MAX_NODES    = 50
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 2
-
-# Set the DOT_TRANSPARENT tag to YES to generate images with a transparent
-# background. This is disabled by default, because dot on Windows does not seem
-# to support this out of the box.
-#
-# Warning: Depending on the platform used, enabling this option may lead to
-# badly anti-aliased labels on the edges of a graph (i.e. they become hard to
-# read).
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This

--- a/doc/python/sphinx/conf.py.in
+++ b/doc/python/sphinx/conf.py.in
@@ -14,15 +14,13 @@ import sys
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute.
 
-sys.path.insert(0, '${CMAKE_BINARY_DIR}/tests')
-
 try:
-    import jsbsim._jsbsim
+    import jsbsim
 except ModuleNotFoundError:
-    # If the JSBSim module cannot be loaded from the `tests` folder then
-    # restore `sys.path` to its inital value and use the globally installed
-    # JSBSim module, if there is one.
-    sys.path = sys.path[1:]
+    # If the JSBSim module is not installed gloablly then use the one from the `tests`
+    # folder.
+    sys.path.insert(0, '${CMAKE_BINARY_DIR}/tests')
+
 
 # -- Project information -----------------------------------------------------
 
@@ -66,7 +64,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -94,7 +92,6 @@ html_theme_options = {
     "github_banner": True,
     "github_user" : "JSBSim-Team",
     "github_repo": "jsbsim",
-    "travis_button" : True,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -16,8 +16,8 @@ set_source_files_properties(${JSBSIM_PYX} PROPERTIES CYTHON_IS_CXX TRUE
 # Autogenerate the Python module doc strings from Doxygen docs
 if(DOXYGEN_FOUND AND BUILD_DOCS)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxy2PyDocStrings.py
-    doxy2pydocs.py)
-  execute_process(COMMAND ${Python3_EXECUTABLE} python/doxy2pydocs.py
+    doxy_to_pyx.py COPYONLY)
+  execute_process(COMMAND ${Python3_EXECUTABLE} python/doxy_to_pyx.py --pyxfile=${JSBSIM_PYX} --doxdir=${CMAKE_BINARY_DIR}/documentation
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
   # Prepare the sphinx build files


### PR DESCRIPTION
The documentation generation is currently failing for the Python module. The failure is due to the tool `python/Doxy2PyDocStrings.py` which is converting the docs generated by Doxygen to Python docs strings.

The tool is actually failing for classes which are not included in the namespace `JSBSim` such as:
https://github.com/JSBSim-Team/jsbsim/blob/9f9a0e62198696d24f72e0b47a1131757d941d08/python/jsbsim.pyx.in#L135-L136
This is producing the following error (note that it is wrongly looking for `JSBSim::SGPropertyNode` stored in the file `classJSBSim_1_1SGPropertyNode.xml`):
```
Traceback (most recent call last):
  File "/Users/runner/work/jsbsim/jsbsim/build/python/doxy2pydocs.py", line 172, in <module>
    tree = et.parse("/Users/runner/work/jsbsim/jsbsim/build/documentation/xml/" + xmlfilename)
  File "/Users/runner/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/xml/etree/ElementTree.py", line 1222, in parse
    tree.parse(source, parser)
  File "/Users/runner/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/xml/etree/ElementTree.py", line 569, in parse
    source = open(source, "rb")
FileNotFoundError: [Errno 2] No such file or directory: '/Users/runner/work/jsbsim/jsbsim/build/documentation/xml/classJSBSim_1_1SGPropertyNode.xml'
```
This PR fixes this bug and restores the docs generation for the Python module. In addition, the source file `src/simgear/props/props.hxx` is now parsed by Doxygen to include the documentation of `SGPropertyNode` which was missing.

In the process, the following changes have been made:
* `python/Doxy2PyDocStrings.py` has been fixed and updated: it is now using type hinting, f-strings, and hardcoded file names have been replaced by parameters passed in the CLI.
* The PR also removes a number of obsolete tags in the Doxygen file `doc/JSBSim.dox.in`.
* The generation of the [HTML documentation of the Python module](https://jsbsim-team.github.io/jsbsim/python/) has also been fixed in `doc/python/sphinx/conf.py.in` to parse the globally installed Python module first.