### PR TITLE
fix uninitialized ThrottlePos in FGTurbine

### DIFF
--- a/src/models/propulsion/FGTurbine.cpp
+++ b/src/models/propulsion/FGTurbine.cpp
@@ -78,6 +78,7 @@ FGTurbine::FGTurbine(FGFDMExec* exec, Element *el, int engine_number, struct Inp
   InjectionTimer = InjWaterNorm = 0.0;
   EPR = 1.0;
   disableWindmill = false;
+  ThrottlePos = 0.0;
 
   Load(exec, el);
   Debug(0);


### PR DESCRIPTION
`ThrottlePos` is used in `InitRunning()` to calculate `N2` before the first `Calculate()` initializes it from the engine.

We observed that sometimes causing astronomical full consumption because `ThrottlePos`->`N2`->`Thrust`->fuel consumption.