### PR TITLE
Reject duplicate input sockets with the same port and protocol

### DIFF
--- a/src/input_output/FGInputSocket.h
+++ b/src/input_output/FGInputSocket.h
@@ -70,6 +70,11 @@ public:
   */
   bool Load(Element* el) override;
 
+  /// @return the port this input socket is bound to (0 if not yet loaded).
+  unsigned int GetPort(void) const { return SockPort; }
+  /// @return the protocol (TCP/UDP) this input socket uses.
+  FGfdmSocket::ProtocolType GetProtocol(void) const { return SockProtocol; }
+
   /** Initializes the instance. This method basically opens the socket to which
       inputs will be directed.
       @result true if the execution succeeded.

--- a/src/models/FGInput.cpp
+++ b/src/models/FGInput.cpp
@@ -40,6 +40,7 @@ INCLUDES
 
 #include "FGInput.h"
 #include "FGFDMExec.h"
+#include "input_output/FGInputSocket.h"
 #include "input_output/FGUDPInputSocket.h"
 #include "input_output/FGXMLFileRead.h"
 #include "input_output/FGModelLoader.h"
@@ -113,6 +114,25 @@ bool FGInput::Load(Element* el)
 
   Input->SetIdx(idx);
   Input->Load(element);
+
+  // Reject a socket input whose port and protocol duplicate one already
+  // registered, so the same port is not bound twice (which fails on reload).
+  FGInputSocket* newSocket = dynamic_cast<FGInputSocket*>(Input);
+  if (newSocket && newSocket->GetPort() != 0) {
+    for (auto existing : InputTypes) {
+      FGInputSocket* existingSocket = dynamic_cast<FGInputSocket*>(existing);
+      if (existingSocket
+          && existingSocket->GetPort() == newSocket->GetPort()
+          && existingSocket->GetProtocol() == newSocket->GetProtocol()) {
+        FGLogging log(LogLevel::WARN);
+        log << "Input socket on port " << newSocket->GetPort()
+            << " already registered, skipping duplicate.\n";
+        delete Input;
+        return false;
+      }
+    }
+  }
+
   PostLoad(element, FDMExec);
 
   InputTypes.push_back(Input);

--- a/src/models/FGInput.cpp
+++ b/src/models/FGInput.cpp
@@ -115,8 +115,12 @@ bool FGInput::Load(Element* el)
   Input->SetIdx(idx);
   Input->Load(element);
 
-  // Reject a socket input whose port and protocol duplicate one already
-  // registered, so the same port is not bound twice (which fails on reload).
+  // It is legitimately possible for more than one <input> directive to name the
+  // same port and protocol. For example one declared in a script and another in the
+  // aircraft XML. That would create two FGInputSocket objects, and the second
+  // one's bind() would fail at InitModel with only a low-level "could not bind"
+  // errno, leaving that input silently dead. Detect the collision here and skip
+  // the duplicate with a clear warning instead.
   FGInputSocket* newSocket = dynamic_cast<FGInputSocket*>(Input);
   if (newSocket && newSocket->GetPort() != 0) {
     for (auto existing : InputTypes) {

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -20,7 +20,8 @@ set(UNIT_TESTS FGColumnVector3Test
                FGAtmosphereTest
                FGAuxiliaryTest
                FGMSISTest
-               FGLogTest)
+               FGLogTest
+               FGInputTest)
 
 
 foreach(test ${UNIT_TESTS})

--- a/tests/unit_tests/FGInputTest.h
+++ b/tests/unit_tests/FGInputTest.h
@@ -1,0 +1,32 @@
+#include <cxxtest/TestSuite.h>
+
+#include <FGFDMExec.h>
+#include <models/FGInput.h>
+#include "TestUtilities.h"
+
+using namespace JSBSim;
+
+class FGInputTest : public CxxTest::TestSuite
+{
+public:
+  // A socket input whose port and protocol duplicate one already registered is
+  // rejected; a socket on a different port is accepted. Load() only parses the
+  // socket parameters (the port is bound later, in InitModel), so this exercises
+  // the duplicate guard without opening a real socket.
+  void testRejectsDuplicateSocketPort()
+  {
+    FGFDMExec fdmex;
+    auto input = fdmex.GetInput();
+
+    Element_ptr first = readFromXML("<input type=\"SOCKET\" port=\"1137\"/>");
+    TS_ASSERT(input->Load(first));
+
+    // Same port and protocol -> rejected.
+    Element_ptr duplicate = readFromXML("<input type=\"SOCKET\" port=\"1137\"/>");
+    TS_ASSERT(!input->Load(duplicate));
+
+    // Different port -> accepted.
+    Element_ptr different = readFromXML("<input type=\"SOCKET\" port=\"1138\"/>");
+    TS_ASSERT(input->Load(different));
+  }
+};


### PR DESCRIPTION
FGInput::Load registers each <input> socket unconditionally, so defining an input socket twice tries to bind the same port again and fails. 

Expose the port and protocol on FGInputSocket and skip a new socket whose port and protocol match one already registered, warning and discarding the duplicate.