### PR TITLE
Optimize calls to `SGPropertyNode::getNode` in `FGAtmosphere::Calculate`

### DIFF
--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -61,6 +61,10 @@ FGAtmosphere::FGAtmosphere(FGFDMExec* fdmex)
   Name = "FGAtmosphere";
 
   bind();
+  SGPropertyNode* root = PropertyManager->GetNode();
+  atmosphere_node = root->getNode("atmosphere");
+
+  assert(atmosphere_node);
   Debug(0);
 }
 
@@ -141,11 +145,10 @@ double FGAtmosphere::ValidateTemperature(double t, const string& msg, bool quiet
 
 void FGAtmosphere::Calculate(double altitude)
 {
-  SGPropertyNode* root = PropertyManager->GetNode();
   double t =0.0;
   double p = 0.0;
 
-  if (!override_node) override_node = root->getNode("atmosphere/override");
+  if (!override_node) override_node = atmosphere_node->getNode("override");
 
   // Temperature and pressure
   if (override_node) {

--- a/src/models/FGAtmosphere.h
+++ b/src/models/FGAtmosphere.h
@@ -237,10 +237,11 @@ protected:
   double KinematicViscosity = 0.0;
 
   // Nodes for atmospheric properties overridding
-  SGPropertyNode_ptr override_node = nullptr;
-  SGPropertyNode_ptr override_temperature_node = nullptr;
-  SGPropertyNode_ptr override_pressure_node = nullptr;
-  SGPropertyNode_ptr override_density_node = nullptr;
+  SGPropertyNode_ptr atmosphere_node;
+  SGPropertyNode_ptr override_node;
+  SGPropertyNode_ptr override_temperature_node;
+  SGPropertyNode_ptr override_pressure_node;
+  SGPropertyNode_ptr override_density_node;
 
   /// Calculate the atmosphere for the given altitude.
   virtual void Calculate(double altitude);


### PR DESCRIPTION
### The problem

As I mentioned in https://github.com/JSBSim-Team/jsbsim/pull/1375#issuecomment-3829000981, the method `FGAtmosphere::Calculate` is spending a significant amount of time resolving property names into property nodes (i.e. calling `SGPropertyNode::getNode`):

<img width="627" height="267" alt="image" src="https://github.com/user-attachments/assets/456f541a-aca7-4cf3-aaa8-8d52c4da2c1a" />

Actually the logic is based on the existence of the nodes `atmosphere/override/temperature`, `atmosphere/override/pressure` and `atmosphere/override/density`.

https://github.com/JSBSim-Team/jsbsim/blob/5988bb46d02b55f019fef7ee6390b01fd3e38984/src/models/FGAtmosphere.cpp#L142-L170

If one of these nodes is existing then the temperature/pressure/density is extracted from its corresponding node. This feature is designed to use an external atmospheric model that would provide its data through the `atmosphere/override` properties.

The problem is that interrogating `SGPropertyNode::getNode` at each iteration is costly: 72012 calls to `SGPropertyNode::getNode` translates into 3,940,012 calls to `strncmp` (in the screenshot above it is an SSE2 optimized version of it).

### The proposed solution

Since all the nodes are located below `atmosphere/override` then the new code is only testing if `atmosphere/override` is existing at each iteration. If it does not exist then there is no point in interrogating the other nodes for the temperature/pressure/density. This is dividing the number of calls to `SGPropertyNode::getNode` by 3 and the time spent in `FGAtmosphere::Calculate` by roughly the same order of magnitude.

<img width="629" height="260" alt="image" src="https://github.com/user-attachments/assets/bfc07e9c-6f48-4b09-9508-5f1fd5a7ff32" />

In addition to that, once the existence of a node is confirmed, it is registered in a variable of type `SGPropertyNode_ptr` so that `FGAtmosphere::Calculate` will no longer need to resolve the name into a node thus avoiding further calls to `SGPropertyNode::getNode`.