### PR TITLE
Don't upload binaries compiled with the expat DLL.

### DIFF
--- a/.github/workflows/cpp-python-build.yml
+++ b/.github/workflows/cpp-python-build.yml
@@ -380,7 +380,7 @@ jobs:
 
       - name: Upload Files for Release
         uses: actions/upload-artifact@v7
-        if: env.release == 'true' && matrix.shared_libs == 'OFF'
+        if: env.release == 'true' && matrix.shared_libs == 'OFF' && matrix.expat == 'OFF'
         with:
           name: ${{ runner.os }}.binaries
           path: |


### PR DESCRIPTION
Following the PR #1458, the artifact `Windows.binaries.zip` is uploaded twice by the job `Windows-MSVC`, one when `matrix.expat` is `OFF` and another one when it is `ON`:
https://github.com/JSBSim-Team/jsbsim/blob/4709ae730eb129b2c225d52bbd7144d0c18b9a3b/.github/workflows/cpp-python-build.yml#L381-L385
As a result, the job `Windows-installer` is now failing when it downloads the version of `Windows.binaries.zip` that has been compiled against the Expat DLL: `JSBSim.exe` fails because the Expat DLL is missing
https://github.com/JSBSim-Team/jsbsim/blob/4709ae730eb129b2c225d52bbd7144d0c18b9a3b/.github/workflows/cpp-python-build.yml#L414-L417
The fix is quite obvious and consists in only uploading the artifact with the JSBSim executable compiled with the embedded version of Expat.