### PR TITLE
Add NEU (North East Up) properties for distance from IC start

### DIFF
--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -185,14 +185,14 @@ bool FGAuxiliary::Run(bool Holding)
   vMachUVW(eW) = vAeroUVW(eW) / in.SoundSpeed;
 
   // Position tracking in local frame with local frame origin at lat, lon of initial condition
-  // and at 0 altitude relative to the geoid ellipsoid. Position is NEU (North, East, UP) in feet.
+  // and at 0 altitude relative to the reference ellipsoid. Position is NEU (North, East, UP) in feet.
   if (!NEUFromStartInitialized) {
     NEUStartLocation = FDMExec->GetIC()->GetPosition();
     NEUStartLocation.SetPositionGeodetic(NEUStartLocation.GetLongitude(), NEUStartLocation.GetGeodLatitudeRad(), 0.0);
     NEUFromStartInitialized = true;
   }
   vNEUFromStart = NEUStartLocation.LocationToLocal(in.vLocation);
-  vNEUFromStart(3) *= -1.0;  // Flip sign for Up, so + for altitude above geoid
+  vNEUFromStart(3) *= -1.0;  // Flip sign for Up, so + for altitude above reference ellipsoid
 
   Vground = sqrt( in.vVel(eNorth)*in.vVel(eNorth) + in.vVel(eEast)*in.vVel(eEast) );
 
@@ -367,7 +367,7 @@ double FGAuxiliary::GetNlf(void) const
 double FGAuxiliary::GetLongitudeRelativePosition(void) const
 {
   return in.vLocation.GetDistanceTo(FDMExec->GetIC()->GetLongitudeRadIC(),
-                                    in.vLocation.GetGeodLatitudeRad())* fttom;
+                                    in.vLocation.GetGeodLatitudeRad());
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -375,7 +375,7 @@ double FGAuxiliary::GetLongitudeRelativePosition(void) const
 double FGAuxiliary::GetLatitudeRelativePosition(void) const
 {
   return in.vLocation.GetDistanceTo(in.vLocation.GetLongitude(),
-                                    FDMExec->GetIC()->GetGeodLatitudeRadIC())* fttom;
+                                    FDMExec->GetIC()->GetGeodLatitudeRadIC());
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -384,7 +384,7 @@ double FGAuxiliary::GetDistanceRelativePosition(void) const
 {
   auto ic = FDMExec->GetIC();
   return in.vLocation.GetDistanceTo(ic->GetLongitudeRadIC(),
-                                    ic->GetGeodLatitudeRadIC())* fttom;
+                                    ic->GetGeodLatitudeRadIC());
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -83,6 +83,8 @@ FGAuxiliary::FGAuxiliary(FGFDMExec* fdmex) : FGModel(fdmex)
   vAeroPQR.InitMatrix();
   vMachUVW.InitMatrix();
   vEulerRates.InitMatrix();
+  vNEUFromStart.InitMatrix();
+  NEUFromStartInitialized = false;
 
   bind();
 
@@ -116,6 +118,8 @@ bool FGAuxiliary::InitModel(void)
   vAeroPQR.InitMatrix();
   vMachUVW.InitMatrix();
   vEulerRates.InitMatrix();
+  vNEUFromStart.InitMatrix();
+  NEUFromStartInitialized = false;
 
   return true;
 }
@@ -180,7 +184,15 @@ bool FGAuxiliary::Run(bool Holding)
   vMachUVW(eV) = vAeroUVW(eV) / in.SoundSpeed;
   vMachUVW(eW) = vAeroUVW(eW) / in.SoundSpeed;
 
-  // Position
+  // Position tracking in local frame with local frame origin at lat, lon of initial condition
+  // and at 0 altitude relative to the geoid ellipsoid. Position is NEU (North, East, UP) in feet.
+  if (!NEUFromStartInitialized) {
+    NEUStartLocation = FDMExec->GetIC()->GetPosition();
+    NEUStartLocation.SetPositionGeodetic(NEUStartLocation.GetLongitude(), NEUStartLocation.GetGeodLatitudeRad(), 0.0);
+    NEUFromStartInitialized = true;
+  }
+  vNEUFromStart = NEUStartLocation.LocationToLocal(in.vLocation);
+  vNEUFromStart(3) *= -1.0;  // Flip sign for Up, so + for altitude above geoid
 
   Vground = sqrt( in.vVel(eNorth)*in.vVel(eNorth) + in.vVel(eEast)*in.vVel(eEast) );
 
@@ -437,6 +449,10 @@ void FGAuxiliary::bind(void)
   PropertyManager->Tie("position/vrp-gc-latitude_deg", &vLocationVRP, &FGLocation::GetLatitudeDeg);
   PropertyManager->Tie("position/vrp-longitude_deg", &vLocationVRP, &FGLocation::GetLongitudeDeg);
   PropertyManager->Tie("position/vrp-radius-ft", &vLocationVRP, &FGLocation::GetRadius);
+
+  PropertyManager->Tie("position/neu-n-ft", this, eX, &FGAuxiliary::GetNEUPositionFromStart);
+  PropertyManager->Tie("position/neu-e-ft", this, eY, &FGAuxiliary::GetNEUPositionFromStart);
+  PropertyManager->Tie("position/neu-u-ft", this, eZ, &FGAuxiliary::GetNEUPositionFromStart);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGAuxiliary.h
+++ b/src/models/FGAuxiliary.h
@@ -277,7 +277,7 @@ public:
   double GetDistanceRelativePosition  (void) const;
 
   /** The North East Up (NEU) position relative to initial condition's lat, lon and 
-  0 alt relative to geoid ellipsoid */
+  0 alt relative to reference ellipsoid */
   double GetNEUPositionFromStart(int idx) const { return vNEUFromStart(idx); }
   const FGColumnVector3& GetNEUPositionFromStart() const { return vNEUFromStart; }
 

--- a/src/models/FGAuxiliary.h
+++ b/src/models/FGAuxiliary.h
@@ -276,6 +276,11 @@ public:
   double GetLatitudeRelativePosition  (void) const;
   double GetDistanceRelativePosition  (void) const;
 
+  /** The North East Up (NEU) position relative to initial condition's lat, lon and 
+  0 alt relative to geoid ellipsoid */
+  double GetNEUPositionFromStart(int idx) const { return vNEUFromStart(idx); }
+  const FGColumnVector3& GetNEUPositionFromStart() const { return vNEUFromStart; }
+
   void SetAeroPQR(const FGColumnVector3& tt) { vAeroPQR = tt; }
 
   struct Inputs {
@@ -328,6 +333,10 @@ private:
   FGColumnVector3 vEulerRates;
   FGColumnVector3 vMachUVW;
   FGLocation vLocationVRP;
+
+  bool NEUFromStartInitialized;
+  FGLocation NEUStartLocation;
+  FGColumnVector3 vNEUFromStart;
 
   double Vt, Vground;
   double Mach, MachU;

--- a/src/models/FGAuxiliary.h
+++ b/src/models/FGAuxiliary.h
@@ -276,8 +276,12 @@ public:
   double GetLatitudeRelativePosition  (void) const;
   double GetDistanceRelativePosition  (void) const;
 
-  /** The North East Up (NEU) position relative to initial condition's lat, lon and 
-  0 alt relative to reference ellipsoid */
+  /** The North East Up (NEU) frame is a local tangential frame fixed in the ECEF
+      frame (i.e following the Earth's rotation).
+      The NEU frame's origin is fixed at the aircrat's initial lat, lon position
+      and at an altitude of 0 ft relative to the reference ellipsoid.
+      The NEU frame is a left-handed coordinate system, unlike the NED frame. So
+      beware of differences when computing cross products. */
   double GetNEUPositionFromStart(int idx) const { return vNEUFromStart(idx); }
   const FGColumnVector3& GetNEUPositionFromStart() const { return vNEUFromStart; }
 


### PR DESCRIPTION
Based on discussion https://github.com/JSBSim-Team/jsbsim/discussions/1318 in terms of a request to be able to easily plot the coordinates of an aircraft in the local frame to show a 2D or 3D plot of the aircraft's trajectory I've added 3 new properties in `FGAuxiliary`.

```
position/neu-n-ft
position/neu-e-ft
position/neu-u-ft
```

They output the current offset of the aircraft in a local frame with an origin based on the initial condition's lat, lon and 0 alt relative to the geoid ellipsoid.