### PR TITLE
Do not prepend the output path to an already-absolute output name

### DIFF
--- a/src/input_output/FGOutputFile.h
+++ b/src/input_output/FGOutputFile.h
@@ -100,7 +100,10 @@ public:
       the next call to SetStartNewOutput().
       @param name new name */
   void SetOutputName(const std::string& fname) override {
-    Name = (FDMExec->GetOutputPath()/fname).utf8Str();
+    // An absolute name is used as-is; only a relative name is taken under the
+    // output path.
+    SGPath p(fname);
+    Name = p.isAbsolute() ? fname : (FDMExec->GetOutputPath()/fname).utf8Str();
     runID_postfix = -1;
     Filename = SGPath();
   }

--- a/src/input_output/FGOutputFile.h
+++ b/src/input_output/FGOutputFile.h
@@ -95,13 +95,13 @@ public:
   */
   void SetStartNewOutput(void) override;
   /** Overwrites the name identifier under which the output will be logged.
+      If fname is a relative filepath then prepend the configured output path,
+      otherwise use the absolute filepath.
       For this method to take effect, it must be called prior to
       FGFDMExec::RunIC(). If it is called after, it will not take effect before
       the next call to SetStartNewOutput().
-      @param name new name */
+      @param fname new name */
   void SetOutputName(const std::string& fname) override {
-    // An absolute name is used as-is; only a relative name is taken under the
-    // output path.
     SGPath p(fname);
     Name = p.isAbsolute() ? fname : (FDMExec->GetOutputPath()/fname).utf8Str();
     runID_postfix = -1;


### PR DESCRIPTION
Fix issue when FGOutputFile::SetOutputName joins the configured output path with the supplied name, which produces a malformed path when the name is itself absolute. 

i.e.; Take an absolute name as-is; only relative names are resolved under the output path.