### PR TITLE
Add trim_trailing_whitespace to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@ root = true
 [*.{h,hpp,cpp}]
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
@bcoconni mentioned:

> And sorry, my IDE cleans up trailing spaces before saving files so there are a few white spaces modifications that are polluting the diff.

So I've added `trim_trailing_whitespace = true` to `.editorconfig` to try and improve consistency. Not guaranteed since someone may use an editor that doesn't support `.editorconfig`. If we did want to guarantee this sort of formatting we'd need to use some tool tied to our CI pipeline.

@bcoconni your examples of removing trailing whitespace were for Python code in .ipynb files. I noticed that currently our `.editorconfig` is only configured for `.h .hpp .cpp` files. So I guess we should also add an entry for `.py` files? Looks like our default there is space for indents, but 4 spaces as opposed to 2?