### PR TITLE
Add an option `--outputpath` to the JSBSim scripts

### DIFF
--- a/python/JSBSim.py
+++ b/python/JSBSim.py
@@ -48,7 +48,7 @@ def main():
                         help="sets (overrides) the name of a data output file")
     parser.add_argument("--logdirectivefile", action="append", metavar="<filename>",
                         help="specifies the name of a data logging directives file")
-    parser.add_argument("--outputpath", metavar="<filename>",
+    parser.add_argument("--outputpath", metavar="<path>",
                         help="specifies the directory where the output files will be written.")
     parser.add_argument("--realtime", default=False, action="store_true",
                         help="specifies to run in real world time")

--- a/python/JSBSim.py
+++ b/python/JSBSim.py
@@ -27,23 +27,25 @@ import sys
 import time
 import xml.etree.ElementTree as et
 
-import _jsbsim
+import jsbsim
 
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("input", nargs='?', help="script file name")
     parser.add_argument("--version", action="version",
-                        version="%(prog)s {}".format(_jsbsim.FGJSBBase().get_version()))
-    parser.add_argument("--outputlogfile", action="append", metavar="<filename>",
-                        help="sets (overrides) the name of a data output file")
-    parser.add_argument("--logdirectivefile", action="append", metavar="<filename>",
-                        help="specifies the name of a data logging directives file")
+                        version="%(prog)s {}".format(jsbsim.FGJSBBase().get_version()))
     parser.add_argument("--root", default='.', metavar="<path>",
                         help="specifies the JSBSim root directory (where aircraft/, engine/, etc. reside)")
     parser.add_argument("--aircraft", metavar="<filename>",
                         help="specifies the name of the aircraft to be modeled")
     parser.add_argument("--script", metavar="<filename>",
                         help="specifies a script to run")
+    parser.add_argument("--outputlogfile", action="append", metavar="<filename>",
+                        help="sets (overrides) the name of a data output file")
+    parser.add_argument("--logdirectivefile", action="append", metavar="<filename>",
+                        help="specifies the name of a data logging directives file")
+    parser.add_argument("--outputpath", metavar="<filename>",
+                        help="specifies the directory where the output files will be written.")
     parser.add_argument("--realtime", default=False, action="store_true",
                         help="specifies to run in real world time")
     parser.add_argument("--nice", default=False, action="store_true",
@@ -113,10 +115,15 @@ def main():
             else:
                 args.aircraft = args.input
 
-    fdm = _jsbsim.FGFDMExec(args.root, None)
+    fdm = jsbsim.FGFDMExec(args.root, None)
 
     if args.nohighlight:
         fdm.disable_highlighting()
+
+    if args.outputpath:
+        fdm.set_output_path(args.outputpath)
+    else:
+        fdm.set_output_path(".")
 
     if args.simulation_rate:
         if args.simulation_rate < 1.0:

--- a/python/JSBSim.py
+++ b/python/JSBSim.py
@@ -33,13 +33,17 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("input", nargs='?', help="script file name")
     parser.add_argument("--version", action="version",
-                        version="%(prog)s {}".format(jsbsim.FGJSBBase().get_version()))
+                        version=f"{jsbsim.FGJSBBase().get_version()}")
     parser.add_argument("--root", default='.', metavar="<path>",
                         help="specifies the JSBSim root directory (where aircraft/, engine/, etc. reside)")
     parser.add_argument("--aircraft", metavar="<filename>",
                         help="specifies the name of the aircraft to be modeled")
     parser.add_argument("--script", metavar="<filename>",
                         help="specifies a script to run")
+    parser.add_argument("--initfile", metavar="<filename>",
+                        help="specifies an initialization file")
+    parser.add_argument("--planet", metavar="<filename>",
+                        help="specifies a planet definition file")
     parser.add_argument("--outputlogfile", action="append", metavar="<filename>",
                         help="sets (overrides) the name of a data output file")
     parser.add_argument("--logdirectivefile", action="append", metavar="<filename>",
@@ -54,10 +58,6 @@ def main():
                         help="specifies that console output should be pure text only (no color)")
     parser.add_argument("--suspend", default=False, action="store_true",
                         help="specifies to suspend the simulation after initialization")
-    parser.add_argument("--initfile", metavar="<filename>",
-                        help="specifies an initialization file")
-    parser.add_argument("--planet", metavar="<filename>",
-                        help="specifies a planet definition file")
     parser.add_argument("--catalog", default=False, action="store_true",
                         help="specifies that all properties for this aircraft model should be printed")
     parser.add_argument("--property", action="append", metavar="<name=value>",

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -859,7 +859,7 @@ void PrintHelp(void)
     cout << "    --outputlogfile=<filename>  sets (overrides) the name of a data output file" << endl;
     cout << "    --logdirectivefile=<filename>  specifies the name of a data logging directives file" << endl;
     cout << "                                   (can appear multiple times)" << endl;
-    cout << "    --outputpath=<filename> specifies the directory where the output files will be written." << endl;
+    cout << "    --outputpath=<path> specifies the directory where the output files will be written." << endl;
     cout << "    --realtime  specifies to run in actual real world time" << endl;
     cout << "    --nice  specifies to run at lower CPU usage" << endl;
     cout << "    --nohighlight  specifies that console output should be pure text only (no color)" << endl;

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -86,6 +86,7 @@ GLOBAL DATA
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 SGPath RootDir;
+SGPath OutputPath;
 SGPath ScriptName;
 string AircraftName;
 SGPath ResetName;
@@ -364,6 +365,7 @@ int real_main(int argc, char* argv[])
   AircraftName = "";
   ResetName = "";
   PlanetName = "";
+  OutputPath = SGPath(".");
   LogOutputName.clear();
   LogDirectiveName.clear();
   bool result = false, success;
@@ -394,7 +396,7 @@ int real_main(int argc, char* argv[])
   FDMExec->SetAircraftPath(SGPath("aircraft"));
   FDMExec->SetEnginePath(SGPath("engine"));
   FDMExec->SetSystemsPath(SGPath("systems"));
-  FDMExec->SetOutputPath(SGPath("."));
+  FDMExec->SetOutputPath(OutputPath);
   FDMExec->GetPropertyManager()->Tie("simulation/frame_start_time", &actual_elapsed_time);
   FDMExec->GetPropertyManager()->Tie("simulation/cycle_duration", &cycle_duration);
 
@@ -712,6 +714,13 @@ bool options(int count, char **arg)
         gripe;
         exit(1);
       }
+    } else if (keyword == "--outputpath") {
+      if (n != string::npos) {
+        OutputPath = SGPath::fromLocal8Bit(value.c_str());
+      } else {
+        gripe;
+        exit(1);
+      }
     } else if (keyword == "--aircraft") {
       if (n != string::npos) {
         AircraftName = value;
@@ -842,12 +851,13 @@ void PrintHelp(void)
   cout << "  options:" << endl;
     cout << "    --help  returns this message" << endl;
     cout << "    --version  returns the version number" << endl;
-    cout << "    --outputlogfile=<filename>  sets (overrides) the name of a data output file" << endl;
-    cout << "    --logdirectivefile=<filename>  specifies the name of a data logging directives file" << endl;
-    cout << "                                   (can appear multiple times)" << endl;
     cout << "    --root=<path>  specifies the JSBSim root directory (where aircraft/, engine/, etc. reside)" << endl;
     cout << "    --aircraft=<filename>  specifies the name of the aircraft to be modeled" << endl;
     cout << "    --script=<filename>  specifies a script to run" << endl;
+    cout << "    --outputlogfile=<filename>  sets (overrides) the name of a data output file" << endl;
+    cout << "    --logdirectivefile=<filename>  specifies the name of a data logging directives file" << endl;
+    cout << "                                   (can appear multiple times)" << endl;
+    cout << "    --outputpath=<filename> specifies the directory where the output files will be written." << endl;
     cout << "    --realtime  specifies to run in actual real world time" << endl;
     cout << "    --nice  specifies to run at lower CPU usage" << endl;
     cout << "    --nohighlight  specifies that console output should be pure text only (no color)" << endl;

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -854,6 +854,8 @@ void PrintHelp(void)
     cout << "    --root=<path>  specifies the JSBSim root directory (where aircraft/, engine/, etc. reside)" << endl;
     cout << "    --aircraft=<filename>  specifies the name of the aircraft to be modeled" << endl;
     cout << "    --script=<filename>  specifies a script to run" << endl;
+    cout << "    --initfile=<filename>  specifies an initialization file" << endl;
+    cout << "    --planet=<filename>  specifies a planet definition file" << endl;
     cout << "    --outputlogfile=<filename>  sets (overrides) the name of a data output file" << endl;
     cout << "    --logdirectivefile=<filename>  specifies the name of a data logging directives file" << endl;
     cout << "                                   (can appear multiple times)" << endl;
@@ -862,8 +864,6 @@ void PrintHelp(void)
     cout << "    --nice  specifies to run at lower CPU usage" << endl;
     cout << "    --nohighlight  specifies that console output should be pure text only (no color)" << endl;
     cout << "    --suspend  specifies to suspend the simulation after initialization" << endl;
-    cout << "    --initfile=<filename>  specifies an initialization file" << endl;
-    cout << "    --planet=<filename>  specifies a planet definition file" << endl;
     cout << "    --catalog specifies that all properties for this aircraft model should be printed" << endl;
     cout << "              (catalog=aircraftname is an optional format)" << endl;
     cout << "    --property=<name=value> e.g. --property=simulation/integrator/rate/rotational=1" << endl;


### PR DESCRIPTION
This PR adds an option `--outputpath` to the binary executable `JSBSim` and the Python script `JSBSim.py`. This allows to specify from the command line the output path where all the output files will be written.

I took this opportunity to:
* change the order the arguments are displayed in and group them by themes (input, output, miscellaneous)
* Fix the Python module name (was `_jsbsim` but should be `jsbsim`). For some reason, no one complained about that, most likely because `JSBSim.py` is not known or used.