### PR TITLE
Improvements to the Python stub file

### DIFF
--- a/python/cython.lark
+++ b/python/cython.lark
@@ -32,17 +32,19 @@ ctemplate_type: name "[" ctype "]"
 pointer_type: (name | ctemplate_type) "*"
 ref_type: (name | ctemplate_type) "&"
 const_type: "const" (name | ref_type | pointer_type | ctemplate_type)
-ctype: name | ref_type | pointer_type | const_type | ctemplate_type
+?ctype: name | ref_type | pointer_type | const_type | ctemplate_type
 
 conversion: "<" ctype ">" name
 new_param: "new" name "(" [arguments] ")"
 cyassign: testlist_star_expr "=" (testlist_star_expr "=")* (new_param | conversion | ctemplate_type "(" [cparameters] ")")
-?ctypedparam: ctype name
-cparameter: (ctypedparam ("=" test)?) | conversion | paramvalue
+ctypedparam: ctype name
+ref_argvalue: "&" argvalue
+?cparamvalue: ctypedparam ("=" (argvalue | ref_argvalue))?
+?cparameter: cparamvalue | conversion | paramvalue
 cparameters: cparameter ("," cparameter)* ["," [starparams | kwparams]]
 cyfuncdef: name "(" [cparameters] ")" ":" suite
 cyclassdef: "class" name ["(" [arguments] ")"] ":" suite
-cdeclare_var: ctypedparam ("=" "&"? argvalue)? _NEWLINE
+cdeclare_var: cparamvalue _NEWLINE
 cdef_stmt: "cdef" (cdeclare_var | cyfuncdef | cyclassdef)
 
 %extend import_stmt: cimport_from

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -825,11 +825,11 @@ cdef class FGFDMExec(FGJSBBase):
     cdef c_FGFDMExec *thisptr      # hold a C++ instance which we're wrapping
     cdef dict properties_cache     # Dictionary cache of property nodes
 
-    def __cinit__(self, root_dir, FGPropertyManager pm_root=None, *args,
-                  **kwargs):
+    def __cinit__(self, root_dir: Optional[str],
+                  pm_root: Optional[FGPropertyManager] = None, *args, **kwargs):
         cdef c_FGPropertyManager* root
 
-        if pm_root:
+        if pm_root is not None:
             root = pm_root.thisptr.get()
         else:
             root = NULL
@@ -838,7 +838,7 @@ cdef class FGFDMExec(FGJSBBase):
         if self.thisptr is NULL:
             raise MemoryError()
 
-        if root_dir:
+        if root_dir is not None:
             if not os.path.isdir(root_dir):
                 raise IOError("Can't find root directory: {0}".format(root_dir))
             self.set_root_dir(root_dir)

--- a/python/pyxstubgen.py
+++ b/python/pyxstubgen.py
@@ -200,6 +200,8 @@ class GenerateStub(Interpreter):
     def python__annassign(self, tree: Tree) -> None:
         assert len(tree.children) == 3
         name = self.get_varname(tree.children[0])
+        if name[0] == "_" and (name[1] != "_" or name[-2:] != "__"):
+            return
         typename = self.get_varname(tree.children[1])
         value = self.visit(tree.children[2])
         instruction = f"{name}: {typename} = {value}"
@@ -210,6 +212,8 @@ class GenerateStub(Interpreter):
 
     def python__assign(self, tree: Tree) -> None:
         name = self.get_varname(tree.children[0])
+        if name[0] == "_" and (name[1] != "_" or name[-2:] != "__"):
+            return
         value_item = tree.children[1]
         value = self.visit(value_item)
         if value_item.data == "python__getattr":

--- a/python/pyxstubgen.py
+++ b/python/pyxstubgen.py
@@ -243,6 +243,13 @@ class GenerateStub(Interpreter):
         param_type = self.visit(tree.children[1])
         return param_name, param_type
 
+    def ctypedparam(self, tree: Tree) -> Tuple[str, str]:
+        assert len(tree.children) == 2
+        param_type = rule_name(tree.children[0])
+        assert isinstance(tree.children[1], Tree)
+        param_name = rule_name(tree.children[1])
+        return param_name, param_type
+
     def python__number(self, tree: Tree) -> str:
         assert len(tree.children) == 1
         assert isinstance(tree.children[0], Token)
@@ -261,81 +268,93 @@ class GenerateStub(Interpreter):
         if decorator_name[0] != "_":
             self.output.write(f"\n{self.TAB_SPACES*self.indent}@{decorator_name}")
 
+    def cyfuncdef(self, tree:Tree) -> None:
+        self.funcdef(tree)
+
+    def cdeclare_var(self, _tree:Tree) -> None:
+        pass
+
+    def cparameters(self, tree:Tree) -> List[str]:
+        parameters: List[str] = []
+        for parameter in tree.children:
+            if parameter is None:
+                continue
+
+            assert isinstance(parameter, Tree)
+            if isinstance(parameter.data, Token):
+                assert parameter.data.type == "RULE"
+                if parameter.data.value == "name":
+                    parameters.append(rule_name(parameter))
+                elif parameter.data.value in ("paramvalue", "cparamvalue"):
+                    assert len(parameter.children) == 2
+                    pname, ptype = self.visit(parameter.children[0])
+                    value = parameter.children[1]
+                    assert isinstance(value, Tree)
+                    if value.data in (
+                        "python__number",
+                        "python__string",
+                    ):
+                        pvalue = self.visit(value)
+                    elif value.data == "python__getattr":
+                        pvalue = ".".join(self.visit(value))
+                    else:
+                        pvalue = get_constant(value)
+                    parameters.append(f"{pname}: {ptype} = {pvalue}")
+                elif parameter.data.value == "ctypedparam":
+                    pname, ptype = self.visit(parameter)
+                    parameters.append(f"{pname}: {ptype}")
+                elif parameter.data.value == "starparams":
+                    pass
+                else:
+                    raise TypeError(
+                        f"Unknown parameter type: {repr(parameter)}"
+                    )
+            elif isinstance(parameter.data, str) and parameter.data in (
+                "python__typedparam",
+                "ctypedparam",
+            ):
+                pname, ptype = self.visit(parameter)
+                parameters.append(f"{pname}: {ptype}")
+            else:
+                raise TypeError(
+                    f"Unknown parameter type: {repr(parameter)}"
+                )
+
+        return parameters
+
     def funcdef(self, tree: Tree) -> None:
         func_name: str = ""
         docstring: str = ""
-        for i, child in enumerate(tree.children):
-            if child is None:
-                if i == 1:
-                    func_name += "()"  # This function has no parameter
-                continue
 
-            assert isinstance(child, Tree)
-            child_type: Union[str, Token] = child.data
-            if isinstance(child_type, Token):
-                if child_type.value == "name":  # Get the function
-                    func_name = rule_name(child)
-                    if func_name in ("__cinit__", "__dealloc__"):
-                        return
-                    if func_name[0] == "_" and func_name[1] != "_":
-                        return
-                elif child_type.value == "cparameters":  # Get the function parameters
-                    parameters: List[str] = []
-                    for cparameter in child.children:
-                        if cparameter is None:
-                            continue
+        func_name = rule_name(tree.children[0])
+        is_cinit = func_name == "__cinit__"
+        if is_cinit:
+            func_name = "__init__"
+        elif func_name[0] == "_":
+            if func_name[1] != "_":
+                return
+            if func_name[-2:] != "__" or func_name == "__dealloc__":
+                return
 
-                        assert isinstance(cparameter, Tree)
-                        cparam_type: Token = cparameter.data
-                        assert isinstance(cparam_type, Token)
-                        if cparam_type.value == "cparameter":
-                            assert len(cparameter.children) == 1
-                            parameter = cparameter.children[0]
-                            assert isinstance(parameter, Tree)
-                            if isinstance(parameter.data, Token):
-                                if parameter.data == "name":
-                                    parameters.append(rule_name(parameter))
-                                elif parameter.data == "paramvalue":
-                                    assert len(parameter.children) == 2
-                                    pname, ptype = self.visit(parameter.children[0])
-                                    value = parameter.children[1]
-                                    assert isinstance(value, Tree)
-                                    if value.data in (
-                                        "python__number",
-                                        "python__string",
-                                    ):
-                                        pvalue = self.visit(value)
-                                    elif value.data == "python__getattr":
-                                        pvalue = ".".join(self.visit(value))
-                                    else:
-                                        pvalue = get_constant(value)
-                                    parameters.append(f"{pname}: {ptype} = {pvalue}")
-                                else:
-                                    raise TypeError(
-                                        f"Unknown parameter type in {func_name}: {repr(parameter)}"
-                                    )
-                            elif (
-                                isinstance(parameter.data, str)
-                                and parameter.data == "python__typedparam"
-                            ):
-                                pname, ptype = self.visit(parameter)
-                                parameters.append(f"{pname}: {ptype}")
-                            else:
-                                raise TypeError(
-                                    f"Uknown parameter type in {func_name}: {repr(parameter)}"
-                                )
-                        else:
-                            raise TypeError(
-                                f"Unknown parameter type in {func_name}: {repr(cparameter)}"
-                            )
-                    func_name += f"({', '.join(parameters)})"
-                else:
-                    assert child_type.value == "suite"
-                    docstring = self.extract_docstring(child)
-            elif isinstance(child_type, str):
-                func_name += f" -> {self.get_varname(child)}"
-            else:
-                raise TypeError(f"Unknown parameter in {func_name}: {repr(child)}")
+        params_item = tree.children[1]
+        if params_item is None:
+            func_name += "()"
+        else:
+            parameters = self.visit(params_item)
+            func_name += f"({', '.join(parameters)})"
+
+        output_type = tree.children[2]
+        if output_type is not None:
+            assert isinstance(output_type, Tree)
+            if isinstance(output_type.data, str):
+                func_name += f" -> {self.get_varname(output_type)}"
+
+        suite_item = tree.children[3]
+        assert isinstance(suite_item, Tree)
+        assert isinstance(suite_item.data, Token)
+        assert suite_item.data.type == "RULE"
+        assert suite_item.data == "suite"
+        docstring = self.extract_docstring(suite_item)
 
         self.has_members = True
         prefix = self.TAB_SPACES * self.indent

--- a/python/pyxstubgen.py
+++ b/python/pyxstubgen.py
@@ -22,7 +22,7 @@
 
 import argparse
 import io
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from lark import Lark
 from lark.indenter import PythonIndenter
@@ -197,6 +197,26 @@ class GenerateStub(Interpreter):
         else:
             return get_constant(tree)
 
+    def python__annassign(self, tree: Tree) -> None:
+        assert len(tree.children) == 3
+        name = self.get_varname(tree.children[0])
+        typename = self.get_varname(tree.children[1])
+        value = self.visit(tree.children[2])
+        instruction = f"{name}: {typename} = {value}"
+        if self.indent == 0:
+            self.output.write(f"\n{instruction}\n")
+        else:
+            self.output.write(f"\n{self.TAB_SPACES * self.indent}{instruction}")
+
+    def python__assign(self, tree: Tree) -> None:
+        name = self.get_varname(tree.children[0])
+        value_item = tree.children[1]
+        value = self.visit(value_item)
+        if value_item.data == "python__getattr":
+            value = ".".join(value)
+        self.has_members = True
+        self.output.write(f"\n{self.TAB_SPACES * self.indent}{name} = {value}")
+
     def python__classdef(self, tree: Tree) -> None:
         class_name: str = ""
         for child in tree.children:
@@ -268,13 +288,13 @@ class GenerateStub(Interpreter):
         if decorator_name[0] != "_":
             self.output.write(f"\n{self.TAB_SPACES*self.indent}@{decorator_name}")
 
-    def cyfuncdef(self, tree:Tree) -> None:
+    def cyfuncdef(self, tree: Tree) -> None:
         self.funcdef(tree)
 
-    def cdeclare_var(self, _tree:Tree) -> None:
+    def cdeclare_var(self, _tree: Tree) -> None:
         pass
 
-    def cparameters(self, tree:Tree) -> List[str]:
+    def cparameters(self, tree: Tree) -> List[str]:
         parameters: List[str] = []
         for parameter in tree.children:
             if parameter is None:
@@ -306,9 +326,7 @@ class GenerateStub(Interpreter):
                 elif parameter.data.value == "starparams":
                     pass
                 else:
-                    raise TypeError(
-                        f"Unknown parameter type: {repr(parameter)}"
-                    )
+                    raise TypeError(f"Unknown parameter type: {repr(parameter)}")
             elif isinstance(parameter.data, str) and parameter.data in (
                 "python__typedparam",
                 "ctypedparam",
@@ -316,9 +334,7 @@ class GenerateStub(Interpreter):
                 pname, ptype = self.visit(parameter)
                 parameters.append(f"{pname}: {ptype}")
             else:
-                raise TypeError(
-                    f"Unknown parameter type: {repr(parameter)}"
-                )
+                raise TypeError(f"Unknown parameter type: {repr(parameter)}")
 
         return parameters
 

--- a/python/pyxstubgen.py
+++ b/python/pyxstubgen.py
@@ -113,32 +113,16 @@ class GenerateStub(Interpreter):
         if not tree.children or not isinstance(tree.children[0], Tree):
             return ""
 
-        # Navigate through the AST to find a string literal
-        # Expected path: tree -> simple_stmt -> expr_stmt -> string
-        current = tree.children[0]
-
-        while isinstance(current, Tree):
-            stmt_data: Union[str, Token] = current.data
-
-            if isinstance(stmt_data, Token):
-                if stmt_data.value in ("simple_stmt", "expr_stmt") and current.children:
-                    current = current.children[0]
-                    continue
-            elif isinstance(stmt_data, str):
-                if stmt_data == "python__string":
-                    # Found a string - this is our docstring
-                    return self.visit(current)
-                elif (
-                    stmt_data in ("python__simple_stmt", "python__expr_stmt")
-                    and current.children
-                ):
-                    current = current.children[0]
-                    continue
-
-            # If we get here, we couldn't navigate further or it's not a docstring
+        first_statement = tree.children[0]
+        if first_statement.data != "python__expr_stmt" or not first_statement.children:
             return ""
 
-        return ""
+        assert len(first_statement.children) == 1
+        content = first_statement.children[0]
+        if not isinstance(content, Tree) or content.data != "python__string":
+            return ""
+
+        return self.visit(content)
 
     def python__dotted_as_name(self, tree: Tree) -> str:
         assert len(tree.children) == 2
@@ -293,7 +277,7 @@ class GenerateStub(Interpreter):
                     func_name = rule_name(child)
                     if func_name in ("__cinit__", "__dealloc__"):
                         return
-                    if  func_name[0] == "_" and func_name[1] != '_':
+                    if func_name[0] == "_" and func_name[1] != "_":
                         return
                 elif child_type.value == "cparameters":  # Get the function parameters
                     parameters: List[str] = []
@@ -322,7 +306,7 @@ class GenerateStub(Interpreter):
                                     ):
                                         pvalue = self.visit(value)
                                     elif value.data == "python__getattr":
-                                        pvalue = '.'.join(self.visit(value))
+                                        pvalue = ".".join(self.visit(value))
                                     else:
                                         pvalue = get_constant(value)
                                     parameters.append(f"{pname}: {ptype} = {pvalue}")


### PR DESCRIPTION
After having cumulated some experience using version 1.3.0 on VS Code, this PR improves our [Python stub file](https://typing.python.org/en/latest/guides/writing_stubs.html) i.e. the file `__init__.pyi`. As a reminder the stub file is automatically built using the script `pyxstubgen.py` (see PR #1287) during the CI workflow: 

https://github.com/JSBSim-Team/jsbsim/blob/e420cef6997582d7fb2176effe87a2ea5f04ece5/.github/workflows/cpp-python-build.yml#L498-L502

The stub file is **not** built by CMake.

The following improvements have been brought:
* The Cython constructors `__cinit__` are converted to `__init__` constructors with a regular Python signature. This conversion is limited to the stub file and **has no impact on the actual code**. It is aimed at emulating `__cinit__` for Python language servers such as [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) and [jedi](https://jedi.readthedocs.io/en/latest/).
* Global variables such as `__version__` and public class members such as `FGLogger.log_level` or `LogLevel.DEBUG` are exposed to the stub file. This is to allow auto-completion when using these variables and members.
* Class names and variable names starting with an underscore are not exposed in the stub file unless they are starting and ending with a double underscore (such as `__bool__` or `__getitem__`).

I took this opportunity to simplify the method `extract_docstring` in `pyxstubgen.py` as well as to fix the parameter types for the constructor `__cinit__` of `FGFDMEXec`. The management of the "rule" `cparameters` has been moved from the method `funcdef` to its own method `cparameters` to make the method `funcdef` easier to read.