### PR TITLE
Add warning for duplicate <gain> elements in FGGain (#497)

### DIFF
--- a/src/models/flight_control/FGGain.cpp
+++ b/src/models/flight_control/FGGain.cpp
@@ -70,10 +70,18 @@ FGGain::FGGain(FGFCS* fcs, Element* element) : FGFCSComponent(fcs, element)
 
   auto PropertyManager = fcs->GetPropertyManager();
   Element* gain_element = element->FindElement("gain");
-  if (gain_element)
+  if (gain_element) {
     Gain = new FGParameterValue(gain_element, PropertyManager);
-  else
+    // Warn if duplicate <gain> elements are provided
+    if (element->FindNextElement("gain")) {
+      FGXMLLogging log(element, LogLevel::ERROR);
+      log << "      Multiple <gain> elements specified.\n"
+          << "      Only the first <gain> value will be used,"
+          << " the remaining ones are ignored.\n";
+    }
+  } else {
     Gain = new FGRealValue(1.0);
+  }
 
   if (Type == "AEROSURFACE_SCALE") {
     Element* scale_element = element->FindElement("domain");


### PR DESCRIPTION
When multiple <gain> elements are specified in a pure_gain, scheduled_gain, or aerosurface_scale component, only the first is used. This adds an error-level warning so users are notified of the misconfiguration, following the existing pattern from CheckInputNodes() in FGFCSComponent.cpp.

Addresses the remaining duplicate element detection issue from #497.

Note: This code was written entirely by Claude Opus 4 (Anthropic AI Assistant) via Claude Code. The human contributor directed the project selection and submitted the PR.