### PR TITLE
Add raw values enumeration to fix segfaults

### DIFF
--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -913,10 +913,10 @@ void FGPropagate::bind(void)
   PropertyManager->Tie("orbital/periapsis-radius-ft", &PeriapsisRadius);
   PropertyManager->Tie("orbital/period-sec", &OrbitalPeriod);
 
-  PropertyManager->Tie("simulation/integrator/rate/rotational", &integrator_rotational_rate);
-  PropertyManager->Tie("simulation/integrator/rate/translational", &integrator_translational_rate);
-  PropertyManager->Tie("simulation/integrator/position/rotational", &integrator_rotational_position);
-  PropertyManager->Tie("simulation/integrator/position/translational", &integrator_translational_position);
+  PropertyManager->Tie("simulation/integrator/rate/rotational", (int*)&integrator_rotational_rate);
+  PropertyManager->Tie("simulation/integrator/rate/translational", (int*)&integrator_translational_rate);
+  PropertyManager->Tie("simulation/integrator/position/rotational", (int*)&integrator_rotational_position);
+  PropertyManager->Tie("simulation/integrator/position/translational", (int*)&integrator_translational_position);
 
   PropertyManager->Tie<FGPropagate, int>("simulation/write-state-file", this,
                                          nullptr, &FGPropagate::WriteStateFile);


### PR DESCRIPTION
After the fine work done in #1304 and #1311, my colleague is still getting a segfault when building with `clang -flto=full -fvirtual-function-elimination -fvisibility=hidden`.

We believe the issue is from how the code is converting from a generic type to an Int type for Enum use. In this case, a casting occurs, changing the underlying object type, and thus swapping from an object type for which the vtable has been optimized away to a type that expects to have a vtable.

This PR shows one way to work around the issue. With this patch, we confirm that the JSBSim HEAD successfully runs on each of the CPUv8 inputs without segfaulting. Please let us know what you think. Thanks!

#834 