### PR TITLE
Filter out JOSS paper from CodeQL, Coverage and C++ Build workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,9 +8,15 @@ name: "CodeQL"
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - "**/*.md"
+      - "joss_paper/**"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
+    paths-ignore:
+      - "**/*.md"
+      - "joss_paper/**"
   schedule:
     - cron: '0 9 * * 2'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches-ignore:
       - 'dependabot/**'
+    paths-ignore:
+      - "**/*.md"
+      - "joss_paper/**"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "joss_paper/**"
 
 jobs:
   Codecov:

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -6,9 +6,11 @@ on:
       - 'dependabot/**'
     paths-ignore:
       - "**/*.md"
+      - "joss_paper/**"
   pull_request:
     paths-ignore:
       - "**/*.md"
+      - "joss_paper/**"
 
 env:
   release: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}


### PR DESCRIPTION
Filter out `joss_paper` directory and `*.md` in whole repo from invoking the CodeQL, Coverage and C++ Python build workflows.