### PR TITLE
Remove redundant (skip ci) management.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,8 +18,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.event.head_commit.message, '[skip ci]') }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +51,7 @@ jobs:
         # to auto-install Python dependencies
         setup-python-dependencies: false
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -11,7 +11,6 @@ env:
 
 jobs:
   XML-validation:
-    if: ${{ !startsWith(github.event.head_commit.message, '[skip ci]') || github.event_name == 'pull_request' }}
     name: XML validation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Following the discussion held in https://github.com/JSBSim-Team/jsbsim/pull/1331#issuecomment-3271832161 and according to [the GitHub docs about *Skipping workflow runs*](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs), this PR removes the logic in the CI workflows that skips running them whenever a commit message starts with `[skip ci]`.

The logic is superseded by GitHub's and therefore the condition in the `if:` tags is always true, making the test actually useless.

Note: "*skip ci*" is between parentheses (instead of brackets) in the PR title, this is on purpose to avoid skipping the CI workflow.