### PR TITLE
Allow telnet property-catalog query without a prior HOLD

### DIFF
--- a/src/input_output/FGInputSocket.cpp
+++ b/src/input_output/FGInputSocket.cpp
@@ -227,12 +227,10 @@ void FGInputSocket::Read(bool Holding)
           socket->Reply("Unknown property\r\n");
           break;
         } else if (!node->hasValue()) {
-          if (Holding) { // if holding can query property list
-            string query = FDMExec->QueryPropertyCatalog(argument, "\r\n");
-            socket->Reply(query);
-          } else {
-            socket->Reply("Must be in HOLD to search properties\r\n");
-          }
+          // Not a leaf: return the matching entries from the (static) property
+          // catalog. This is a read-only lookup, so it no longer requires the
+          // client to place the sim in HOLD first.
+          socket->Reply(FDMExec->QueryPropertyCatalog(argument, "\r\n"));
         } else {
           ostringstream buf;
           buf << argument << " = " << setw(12) << setprecision(6) << node->getDoubleValue() << '\r' << endl;


### PR DESCRIPTION
The telnet `get` handler refuses a property-catalog query (a `get` on a non-leaf node) unless the simulation is already in HOLD, replying `Must be in HOLD to search properties`. A client therefore has to bracket the lookup with `hold` and `resume`.

This is a genuine obstacle to driving the telnet interface from another program. Every reply is terminated by a `JSBSim> ` prompt and nothing is length framed, so a client must read to each of the three prompts in lockstep. The variable-length catalog reply sits between them; any mis-step runs the catalog output, the `Resuming` line and the next prompt together. The bracket also pauses the simulation for what is only a read-only lookup.

AFAICT the property catalog is a static list that does not depend on the simulation state so I'm not quite clear why we have to be in HOLD to return this. Maybe it was originally due to performance of building or sending a large list over TCP/IP.

My proposed solution is to answers the query directly thus streamlining the exchange to a single command.

