### PR TITLE
Address the sunset of macOS 13 runners.

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -190,13 +190,13 @@ jobs:
       - name: Set up Matlab
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2022a
+          release: R2023b
           products: Simulink
       - name: Configure JSBSim
         run: |
           mkdir build
           cd build
-          cmake -DBUILD_MATLAB_SFUNCTION=ON -DCMAKE_OSX_ARCHITECTURES="x86_64" ..
+          cmake -DBUILD_MATLAB_SFUNCTION=ON ..
       - name: Build JSBSim S-Function
         working-directory: build
         run: cmake --build . --config RelWithDebInfo --target JSBSim_SFunction --parallel 3


### PR DESCRIPTION
According to [GitHub announcement](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), macOS 13 runners will close down on Dec 04, 2025.

This PR migrates our CI workflow to macOS 14 runners and upgrade the version of Matlab used for our testing from `R2022a` to `R2023b` (see matlab-actions/setup-matlab#113 for the details).

The job is using Python 3.10 because it always did for macOS 14 runners (see https://github.com/JSBSim-Team/jsbsim/pull/1030#issuecomment-1925412137) and [3.9 has reached "End of life"](https://peps.python.org/pep-0596/#lifespan) anyway. 

Bonus point: this removes the need of having 2 jobs for MacOSX (one for x86_64 and another one for Apple Silicon chips).