### PR TITLE
Fix the failure of `TestInputSocket.py` when extra lines are found.

### DIFF
--- a/tests/TestInputSocket.py
+++ b/tests/TestInputSocket.py
@@ -38,7 +38,7 @@ class TelnetInterface:
 
     async def get_output(self):
         msg = await self.reader.read(1024)
-        lines = msg.split("\r\n")
+        lines = msg.splitlines()
         if lines[-1] == "JSBSim> ":
             return "\n".join(lines[:-1])
         else:
@@ -52,7 +52,7 @@ class TelnetInterface:
         return await self.get_output()
 
     async def get_property_value(self, property_name):
-        msg = (await self.send_command(f"get {property_name}")).split("\n")
+        msg = (await self.send_command(f"get {property_name}")).splitlines()
         return float(msg[0].split("=")[1])
 
 
@@ -122,7 +122,7 @@ class TestInputSocket(JSBSimTestCase):
 
     async def shell(self, root, dt, reader, writer):
         await self.sanity_check(reader, writer)
-        msg = (await self.telnet.send_command("info")).split("\n")
+        msg = (await self.telnet.send_command("info")).splitlines()
 
         # Check the aircraft name and its version
         self.assertEqual(msg[2].split(":")[1].strip(), root.attrib["name"].strip())
@@ -210,7 +210,7 @@ class TestInputSocket(JSBSimTestCase):
             sorted(
                 map(
                     lambda x: x.split("{")[0].strip(),
-                    out.split("\n")[2:-1],
+                    out.strip().splitlines()[2:],
                 )
             ),
             ["get", "help", "hold", "info", "iterate", "quit", "resume", "set"],


### PR DESCRIPTION
I had several occurrences in a row where the Ubuntu builds of the CI workflow are failing with the following error (note the empty string at the start of one list):
```
Lists differ: ['', 'get', 'help', 'hold', 'info', 'iterate', 'quit', 'resume', 'set'] != ['get', 'help', 'hold', 'info', 'iterate', 'quit', 'resume', 'set']

First differing element 0:
''
'get'

First list contains 1 additional elements.
First extra element 8:
'set'

- ['', 'get', 'help', 'hold', 'info', 'iterate', 'quit', 'resume', 'set']
?  ----

+ ['get', 'help', 'hold', 'info', 'iterate', 'quit', 'resume', 'set']
FAIL
```
I am not sure why Ubuntu is triggering this error while other platforms do not. And previously it was occurring seldomly while it is now happening systematically on the Ubuntu runners. This may be linked to the fact that CRLF are used in the help string while our Python code is splitting the lines using `split("\n")`:
https://github.com/JSBSim-Team/jsbsim/blob/3003423070d7c2791ec28d7ab867cf39b4f57e26/src/input_output/FGInputSocket.cpp#L255-L264
https://github.com/JSBSim-Team/jsbsim/blob/3003423070d7c2791ec28d7ab867cf39b4f57e26/tests/TestInputSocket.py#L205-L213
This PR is replacing all occurrences of `.split("\n")` by `.splitlines()`. The latter handles correctly the various ends of lines (`\n`, `\r\n`, etc.). Following this change, the error stopped to occur on my fork.