### PR TITLE
Ignore Python notebooks.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,12 +11,14 @@ on:
     paths-ignore:
       - "**/*.md"
       - "joss_paper/**"
+      - "**/*.ipynb"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
     paths-ignore:
       - "**/*.md"
       - "joss_paper/**"
+      - "**/*.ipynb"
   schedule:
     - cron: '0 9 * * 2'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,10 +7,12 @@ on:
     paths-ignore:
       - "**/*.md"
       - "joss_paper/**"
+      - "**/*.ipynb"
   pull_request:
     paths-ignore:
       - "**/*.md"
       - "joss_paper/**"
+      - "**/*.ipynb"
 
 jobs:
   Codecov:

--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -7,10 +7,12 @@ on:
     paths-ignore:
       - "**/*.md"
       - "joss_paper/**"
+      - "**/*.ipynb"
   pull_request:
     paths-ignore:
       - "**/*.md"
       - "joss_paper/**"
+      - "**/*.ipynb"
 
 env:
   release: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}


### PR DESCRIPTION
In addition to MarkDown files, this PR modifies the CI workflow to ignore Python notebooks modifications.

**Reminder:** commits containing **only** some modifications of one or several Python notebooks will be ignored. If the commit modifies some other files that do not match the `paths-ignore:` filter then the `push`/`pull_request` event will trigger the workflow.