### PR TITLE
Synchronize CMake min version with the overall project.

### DIFF
--- a/src/models/atmosphere/MSIS/CMakeLists.txt
+++ b/src/models/atmosphere/MSIS/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.15)
 
 project(NRLMSIS)
 


### PR DESCRIPTION
With the release of CMake 4.0, [compatibility with versions earlier than 3.5 are no longer supported](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features). This PR updates the CMake minimum version requirement to 3.15 for the MSIS test that is run by our CI workflow.

Version 3.15 is already the minimum version required for the overall *JSBSim* project so this will not imply an upgrade for the developers or anyone compiling JSBSim from scratch:
https://github.com/JSBSim-Team/jsbsim/blob/405c00d830cf4dd912908085d606c057d9c415d8/CMakeLists.txt#L1