### PR TITLE
Move the code coverage job to its own workflow.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Code coverage
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+
+jobs:
+  Codecov:
+    name: Code coverage
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Ubuntu packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install cxxtest lcov
+      - name: Checkout JSBSim
+        uses: actions/checkout@v5
+      - name: Configure JSBSim
+        run: |
+          mkdir build && cd build
+          cmake -DENABLE_COVERAGE=ON -DBUILD_PYTHON_MODULE=OFF -DBUILD_DOCS=OFF ..
+      - name: Build JSBSim
+        working-directory: build
+        run: make --jobs=$(nproc)
+      - name: Run JSBSim tests
+        working-directory: build
+        run: ctest -R Test1 --output-on-failure
+      - name: Generate coverage report
+        working-directory: build
+        run: make lcov
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./build/lcov/data/capture/all_targets.info
+          disable_search: true
+          fail_ci_if_error: true

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -721,40 +721,6 @@ jobs:
           name: ${{ matrix.os }}-Wheels.binaries
           path: ./wheelhouse/*.whl
 
-  Codecov:
-    name: Code coverage
-    needs: Linux
-    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Ubuntu packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install cxxtest lcov
-      - name: Checkout JSBSim
-        uses: actions/checkout@v5
-      - name: Configure JSBSim
-        run: |
-          mkdir build && cd build
-          cmake -DENABLE_COVERAGE=ON -DBUILD_PYTHON_MODULE=OFF -DBUILD_DOCS=OFF ..
-      - name: Build JSBSim
-        working-directory: build
-        run: make --jobs=$(nproc)
-      - name: Run JSBSim tests
-        working-directory: build
-        run: ctest -R Test1 --output-on-failure
-      - name: Generate coverage report
-        working-directory: build
-        run: make lcov
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: ./build/lcov/data/capture/all_targets.info
-          disable_search: true
-          fail_ci_if_error: true
-
   Rolling-Release:
     needs: [Test-Build-PyPackage-From-Source, Windows-MinGW, Windows-installer]
     name: Deploy Rolling Release


### PR DESCRIPTION
We currently have the PRs #1319, #1324 and #1333 pending because they are all causing the job `Codecov` to fail.

https://github.com/JSBSim-Team/jsbsim/blob/405c00d830cf4dd912908085d606c057d9c415d8/.github/workflows/cpp-python-build.yml#L724-L756

This PR moves the `Codecov` job to its own CI workflow so that the aforementioned PRs will no longer collide with it, which should allow to merge them.

The `Codecov` job is completely independent from the other jobs in the `C/C++ build` workflow. It has been included in the `C/C++ build` workflow to avoid compiling code for the tests coverage when something was going wrong in one of the jobs upstream in the workflow sequence.

After this PR is merged, the coverage job will always be run and will use [one of the 20 concurrent jobs that the free plan is allocating to us](https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners). This should not be much of a concern since our CI workflows have some margin before hitting that limit (max is 11 concurrent jobs at the moment).