### PR TITLE
Fix type hinting for the Python module

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -463,7 +463,7 @@ jobs:
       - name: Install Python packages
         run: |
           pip install -r python/requirements.txt
-          pip install build mypy
+          pip install build lark
       - name: Set up Julia
         uses: julia-actions/setup-julia@v2
       - name: Install & Configure Doxygen
@@ -488,7 +488,7 @@ jobs:
           mkdir -p build && cd build
           julia -e "import Pkg;Pkg.add(\"CxxWrap\")"
           export CXXWRAP_PREFIX_PATH=`julia -e "using CxxWrap;print(CxxWrap.prefix_path())"`
-          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DBUILD_JULIA_PACKAGE=ON -DCYTHON_FLAGS="-X embedsignature=True" -DCMAKE_PREFIX_PATH=$CXXWRAP_PREFIX_PATH -DCMAKE_C_FLAGS_DEBUG="-g -O2 -fno-fast-math" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2 -fno-fast-math" -DCMAKE_BUILD_TYPE=Debug ..
+          cmake -DCMAKE_INCLUDE_PATH=$PWD/../cxxtest -DBUILD_JULIA_PACKAGE=ON -DCMAKE_PREFIX_PATH=$CXXWRAP_PREFIX_PATH -DCMAKE_C_FLAGS_DEBUG="-g -O2 -fno-fast-math" -DCMAKE_CXX_FLAGS_DEBUG="-g -O2 -fno-fast-math" -DCMAKE_BUILD_TYPE=Debug ..
       - name: Build JSBSim
         working-directory: build
         run: make --jobs=$(sysctl -n hw.logicalcpu)
@@ -497,15 +497,14 @@ jobs:
         run: ctest --parallel $(sysctl -n hw.logicalcpu) --output-on-failure
       - name: Build the source package for Python
         if: env.release == 'true' && matrix.os == 'macos-13'
-        working-directory: build/tests
+        working-directory: build/python
         run: |
-          echo "::group::Build the type hints stubs"
-          stubgen -p jsbsim -o ../python
+          echo "::group::Generate the type hints stub"
+          python ../../python/pyxstubgen.py --pyxfile=_jsbsim.pyx --output=jsbsim/_jsbsim.pyi
+          touch jsbsim/py.typed
           echo "::endgroup::"
 
           echo "::group::Build the source package"
-          cd ../python
-          touch jsbsim/py.typed
           rm -f _jsbsim.cxx  # Make sure that jsbsim.cxx is not stored in the source distribution
           python -m build --sdist
           echo "::endgroup::"

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,3 +1,4 @@
+from . import _jsbsim
 from ._jsbsim import (
     __version__,
     Attribute,

--- a/python/cython.lark
+++ b/python/cython.lark
@@ -1,0 +1,56 @@
+// A Minimum Lark grammar to parse the JSBSim cython files.
+//
+// Copyright (c) 2025 Bertrand Coconnier
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+%import python (file_input, dots, dotted_name, import_as_names, import_stmt)
+%import python (name, assign_stmt, testlist_star_expr, compound_stmt, suite)
+%import python (paramvalue, starparams, kwparams, funcdef, test, argvalue)
+%import python (arguments, stmt)
+%import python (COMMENT, _INDENT, _DEDENT, _NEWLINE)
+
+cimport_from: "from" (dots? dotted_name | dots) "cimport" ("*" | "(" import_as_names ")" | import_as_names)
+
+ctemplate_type: name "[" ctype "]"
+pointer_type: (name | ctemplate_type) "*"
+ref_type: (name | ctemplate_type) "&"
+const_type: "const" (name | ref_type | pointer_type | ctemplate_type)
+ctype: name | ref_type | pointer_type | const_type | ctemplate_type
+
+conversion: "<" ctype ">" name
+new_param: "new" name "(" [arguments] ")"
+cyassign: testlist_star_expr "=" (testlist_star_expr "=")* (new_param | conversion)
+?ctypedparam: ctype name
+cparameter: (ctypedparam ("=" test)?) | paramvalue
+cparameters: cparameter ("," cparameter)* ["," [starparams | kwparams]]
+cyfuncdef: name "(" cparameters ")" ":" suite
+cyclassdef: "class" name ["(" [arguments] ")"] ":" suite
+cdeclare_var: ctypedparam ("=" "&"? argvalue)? _NEWLINE
+cdef_stmt: "cdef" (cdeclare_var | cyfuncdef | cyclassdef)
+
+%extend import_stmt: cimport_from
+%extend assign_stmt: cyassign
+%extend stmt: cdef_stmt
+%extend argvalue: new_param
+%override funcdef: "def" name "(" [cparameters] ")" ["->" test] ":" suite
+
+%ignore /[\t \f]+/          // WS
+%ignore /\\[\t \f]*\r?\n/   // LINE_CONT
+%ignore COMMENT

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -39,8 +39,7 @@ import sys
 import numpy
 
 
-
-__version__='${PROJECT_VERSION}'
+__version__:str = '${PROJECT_VERSION}'
 
 
 class BaseError(RuntimeError):

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -39,7 +39,7 @@ import sys
 import numpy
 
 
-__version__:str = '${PROJECT_VERSION}'
+__version__: str = '${PROJECT_VERSION}'
 
 
 class BaseError(RuntimeError):

--- a/python/pyxstubgen.py
+++ b/python/pyxstubgen.py
@@ -1,0 +1,222 @@
+import sys
+from typing import List, Union, Tuple
+
+from lark import Lark
+from lark.indenter import PythonIndenter
+from lark.lexer import Token
+from lark.tree import Tree
+from lark.visitors import Interpreter
+
+parser = Lark.open(
+    "cython.lark", parser="lalr", postlex=PythonIndenter(), start="file_input"
+)
+
+with open("jsbsim.pyx.in", "r", encoding="utf-8") as f:
+    pyx_tree = parser.parse(f.read())
+
+
+def rule_name(tree: Tree) -> str:
+    item_type: Token = tree.data
+    assert isinstance(item_type, Token)
+    assert item_type.type == "RULE"
+    assert item_type.value == "name"
+    assert len(tree.children) == 1
+    item_name: Token = tree.children[0]
+    assert isinstance(item_name, Token)
+    assert item_name.type == "python__NAME"
+    return item_name.value
+
+
+def get_constant(tree: Tree) -> str:
+    if tree.children != []:
+        raise TypeError(f"Not a constant: {repr(tree)}")
+    assert tree.children == []
+    if tree.data == "python__const_false":
+        return "False"
+    elif tree.data == "python__const_true":
+        return "True"
+    elif tree.data == "python__const_none":
+        return "None"
+    else:
+        raise TypeError(f"Unknown constant value: {repr(tree)}")
+
+
+class GenerateStub(Interpreter):
+    TAB_SPACES: str = "    "
+    indent: int = 0
+
+    def cyclassdef(self, tree: Tree) -> None:
+        return self.python__classdef(tree)
+
+    def python__var(self, tree: Tree) -> str:
+        assert len(tree.children) == 1
+        var: Tree = tree.children[0]
+        assert isinstance(var, Tree)
+        return rule_name(var)
+
+    def python__getattr(self, tree: Tree) -> List[str]:
+        assert len(tree.children) >= 2
+        attrs: List[str] = [self.visit(tree.children[0])]
+        for child in tree.children[1:]:
+            assert isinstance(child, Tree)
+            attrs.append(rule_name(child))
+        return attrs
+
+    def python__getitem(self, tree: Tree) -> str:
+        assert len(tree.children) == 2
+        name = self.visit(tree.children[0])
+        argument: Tree = tree.children[1]
+        assert isinstance(argument, Tree)
+        if argument.data == "python__var":
+            return f"{name}[{self.visit(argument)}]"
+        elif argument.data == "python__getattr":
+            return f"{name}[{'.'.join(self.visit(argument))}]"
+        else:
+            raise TypeError(f"Unknown argument type: {tree}")
+
+    def get_varname(self, tree: Tree) -> str:
+        if tree.data in ("python__var", "python__getitem"):
+            return self.visit(tree)
+        elif tree.data == "python__getattr":
+            return ".".join(self.visit(tree))
+        else:
+            return get_constant(tree)
+
+    def python__classdef(self, tree: Tree) -> None:
+        class_name: str = ""
+        for child in tree.children:
+            if child is None:  # This class does not inherit
+                continue
+
+            assert isinstance(child, Tree)
+            item: Token = child.data
+            assert isinstance(item, Token)
+
+            if item.value == "name":  # Class name
+                class_name = rule_name(child)
+            elif (
+                item.value == "arguments"
+            ):  # Classes that this class is inheriting from
+                arguments: List[str] = []
+                for argument in child.children:
+                    assert isinstance(argument, Tree)
+                    arguments.append(self.get_varname(argument))
+                if arguments:
+                    class_name += f"({', '.join(arguments)})"
+            else:  # Class body
+                print(f"class {class_name}: ...")
+                assert item.value == "suite"
+                self.indent += 1
+                # Look for the class methods
+                self.visit(tree.children[2])
+                self.indent -= 1
+                print("")
+
+    def python__typedparam(self, tree: Tree) -> Tuple[str, str]:
+        assert len(tree.children) == 2
+        assert isinstance(tree.children[0], Tree)
+        param_name = rule_name(tree.children[0])
+        assert isinstance(tree.children[1], Tree)
+        param_type = self.visit(tree.children[1])
+        return param_name, param_type
+
+    def python__number(self, tree: Tree) -> str:
+        assert len(tree.children) == 1
+        assert isinstance(tree.children[0], Token)
+        return tree.children[0].value
+
+    def python__string(self, tree: Tree) -> str:
+        assert len(tree.children) == 1
+        assert isinstance(tree.children[0], Token)
+        assert tree.children[0].type in ("python__STRING", "python__LONG_STRING")
+        return tree.children[0].value
+
+    def python__decorator(self, tree:Tree) -> str:
+        assert len(tree.children) == 2
+        assert tree.children[1] is None
+        deco_name:Tree = tree.children[0]
+        assert isinstance(deco_name, Tree)
+        deco_type:Token = deco_name.data
+        assert isinstance(deco_type, Token)
+        assert deco_type.type == "RULE"
+        assert deco_type.value == "dotted_name"
+        names:List[str] = []
+        for child in deco_name.children:
+            names.append(rule_name(child))
+        print(f"{self.TAB_SPACES*self.indent}@{'.'.join(names)}")
+
+    def funcdef(self, tree: Tree) -> None:
+        func_name: str = ""
+        for i, child in enumerate(tree.children):
+            if child is None:
+                if i == 1:
+                    func_name += "()"  # This function has no parameter
+                continue
+
+            assert isinstance(child, Tree)
+            child_type: Union[str, Token] = child.data
+            if isinstance(child_type, Token):
+                if child_type.value == "name":  # Get the function
+                    func_name = rule_name(child)
+                    if func_name in ("__cinit__", "__dealloc__"):
+                        return
+                elif child_type.value == "cparameters":  # Get the function parameters
+                    parameters: List[str] = []
+                    for cparameter in child.children:
+                        if cparameter is None:
+                            continue
+
+                        assert isinstance(cparameter, Tree)
+                        cparam_type: Token = cparameter.data
+                        assert isinstance(cparam_type, Token)
+                        if cparam_type.value == "cparameter":
+                            assert len(cparameter.children) == 1
+                            parameter = cparameter.children[0]
+                            assert isinstance(parameter, Tree)
+                            if isinstance(parameter.data, Token):
+                                if parameter.data == "name":
+                                    parameters.append(rule_name(parameter))
+                                elif parameter.data == "paramvalue":
+                                    assert len(parameter.children) == 2
+                                    pname, ptype = self.visit(parameter.children[0])
+                                    value = parameter.children[1]
+                                    assert isinstance(value, Tree)
+                                    if value.data in (
+                                        "python__number",
+                                        "python__string",
+                                    ):
+                                        pvalue = self.visit(value)
+                                    else:
+                                        pvalue = get_constant(value)
+                                    parameters.append(f"{pname}: {ptype} = {pvalue}")
+                                else:
+                                    raise TypeError(
+                                        f"Unknown parameter type in {func_name}: {repr(parameter)}"
+                                    )
+                            elif (
+                                isinstance(parameter.data, str)
+                                and parameter.data == "python__typedparam"
+                            ):
+                                pname, ptype = self.visit(parameter)
+                                parameters.append(f"{pname}: {ptype}")
+                            else:
+                                raise TypeError(
+                                    f"Uknown parameter type in {func_name}: {repr(parameter)}"
+                                )
+                        else:
+                            raise TypeError(
+                                f"Unknown parameter type in {func_name}: {repr(cparameter)}"
+                            )
+                    func_name += f"({', '.join(parameters)})"
+                else:
+                    assert child_type.value == "suite"
+            elif isinstance(child_type, str):
+                func_name += f" -> {self.get_varname(child)}"
+            else:
+                raise TypeError(f"Unknown parameter in {func_name}: {repr(child)}")
+        print(f"{self.TAB_SPACES*self.indent}def {func_name}: ...")
+        if self.indent == 0:
+            print("")
+
+
+GenerateStub().visit(pyx_tree)


### PR DESCRIPTION
The type hinting introduced by PR #755 is broken. By inspection of the stub files `*.pyi` it appears that the utility tool `stubgen` from the `mypy` package is producing garbage for modules generated by Cython .

This PR replaces the usage of `stubgen` by a new Python script `pyxstubgen.py` that parses `jsbsim.pyx` to find all the classes, methods and functions declarations with their type hints and then generates a proper stub file `_jsbsim.pyi`.

Since parsing a Cython file is no trivial job, the script `pystubgen.py` is using the [lark parser](https://github.com/lark-parser/lark) (a parser toolkit fully written in Python). A grammar file `cython.lark` has been created for that purpose. It is the minimum grammar that works for the JSBSim cython code and is by no means pretending to be able to read *any* cython file.

This PR is addressing some [proverbial itch scratching](https://thebasics.guide/scratch-your-own-itch/): I am annoyed that my favorite IDE does not autocomplete the classes and functions from the JSBSim Python module. I have run some tests that confirm that autocomplete works when the Python module is generated using the new script `pyxstubgen.py`.

Please note that this feature is meant to be used by our CI workflow when building the packages that will uploaded to PyPI. It is not part of the standard development cycle (i.e. write code/build/tests) so developers do not need to install `lark` on their systems.