### PR TITLE
Don't assume STDOUT LogLevel for all calls to FGTable::Print()

### DIFF
--- a/src/math/FGTable.cpp
+++ b/src/math/FGTable.cpp
@@ -749,6 +749,12 @@ FGTable& FGTable::operator<<(const double x)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+void FGTable::Print()
+{
+  FGLogging out(LogLevel::STDOUT);
+  Print(out);
+}
+
 void FGTable::Print(FGLogging& out)
 {
   out << std::setprecision(4);

--- a/src/math/FGTable.cpp
+++ b/src/math/FGTable.cpp
@@ -469,7 +469,10 @@ FGTable::FGTable(std::shared_ptr<FGPropertyManager> pm, Element* el,
 
   bind(el, Prefix);
 
-  if (debug_lvl & 1) Print();
+  if (debug_lvl & 1) {
+    FGLogging out(LogLevel::DEBUG);
+    Print(out);
+  }
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -746,9 +749,8 @@ FGTable& FGTable::operator<<(const double x)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGTable::Print(void)
+void FGTable::Print(FGLogging& out)
 {
-  FGLogging out(LogLevel::STDOUT);
   out << std::setprecision(4);
 
   switch(Type) {
@@ -785,7 +787,7 @@ void FGTable::Print(void)
       out << Data[p++] << "\t";
       if (Type == ttND) {
         out << "\n";
-        Tables[r-1]->Print();
+        Tables[r-1]->Print(out);
       }
     }
     out << "\n";

--- a/src/math/FGTable.h
+++ b/src/math/FGTable.h
@@ -411,7 +411,8 @@ public:
 
   unsigned int GetNumRows() const {return nRows;}
 
-  void Print(FGLogging& out = FGLogging(LogLevel::STDOUT));
+  void Print();
+  void Print(FGLogging& out);
 
   std::string GetName(void) const {return Name;}
 

--- a/src/math/FGTable.h
+++ b/src/math/FGTable.h
@@ -411,7 +411,7 @@ public:
 
   unsigned int GetNumRows() const {return nRows;}
 
-  void Print(FGLogging& out);
+  void Print(FGLogging& out = FGLogging(LogLevel::STDOUT));
 
   std::string GetName(void) const {return Name;}
 

--- a/src/math/FGTable.h
+++ b/src/math/FGTable.h
@@ -411,7 +411,7 @@ public:
 
   unsigned int GetNumRows() const {return nRows;}
 
-  void Print(void);
+  void Print(FGLogging& out);
 
   std::string GetName(void) const {return Name;}
 

--- a/src/models/flight_control/FGGain.cpp
+++ b/src/models/flight_control/FGGain.cpp
@@ -214,7 +214,7 @@ void FGGain::Debug(int from)
       }
       if (Table) {
         log << "      Scheduled by table:\n";
-        Table->Print();
+        Table->Print(log);
       }
     }
   }

--- a/src/models/propulsion/FGPiston.cpp
+++ b/src/models/propulsion/FGPiston.cpp
@@ -1056,12 +1056,12 @@ void FGPiston::Debug(int from)
 
       log << "\n";
       log << "      Combustion Efficiency table:\n";
-      Lookup_Combustion_Efficiency->Print();
+      Lookup_Combustion_Efficiency->Print(log);
       log << "\n";
 
       log << "\n";
       log << "      Mixture Efficiency Correlation table:\n";
-      Mixture_Efficiency_Correlation->Print();
+      Mixture_Efficiency_Correlation->Print(log);
       log << "\n";
     }
   }


### PR DESCRIPTION
While testing various combinations of `jsbsim.FGJSBBase().debug_lvl` and `jsbsim.get_logger().set_min_level(jsbsim.LogLevel.XXX)` I noticed something odd with the output of FGTable data.

With `jsbsim.FGJSBBase().debug_lvl = 1` and `jsbsim.get_logger().set_min_level(jsbsim.LogLevel.DEBUG)` I would see output along these lines, i.e. function name with any associated table for the function.

```sh
    Function: aero/coefficient/Clr
    1 dimensional table with 2 rows.
        0       0.1
        2       0.033
    Function: aero/coefficient/Clda
    Function: aero/coefficient/Cldr
    Function: aero/coefficient/Cmalpha
    1 dimensional table with 2 rows.
        0       -1.2
        2       -0.3
    Function: aero/coefficient/Cmde
```

But with `jsbsim.get_logger().set_min_level(jsbsim.LogLevel.FATAL)` then the function names would disappear, and other aircraft config output, e.g. mass details, FCS details etc., would also disappear, but there would be table data output with no context, e.g.

```sh
    1 dimensional table with 2 rows.
        0       0.1
        2       0.033
    1 dimensional table with 2 rows.
        0       -1.2
        2       -0.3
```

That's because all the other data/details were being output at `LogLevel::DEBUG`, e.g.

```c++
  if (debug_lvl & 1) { // Standard console startup message output
    if (from == 0) { // Constructor
      if (!Name.empty()) {
        FGLogging log(LogLevel::DEBUG);
        log << "    Function: " << Name << endl;
      }
    }

  if (debug_lvl > 0) {
    MassBalance->GetMassPropertiesReport(0);
```

But `FGTable::Print()` was set to output at `LogLevel::STDOUT`:

```c++
FGTable::FGTable()
  if (debug_lvl & 1) Print();

void FGTable::Print(void)
{
  FGLogging out(LogLevel::STDOUT);
  out << std::setprecision(4);

  switch(Type) {
    case tt1D:
      out << "    1 dimensional table with " << nRows << " rows.\n";
      break;
    case tt2D:
```

So I've modified `FGTable::Print()` to take a reference to a `FGLogging` instance, and defaulted the constructor to assume `LogLevel::DEBUG`. Then modified the handful of call sites that explicitly call `FGTable::Print()` to pass a reference to a `FGLogging` instance. 

```c++
FGTable::FGTable()
  if (debug_lvl & 1) {
    FGLogging out(LogLevel::DEBUG);
    Print(out);
  }

void FGTable::Print(FGLogging& out)
{
  out << std::setprecision(4);
```

So at some point if there was a command line argument, or property tree entry allowing a user to request a `FGTable` to print itself, it could pass a `FGLogging` instance with `LogLevel::STDOUT`.