### PR TITLE
Add function GetAltitudeDependentConditions to API

### DIFF
--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -195,6 +195,17 @@ double FGAtmosphere::GetSoundSpeed(double altitude) const
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+// Get all atmospheric conditions which depend on the altitude
+
+void FGAtmosphere::GetAltitudeDependentConditions(AltitudeDependentConditions& conditions, double altitude) const
+{
+  conditions.Temperature = GetTemperature(altitude);
+  conditions.Pressure = GetPressure(altitude);
+  conditions.Density = (conditions.Pressure / (Reng * conditions.Temperature));
+  conditions.SoundSpeed = sqrt(SHRatio * Reng * conditions.Temperature);
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 // This function sets the sea level temperature.
 // Internally, the Rankine scale is used for calculations, so any temperature
 // supplied must be converted to that unit.

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -82,6 +82,13 @@ public:
   /// Enums for specifying pressure units.
   enum ePressure {eNoPressUnit=0, ePSF, eMillibars, ePascals, eInchesHg};
 
+  typedef struct AltitudeDependentConditions {
+    double Temperature = 0.0;
+    double Pressure = 0.0;
+    double Density = 0.0;
+    double SoundSpeed = 0.0;
+  } AltitudeDependentConditions;
+
   /// Constructor
   FGAtmosphere(FGFDMExec*);
 
@@ -205,6 +212,8 @@ public:
   virtual double GetDensityAltitude() const {return DensityAltitude;}
 
   virtual double GetPressureAltitude() const {return PressureAltitude;}
+
+  virtual void GetAltitudeDependentConditions(AltitudeDependentConditions& conditions, const double altitude) const;
 
   struct Inputs {
     double altitudeASL;

--- a/tests/unit_tests/FGAtmosphereTest.h
+++ b/tests/unit_tests/FGAtmosphereTest.h
@@ -150,8 +150,17 @@ public:
     const double nu0 = mu0/rho0;
 
     for(double h=-1000.0; h<10000; h+= 1000) {
-      double T = T0 + 0.1*h;
-      double P = P0 + 1.0*h;
+      const double T = T0 + 0.1 * h;
+      const double P = P0 + 1.0 * h;
+      const double rho = P / (R * T);
+      const double a = sqrt(gama * R * T);
+
+      FGAtmosphere::AltitudeDependentConditions adv;
+      atm.GetAltitudeDependentConditions(adv, h);
+      TS_ASSERT_DELTA(adv.Temperature, T, epsilon);
+      TS_ASSERT_DELTA(adv.Pressure, P, epsilon);
+      TS_ASSERT_DELTA(adv.Density, rho, epsilon);
+      TS_ASSERT_DELTA(adv.SoundSpeed, a, epsilon);
 
       TS_ASSERT_DELTA(atm.GetTemperature(h), T, epsilon);
       TS_ASSERT_EQUALS(atm.GetTemperature(0.0), T0);
@@ -160,11 +169,9 @@ public:
       TS_ASSERT_DELTA(atm.GetPressure(h), P, epsilon);
       TS_ASSERT_EQUALS(atm.GetPressure(0.0), P0);
 
-      double rho = P/(R*T);
       TS_ASSERT_DELTA(atm.GetDensity(h), rho, epsilon);
       TS_ASSERT_DELTA(atm.GetDensity(0.0), rho0, epsilon);
 
-      double a = sqrt(gama*R*T);
       TS_ASSERT_DELTA(atm.GetSoundSpeed(h), a, epsilon);
       TS_ASSERT_DELTA(atm.GetSoundSpeed(0.0), a0, epsilon);
 


### PR DESCRIPTION
New API function to access atmospheric conditions in one go.
Related to #1194 , which needed split.