### PR TITLE
Expose Input enable/disable and implement for additional cases

### DIFF
--- a/python/jsbsim.pxd
+++ b/python/jsbsim.pxd
@@ -249,6 +249,8 @@ cdef extern from "FGFDMExec.h" namespace "JSBSim":
         void DoTrim(int mode) except +convertJSBSimToPyExc
         void DisableOutput()
         void EnableOutput()
+        void DisableInput()
+        void EnableInput()
         void Hold()
         void EnableIncrementThenHold(int time_steps)
         void CheckIncrementalHold()

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -1018,6 +1018,14 @@ cdef class FGFDMExec(FGJSBBase):
         """@Dox(JSBSim::FGFDMExec::EnableOutput)"""
         self.thisptr.EnableOutput()
 
+    def disable_input(self) -> None:
+        """@Dox(JSBSim::FGFDMExec::DisableInput)"""
+        self.thisptr.DisableInput()
+
+    def enable_input(self) -> None:
+        """@Dox(JSBSim::FGFDMExec::EnableInput)"""
+        self.thisptr.EnableInput()
+
     def hold(self) -> None:
         """@Dox(JSBSim::FGFDMExec::Hold)"""
         self.thisptr.Hold()

--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -45,6 +45,7 @@ INCLUDES
 
 #include "models/FGPropagate.h"
 #include "models/FGOutput.h"
+#include "models/FGInput.h"
 #include "math/FGTemplateFunc.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -66,7 +67,6 @@ class FGExternalReactions;
 class FGGroundReactions;
 class FGFCS;
 class FGInertial;
-class FGInput;
 class FGPropulsion;
 class FGMassBalance;
 class FGLogger;
@@ -485,6 +485,10 @@ public:
   void DisableOutput(void) { Output->Disable(); }
   /// Enables data logging to all outputs.
   void EnableOutput(void) { Output->Enable(); }
+  /// Disables input from all inputs.
+  void DisableInput(void) { Input->Disable(); }
+  /// Enables input from all inputs.
+  void EnableInput(void) { Input->Enable(); }
   /// Pauses execution by preventing time from incrementing.
   void Hold(void) {holding = true;}
   /// Turn on hold after increment

--- a/src/input_output/FGInputSocket.cpp
+++ b/src/input_output/FGInputSocket.cpp
@@ -98,7 +98,6 @@ bool FGInputSocket::InitModel(void)
 
 bool FGInputSocket::CreateSocket()
 {
-  socket.reset(); // close any existing socket
   socket = std::make_unique<FGfdmSocket>(SockPort, SockProtocol);
 
   if (!socket) return false;

--- a/src/input_output/FGInputSocket.cpp
+++ b/src/input_output/FGInputSocket.cpp
@@ -53,8 +53,8 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGInputSocket::FGInputSocket(FGFDMExec* fdmex) :
-  FGInputType(fdmex), socket(0), SockProtocol(FGfdmSocket::ptTCP),
+FGInputSocket::FGInputSocket(FGFDMExec* fdmex, bool isEnabled) :
+  FGInputType(fdmex, isEnabled), SockProtocol(FGfdmSocket::ptTCP),
   BlockingInput(false)
 {
 }
@@ -63,7 +63,7 @@ FGInputSocket::FGInputSocket(FGFDMExec* fdmex) :
 
 FGInputSocket::~FGInputSocket()
 {
-  delete socket;
+  socket.reset();
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -92,17 +92,56 @@ bool FGInputSocket::Load(Element* el)
 
 bool FGInputSocket::InitModel(void)
 {
-  if (FGInputType::InitModel()) {
-    delete socket;
-    socket = new FGfdmSocket(SockPort, SockProtocol);
+  if (!FGInputType::InitModel())
+    return false;
 
-    if (socket == 0) return false;
-    if (!socket->GetConnectStatus()) return false;
+  if (enabled)
+    return CreateSocket();
 
-    return true;
-  }
+  return true;
+}
 
-  return false;
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+bool FGInputSocket::CreateSocket()
+{
+  socket.reset(); // close any existing socket
+  socket = std::make_unique<FGfdmSocket>(SockPort, SockProtocol);
+
+  if (!socket) return false;
+  if (!socket->GetConnectStatus()) return false;
+
+  return true;
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+void FGInputSocket::Enable()
+{
+  if (enabled) return; // already enabled
+  FGInputType::Enable();
+  CreateSocket();
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+void FGInputSocket::Disable()
+{
+  FGInputType::Disable();
+  socket.reset();
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+bool FGInputSocket::Toggle()
+{
+  bool enabled_status = FGInputType::Toggle();
+  if (enabled_status)
+    CreateSocket();
+  else
+    socket.reset();
+
+  return enabled_status;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/input_output/FGInputSocket.cpp
+++ b/src/input_output/FGInputSocket.cpp
@@ -61,13 +61,6 @@ FGInputSocket::FGInputSocket(FGFDMExec* fdmex, bool isEnabled) :
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-FGInputSocket::~FGInputSocket()
-{
-  socket.reset();
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
 bool FGInputSocket::Load(Element* el)
 {
   if (!FGInputType::Load(el))

--- a/src/input_output/FGInputSocket.h
+++ b/src/input_output/FGInputSocket.h
@@ -65,9 +65,6 @@ public:
   /** Constructor. */
   FGInputSocket(FGFDMExec* fdmex, bool isEnabled);
 
-  /** Destructor. */
-  ~FGInputSocket() override;
-
   /** Init the input directives from an XML file.
       @param element XML Element that is pointing to the input directives
   */

--- a/src/input_output/FGInputSocket.h
+++ b/src/input_output/FGInputSocket.h
@@ -63,7 +63,7 @@ class FGInputSocket : public FGInputType
 {
 public:
   /** Constructor. */
-  FGInputSocket(FGFDMExec* fdmex);
+  FGInputSocket(FGFDMExec* fdmex, bool isEnabled);
 
   /** Destructor. */
   ~FGInputSocket() override;
@@ -82,10 +82,17 @@ public:
   /// Generates the input.
   void Read(bool Holding) override;
 
+  /// Methods to enable, disable and toggle the input
+  void Enable() override;
+  void Disable() override;
+  bool Toggle() override;
+
 protected:
 
+  bool CreateSocket();
+
   unsigned int SockPort;
-  FGfdmSocket* socket;
+  std::unique_ptr<FGfdmSocket> socket;
   FGfdmSocket::ProtocolType SockProtocol;
   std::string data;
   bool BlockingInput;

--- a/src/input_output/FGInputType.cpp
+++ b/src/input_output/FGInputType.cpp
@@ -49,8 +49,8 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGInputType::FGInputType(FGFDMExec* fdmex) :
-  FGModel(fdmex), enabled(true)
+FGInputType::FGInputType(FGFDMExec* fdmex, bool isEnabled) :
+  FGModel(fdmex), enabled(isEnabled)
 {
   Debug(0);
 }

--- a/src/input_output/FGInputType.h
+++ b/src/input_output/FGInputType.h
@@ -76,7 +76,7 @@ public:
   /** Constructor (implement the FGModel interface).
       @param fdmex a pointer to the parent executive object
    */
-  FGInputType(FGFDMExec* fdmex);
+  FGInputType(FGFDMExec* fdmex, bool isEnabled=true);
 
   /// Destructor
   ~FGInputType() override;
@@ -109,13 +109,13 @@ public:
   virtual void Read(bool Holding) = 0;
 
   /// Enables the input generation.
-  void Enable(void) { enabled = true; }
+  virtual void Enable(void) { enabled = true; }
   /// Disables the input generation.
-  void Disable(void) { enabled = false; }
+  virtual void Disable(void) { enabled = false; }
   /** Toggles the input generation.
       @result the input generation status i.e. true if the input has been
               enabled, false if the input has been disabled. */
-  bool Toggle(void) {enabled = !enabled; return enabled;}
+  virtual bool Toggle(void) {enabled = !enabled; return enabled;}
 
   /** Overwrites the name identifier under which the input will be read.
       This method is taken into account if it is called before

--- a/src/input_output/FGUDPInputSocket.cpp
+++ b/src/input_output/FGUDPInputSocket.cpp
@@ -90,7 +90,7 @@ bool FGUDPInputSocket::Load(Element* el)
 
 void FGUDPInputSocket::Read(bool Holding)
 {
-  if (socket == 0) return;
+  if (!socket) return;
 
   data = socket->Receive();
 

--- a/src/input_output/FGUDPInputSocket.cpp
+++ b/src/input_output/FGUDPInputSocket.cpp
@@ -51,8 +51,8 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGUDPInputSocket::FGUDPInputSocket(FGFDMExec* fdmex) :
-  FGInputSocket(fdmex), rate(20), oldTimeStamp(0.0)
+FGUDPInputSocket::FGUDPInputSocket(FGFDMExec* fdmex, bool isEnabled) :
+  FGInputSocket(fdmex, isEnabled), rate(20), oldTimeStamp(0.0)
 {
   SockPort = 5139;
   SockProtocol = FGfdmSocket::ptUDP;

--- a/src/input_output/FGUDPInputSocket.h
+++ b/src/input_output/FGUDPInputSocket.h
@@ -61,7 +61,7 @@ class FGUDPInputSocket : public FGInputSocket
 {
 public:
   /** Constructor. */
-  FGUDPInputSocket(FGFDMExec* fdmex);
+  FGUDPInputSocket(FGFDMExec* fdmex, bool isEnabled=true);
 
   /** Reads the property names from an XML file.
       @param element The root XML Element of the input file.

--- a/src/models/FGInput.cpp
+++ b/src/models/FGInput.cpp
@@ -101,9 +101,9 @@ bool FGInput::Load(Element* el)
   type = to_upper(type);
 
   if (type.empty() || type == "SOCKET") {
-    Input = new FGInputSocket(FDMExec);
+    Input = new FGInputSocket(FDMExec, enabled);
   } else if (type == "QTJSBSIM") {
-    Input = new FGUDPInputSocket(FDMExec);
+    Input = new FGUDPInputSocket(FDMExec, enabled);
   } else if (type != string("NONE")) {
     FGXMLLogging log(element, LogLevel::ERROR);
     log << "Unknown type of input specified in config file" << endl;
@@ -203,6 +203,23 @@ string FGInput::GetInputName(unsigned int idx) const
   return name;
 }
 
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+/// Enables the input generation for all input instances.
+void FGInput::Enable(void)
+{
+  enabled = true;
+  for (auto input : InputTypes)
+    input->Enable();
+}
+
+/// Disables the input generation for all input instances.
+void FGInput::Disable(void)
+{
+  enabled = false;
+  for (auto input : InputTypes)
+    input->Disable();
+}
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 //    The bitmasked value choices are as follows:

--- a/src/models/FGInput.h
+++ b/src/models/FGInput.h
@@ -118,9 +118,9 @@ public:
   bool SetDirectivesFile(const SGPath& fname);
 
   /// Enables the input generation for all input instances.
-  void Enable(void) { enabled = true; }
+  void Enable(void);
   /// Disables the input generation for all input instances.
-  void Disable(void) { enabled = false; }
+  void Disable(void);
   /** Toggles the input generation of each input instance.
       @param idx ID of the input instance which input generation will be
                  toggled.


### PR DESCRIPTION
As per discussion - https://github.com/JSBSim-Team/jsbsim/discussions/1428 this PR adds `DisableInput` and `EnableInput` to `FGFDMExec` to allow clients to control whether any inputs are enabled or disabled.

- Add `FGFDMExec::DisableInput()` and `FGFDMExec::EnableInput()`
- Add python wrappers `FGFDMExec.disable_input()` and `FGFDMExec.enable_input()`
- Use of `std::unique_ptr<FGfdmSocket>` in place of original raw pointer for `socket` in `FGInputSocket`.

`FGFDMExec` contains a single `FGInput` instance which in turn has a `std::vector<FGInputType*>` containing each of the input types that are defined in the aircraft's FDM etc.

There was already `Enable() Disable()` logic in `FGInput`, updating an `enable` field, which is then used within `FGInput::Run()` to potentially not call `FGInputType::Run()` for all of the input instances .

```c++
bool FGInput::Run(bool Holding)
{
  if (FDMExec->GetTrimStatus()) return true;
  if (FGModel::Run(Holding)) return true;
  if (!enabled) return true;

  vector<FGInputType*>::iterator it;
  for (it = InputTypes.begin(); it != InputTypes.end(); ++it)
    (*it)->Run(Holding);

  return false;
}
```

So this would then prevent a socket based input type from reading from a socket. However there was no mechanism to pass on this change in enabled state to the input types for a global change in enabled state for the `FGInput` instance. Which means the input types couldn't close their socket.

Also there was no way to disable an input type so that between creation and it's `InitModel()` method being called it would know not to bother creating a socket.

So the current enabled state of `FGInput` is now passed along to the ctors of the `FGInputType` classes.

```c++
  if (type.empty() || type == "SOCKET") {
    Input = new FGInputSocket(FDMExec, enabled);
  } else if (type == "QTJSBSIM") {
    Input = new FGUDPInputSocket(FDMExec, enabled);
  } 
```

So there was a bit more logic that needed to be added compared to what I was expecting when I started.

So now a user, especially one concerned about running multiple instances at the same time of an aircraft with socket based inputs defined in it's FDM can use the following logic to prevent any sockets being created by any instance so that there is no concurrency clash with regards to creating a listening UDP/TCP socket on the same port.

```python
fdm = jsbsim.FGFDMExec(None)
fdm.disable_input()
fdm.load_model('737')
```

A user can also toggle the enabled state during execution, e.g.

```python
fdm = jsbsim.FGFDMExec(None)
fdm.load_model('737')
while true:
   if some_condition:
      fdm.disable_input()
   if some_other_condition:
      fdm.enable_input()
   fdm.run()
```