### PR TITLE
FGInitialCondition::Load throws instead of returning false

### DIFF
--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -1020,15 +1020,15 @@ bool FGInitialCondition::Load(const SGPath& rstfile, bool useAircraftPath)
 
   // Make sure that the document is valid
   if (!document) {
-    LogException err;
-    err << "File: " << init_file_name << " could not be read.\n";
-    throw err;
+    FGLogging log(LogLevel::ERROR);
+    log << "Init file: " << init_file_name << " could not be loaded.\n";
+    return false;
   }
 
   if (document->GetName() != "initialize") {
-    LogException err;
-    err << "File: " << init_file_name << " is not a reset file.\n";
-    throw err;
+    FGLogging log(LogLevel::ERROR);
+    log << "File: " << init_file_name << " is not a valid reset file.\n";
+    return false;
   }
 
   bool result = false;
@@ -1038,9 +1038,9 @@ bool FGInitialCondition::Load(const SGPath& rstfile, bool useAircraftPath)
     double version = document->GetAttributeValueAsNumber("version");
 
     if (version >= 3.0) {
-      XMLLogException err(document);
-      err << "Only initialization file formats 1 and 2 are currently supported\n";
-      throw err;
+      FGLogging log(LogLevel::ERROR);
+      log << "Only initialization file formats 1 and 2 are currently supported\n";
+      return false;
     } else if (version >= 2.0) {
       result = Load_v2(document);
     } else if (version >= 1.0) {

--- a/src/initialization/FGInitialCondition.cpp
+++ b/src/initialization/FGInitialCondition.cpp
@@ -1015,48 +1015,48 @@ bool FGInitialCondition::Load(const SGPath& rstfile, bool useAircraftPath)
     init_file_name = rstfile;
   }
 
-  FGXMLFileRead XMLFileRead;
-  Element* document = XMLFileRead.LoadXMLDocument(init_file_name);
-
-  // Make sure that the document is valid
-  if (!document) {
-    FGLogging log(LogLevel::ERROR);
-    log << "Init file: " << init_file_name << " could not be loaded.\n";
-    return false;
-  }
-
-  if (document->GetName() != "initialize") {
-    FGLogging log(LogLevel::ERROR);
-    log << "File: " << init_file_name << " is not a valid reset file.\n";
-    return false;
-  }
-
   bool result = false;
+  try {
+    FGXMLFileRead XMLFileRead;
+    Element* document = XMLFileRead.LoadXMLDocument(init_file_name);
 
-  // If doc has an version, check it. Otherwise fall back to legacy.
-  if (document->HasAttribute("version")) {
-    double version = document->GetAttributeValueAsNumber("version");
-
-    if (version >= 3.0) {
+    // Make sure that the document is valid
+    if (!document) {
       FGLogging log(LogLevel::ERROR);
-      log << "Only initialization file formats 1 and 2 are currently supported\n";
+      log << "Init file: " << init_file_name << " could not be loaded.\n";
       return false;
-    } else if (version >= 2.0) {
-      result = Load_v2(document);
-    } else if (version >= 1.0) {
-      result = Load_v1(document);
     }
 
-  } else {
-    result = Load_v1(document);
-  }
+    if (document->GetName() != "initialize") {
+      FGLogging log(LogLevel::ERROR);
+      log << "File: " << init_file_name << " is not a valid reset file.\n";
+      return false;
+    }
 
-  // Check to see if any engines are specified to be initialized in a running state
-    Element* running_elements = document->FindElement("running");
-  while (running_elements) {
-    int engineNumber = int(running_elements->GetDataAsNumber());
-    enginesRunning |= engineNumber == -1 ? engineNumber : 1 << engineNumber;
-    running_elements = document->FindNextElement("running");
+    // If doc has an version, check it. Otherwise fall back to legacy.
+    if (document->HasAttribute("version")) {
+      double version = document->GetAttributeValueAsNumber("version");
+
+      if (version >= 3.0) {
+        FGLogging log(LogLevel::ERROR);
+        log << "Only initialization file formats 1 and 2 are currently supported\n";
+        return false;
+      } else if (version >= 2.0) {
+        result = Load_v2(document);
+      } else if (version >= 1.0) {
+        result = Load_v1(document);
+      }
+
+    } else {
+      result = Load_v1(document);
+    }
+  }
+  catch (BaseException& err)
+  {
+    FGLogging log(LogLevel::ERROR);
+    log << "Error parsing " << init_file_name << "\n";
+    log << err.what();
+    return false;
   }
 
   return result;
@@ -1196,6 +1196,8 @@ bool FGInitialCondition::Load_v1(Element* document)
     SetTrimRequest(document->FindElementValue("trim"));
 
   vPQR_body.InitMatrix();
+
+  Load_running(document);
 
   return result;
 }
@@ -1445,7 +1447,20 @@ bool FGInitialCondition::Load_v2(Element* document)
       vPQR_body.InitMatrix();
   }
 
+  Load_running(document);
+
   return result;
+}
+
+void FGInitialCondition::Load_running(Element* document)
+{
+  // Check to see if any engines are specified to be initialized in a running state
+  Element* running_elements = document->FindElement("running");
+  while (running_elements) {
+    int engineNumber = int(running_elements->GetDataAsNumber());
+    enginesRunning |= engineNumber == -1 ? engineNumber : 1 << engineNumber;
+    running_elements = document->FindNextElement("running");
+  }
 }
 
 //******************************************************************************

--- a/src/initialization/FGInitialCondition.h
+++ b/src/initialization/FGInitialCondition.h
@@ -714,6 +714,7 @@ private:
 
   bool Load_v1(Element* document);
   bool Load_v2(Element* document);
+  void Load_running(Element* document);
 
   void SetEulerAngleRadIC(int idx, double angle);
   void SetBodyVelFpsIC(int idx, double vel);

--- a/src/input_output/FGScript.cpp
+++ b/src/input_output/FGScript.cpp
@@ -193,7 +193,7 @@ bool FGScript::LoadScript(const SGPath& script, double default_dT,
   }
 
   auto IC = FDMExec->GetIC();
-  if ( ! IC->Load( initialize )) {
+  if ( ! IC->Load( initialize )) { // here
     FGLogging log(LogLevel::ERROR);
     log << "Initialization unsuccessful\n";
     return false;


### PR DESCRIPTION
Following discussion #1407 
_Hint: Hide white space differences when checking Files changes_

The function `FGInitialCondition::Load` was obviously patched up along the years. Upon error, it could
- throw a LogException (unhandled)
- throw XMLLogException  (unhandled)
- return false  

It is now unified to return false in all cases. Functions inside Load( ) which could throw are now guarded by a try / catch.

Other corrected minor issue: the reading of engine configuration was done directly in FGInitialCondition::Load( ), instead of being done in the functions Load_v1 or Load_v2 like any other tag.

### Current usage in the codebase
In the codebase, Load( ) was called in two different places:

https://github.com/JSBSim-Team/jsbsim/blob/98c03332e75ac5749fb2f699700154130e2a3a38/src/input_output/FGScript.cpp#L195-L200

https://github.com/JSBSim-Team/jsbsim/blob/98c03332e75ac5749fb2f699700154130e2a3a38/src/JSBSim.cpp#L477-L482

In both cases, the return value ( true or false ) was correctly checked, nothing to do there.

### Testing
Testing in command line, the errors are caught correctly and JSBSim terminates with the proper error message, instead of terminate suddenly with FATAL ERROR and less log:

```
Could not open file: Path "aircraft/c172r/reset0.xml"
Init file: Path "aircraft/c172r/reset0" could not be loaded.
Initialization unsuccessful
Script file Path "scripts/c1721.xml" was not successfully loaded

D:\DEV\jsbsim>
```
```
In file aircraft/c172r/reset00.xml: line 16
XML parse error: mismatched tag
Error parsing Path "aircraft/c172r/reset00"
In file aircraft/c172r/reset00.xml: line 16
XML parse error: mismatched tagInitialization unsuccessful
Script file Path "scripts/c1721.xml" was not successfully loaded

D:\DEV\jsbsim\Debug\JSBSim.exe (process 2552) exited with code -1 (0xffffffff).
```