### PR TITLE
Fix the decrement of children counter.

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -177,7 +177,7 @@ FGFDMExec::~FGFDMExec()
     log << "Caught error: " << msg << endl;
   }
 
-  if (!FDMctr) (*FDMctr)--;
+  if (FDMctr) (*FDMctr)--;
 
   Debug(1);
 }


### PR DESCRIPTION
An issue reported by [code inspection from the FlightGear maintainers](https://gitlab.com/flightgear/flightgear/-/merge_requests/455#note_3436123209).

https://github.com/JSBSim-Team/jsbsim/blob/0d44e1253435780acddac8e9a05dd8b6c08ff6a4/src/FGFDMExec.cpp#L180

This code is faulty since the decrement would only take place if `FDMctr` is null and in that case there would be a segmentation fault. Fortunately, this scenario can never occur since the shared pointer is always constructed:
https://github.com/JSBSim-Team/jsbsim/blob/0d44e1253435780acddac8e9a05dd8b6c08ff6a4/src/FGFDMExec.cpp#L111-L114

However, the code at stake is intended to decrement the FDM children counter when one of the children is destroyed. And since `!FDMctr` is always false, the decrement never occurs.