### PR TITLE
Fix pkgconfig libs so they don't include CMake object/interface libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,17 @@ if (PkgConfig_FOUND)
   if (NOT BUILD_SHARED_LIBS)
     get_target_property(libJSBSim_LINK_LIBRARIES libJSBSim LINK_LIBRARIES)
     foreach(_LIB ${libJSBSim_LINK_LIBRARIES})
+
+      # Ensure this library is not a CMake object library or interface library
+      if (TARGET ${_LIB}) # Non-CMake libraries are ok (specifically libm)
+        get_target_property(LINK_LIB_TYPE ${_LIB} TYPE)
+        if (NOT ((${LINK_LIB_TYPE} STREQUAL "STATIC_LIBRARY") OR (${LINK_LIB_TYPE} STREQUAL "SHARED_LIBRARY")))
+          continue()
+        endif()
+      endif()
+
       set(JSBSIM_PKG_CONFIG_LINK_LIBRARIES "${JSBSIM_PKG_CONFIG_LINK_LIBRARIES} -l${_LIB}")
+
     endforeach(_LIB)
   endif(NOT BUILD_SHARED_LIBS)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/JSBSim.pc.in ${CMAKE_CURRENT_BINARY_DIR}/JSBSim.pc @ONLY)


### PR DESCRIPTION
A recent update to the CMake configuration made it where the `libJSBSim` receives the contents of the various object libraries using the `target_link_libraries()` command, instead of the previously used generator statements to pull the object files directly into the library.

However, because CMake now sees multiple "libraries" being linked to `libJSBSim`, this caused script that generates the pkg-config file to fail, as it simply adds the name of each library to the "libs" section, regardless of whether it's a real static/shared library, vs CMake's virtual object/interface libraries.

This change attempts to fix that by checking if a library is a static or shared library before adding it to the list of pkg-config libraries.