### PR TITLE
Add a per-model execution-enable property

### DIFF
--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -162,6 +162,23 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   instance->Tie("simulation/trim-completed", &trim_completed);
   instance->Tie("forces/hold-down", this, &FGFDMExec::GetHoldDown, &FGFDMExec::SetHoldDown);
 
+  // Per-model execution-enable property: simulation/models/<name>/enabled
+  // (default true). Setting one false skips that model's Run() while preserving
+  // its state. This is the property-tree mechanism by which an external system
+  // can replace a model, for example external propagation or host-owned ground
+  // reactions. Names use the stable canonical eModels order, independent of
+  // FGModel::Name.
+  static const char* const modelEnableNames[] = {
+    "propagate", "input", "inertial", "atmosphere", "winds", "systems",
+    "massbalance", "auxiliary", "propulsion", "aerodynamics", "groundreactions",
+    "externalreactions", "buoyantforces", "aircraft", "accelerations", "output"
+  };
+  static_assert(sizeof(modelEnableNames)/sizeof(*modelEnableNames) == eNumStandardModels,
+                "modelEnableNames must stay in step with eModels");
+  for (unsigned int i = 0; i < Models.size(); ++i)
+    if (Models[i])
+      Models[i]->BindModelEnabled(modelEnableNames[i]);
+
   Constructing = false;
 }
 

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -162,23 +162,6 @@ FGFDMExec::FGFDMExec(FGPropertyManager* root, std::shared_ptr<unsigned int> fdmc
   instance->Tie("simulation/trim-completed", &trim_completed);
   instance->Tie("forces/hold-down", this, &FGFDMExec::GetHoldDown, &FGFDMExec::SetHoldDown);
 
-  // Per-model execution-enable property: simulation/models/<name>/enabled
-  // (default true). Setting one false skips that model's Run() while preserving
-  // its state. This is the property-tree mechanism by which an external system
-  // can replace a model, for example external propagation or host-owned ground
-  // reactions. Names use the stable canonical eModels order, independent of
-  // FGModel::Name.
-  static const char* const modelEnableNames[] = {
-    "propagate", "input", "inertial", "atmosphere", "winds", "systems",
-    "massbalance", "auxiliary", "propulsion", "aerodynamics", "groundreactions",
-    "externalreactions", "buoyantforces", "aircraft", "accelerations", "output"
-  };
-  static_assert(sizeof(modelEnableNames)/sizeof(*modelEnableNames) == eNumStandardModels,
-                "modelEnableNames must stay in step with eModels");
-  for (unsigned int i = 0; i < Models.size(); ++i)
-    if (Models[i])
-      Models[i]->BindModelEnabled(modelEnableNames[i]);
-
   Constructing = false;
 }
 

--- a/src/input_output/FGInputType.cpp
+++ b/src/input_output/FGInputType.cpp
@@ -50,8 +50,9 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGInputType::FGInputType(FGFDMExec* fdmex, bool isEnabled) :
-  FGModel(fdmex), enabled(isEnabled)
+  FGModel(fdmex, "")
 {
+  enabled = isEnabled;
   Debug(0);
 }
 
@@ -100,7 +101,6 @@ bool FGInputType::InitModel(void)
 bool FGInputType::Run(bool Holding)
 {
   if (FGModel::Run(Holding)) return true;
-  if (!enabled) return true;
 
   RunPreFunctions();
   Read(Holding);

--- a/src/input_output/FGInputType.h
+++ b/src/input_output/FGInputType.h
@@ -130,7 +130,6 @@ public:
 
 protected:
   unsigned int InputIdx;
-  bool enabled;
 
   void Debug(int from) override;
 };

--- a/src/input_output/FGOutputType.cpp
+++ b/src/input_output/FGOutputType.cpp
@@ -54,9 +54,8 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGOutputType::FGOutputType(FGFDMExec* fdmex) :
-  FGModel(fdmex),
-  SubSystems(0),
-  enabled(true)
+  FGModel(fdmex, ""),
+  SubSystems(0)
 {
   Aerodynamics = FDMExec->GetAerodynamics();
   Auxiliary = FDMExec->GetAuxiliary();
@@ -186,7 +185,6 @@ bool FGOutputType::InitModel(void)
 bool FGOutputType::Run(bool Holding)
 {
   if (FGModel::Run(Holding)) return true;
-  if (!enabled) return true;
 
   RunPreFunctions();
   Print();

--- a/src/input_output/FGOutputType.h
+++ b/src/input_output/FGOutputType.h
@@ -196,7 +196,6 @@ protected:
   int SubSystems;
   std::vector <FGPropertyValue*> OutputParameters;
   std::vector <std::string> OutputCaptions;
-  bool enabled;
 
   std::shared_ptr<FGAerodynamics> Aerodynamics;
   std::shared_ptr<FGAuxiliary> Auxiliary;

--- a/src/models/FGAccelerations.cpp
+++ b/src/models/FGAccelerations.cpp
@@ -66,10 +66,9 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGAccelerations::FGAccelerations(FGFDMExec* fdmex)
-  : FGModel(fdmex, "accelerations")
+  : FGModel(fdmex, "FGAccelerations")
 {
   Debug(0);
-  Name = "FGAccelerations";
   gravTorque = false;
 
   vPQRidot.InitMatrix();

--- a/src/models/FGAccelerations.cpp
+++ b/src/models/FGAccelerations.cpp
@@ -66,7 +66,7 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGAccelerations::FGAccelerations(FGFDMExec* fdmex)
-  : FGModel(fdmex)
+  : FGModel(fdmex, "accelerations")
 {
   Debug(0);
   Name = "FGAccelerations";

--- a/src/models/FGAerodynamics.cpp
+++ b/src/models/FGAerodynamics.cpp
@@ -50,7 +50,7 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 
-FGAerodynamics::FGAerodynamics(FGFDMExec* FDMExec) : FGModel(FDMExec)
+FGAerodynamics::FGAerodynamics(FGFDMExec* FDMExec) : FGModel(FDMExec, "aerodynamics")
 {
   Name = "FGAerodynamics";
 

--- a/src/models/FGAerodynamics.cpp
+++ b/src/models/FGAerodynamics.cpp
@@ -50,9 +50,8 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 
-FGAerodynamics::FGAerodynamics(FGFDMExec* FDMExec) : FGModel(FDMExec, "aerodynamics")
+FGAerodynamics::FGAerodynamics(FGFDMExec* FDMExec) : FGModel(FDMExec, "FGAerodynamics")
 {
-  Name = "FGAerodynamics";
 
   AxisIdx["DRAG"]   = 0;
   AxisIdx["SIDE"]   = 1;

--- a/src/models/FGAerodynamics.cpp
+++ b/src/models/FGAerodynamics.cpp
@@ -52,7 +52,6 @@ CLASS IMPLEMENTATION
 
 FGAerodynamics::FGAerodynamics(FGFDMExec* FDMExec) : FGModel(FDMExec, "FGAerodynamics")
 {
-
   AxisIdx["DRAG"]   = 0;
   AxisIdx["SIDE"]   = 1;
   AxisIdx["LIFT"]   = 2;

--- a/src/models/FGAircraft.cpp
+++ b/src/models/FGAircraft.cpp
@@ -51,9 +51,8 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGAircraft::FGAircraft(FGFDMExec* fdmex) : FGModel(fdmex, "aircraft")
+FGAircraft::FGAircraft(FGFDMExec* fdmex) : FGModel(fdmex, "FGAircraft")
 {
-  Name = "FGAircraft";
   WingSpan = 0.0;
   WingArea = 0.0;
   cbar = 0.0;

--- a/src/models/FGAircraft.cpp
+++ b/src/models/FGAircraft.cpp
@@ -51,7 +51,7 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGAircraft::FGAircraft(FGFDMExec* fdmex) : FGModel(fdmex)
+FGAircraft::FGAircraft(FGFDMExec* fdmex) : FGModel(fdmex, "aircraft")
 {
   Name = "FGAircraft";
   WingSpan = 0.0;

--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -55,7 +55,7 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGAtmosphere::FGAtmosphere(FGFDMExec* fdmex)
-  : FGModel(fdmex),
+  : FGModel(fdmex, "atmosphere"),
     StdDaySLsoundspeed(sqrt(SHRatio*Reng0*StdDaySLtemperature))
 {
   Name = "FGAtmosphere";

--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -55,10 +55,9 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGAtmosphere::FGAtmosphere(FGFDMExec* fdmex)
-  : FGModel(fdmex, "atmosphere"),
+  : FGModel(fdmex, "FGAtmosphere"),
     StdDaySLsoundspeed(sqrt(SHRatio*Reng0*StdDaySLtemperature))
 {
-  Name = "FGAtmosphere";
 
   bind();
   SGPropertyNode* root = PropertyManager->GetNode();

--- a/src/models/FGAtmosphere.cpp
+++ b/src/models/FGAtmosphere.cpp
@@ -58,7 +58,6 @@ FGAtmosphere::FGAtmosphere(FGFDMExec* fdmex)
   : FGModel(fdmex, "FGAtmosphere"),
     StdDaySLsoundspeed(sqrt(SHRatio*Reng0*StdDaySLtemperature))
 {
-
   bind();
   SGPropertyNode* root = PropertyManager->GetNode();
   atmosphere_node = root->getNode("atmosphere");

--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -59,7 +59,7 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 
-FGAuxiliary::FGAuxiliary(FGFDMExec* fdmex) : FGModel(fdmex)
+FGAuxiliary::FGAuxiliary(FGFDMExec* fdmex) : FGModel(fdmex, "auxiliary")
 {
   Name = "FGAuxiliary";
   pt = FGAtmosphere::StdDaySLpressure;     // ISA SL pressure

--- a/src/models/FGAuxiliary.cpp
+++ b/src/models/FGAuxiliary.cpp
@@ -59,9 +59,8 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 
-FGAuxiliary::FGAuxiliary(FGFDMExec* fdmex) : FGModel(fdmex, "auxiliary")
+FGAuxiliary::FGAuxiliary(FGFDMExec* fdmex) : FGModel(fdmex, "FGAuxiliary")
 {
-  Name = "FGAuxiliary";
   pt = FGAtmosphere::StdDaySLpressure;     // ISA SL pressure
   tat = FGAtmosphere::StdDaySLtemperature; // ISA SL temperature
   tatc = RankineToCelsius(tat);

--- a/src/models/FGBuoyantForces.cpp
+++ b/src/models/FGBuoyantForces.cpp
@@ -49,9 +49,8 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGBuoyantForces::FGBuoyantForces(FGFDMExec* FDMExec) : FGModel(FDMExec, "buoyantforces")
+FGBuoyantForces::FGBuoyantForces(FGFDMExec* FDMExec) : FGModel(FDMExec, "FGBuoyantForces")
 {
-  Name = "FGBuoyantForces";
 
   NoneDefined = true;
 

--- a/src/models/FGBuoyantForces.cpp
+++ b/src/models/FGBuoyantForces.cpp
@@ -49,7 +49,7 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGBuoyantForces::FGBuoyantForces(FGFDMExec* FDMExec) : FGModel(FDMExec)
+FGBuoyantForces::FGBuoyantForces(FGFDMExec* FDMExec) : FGModel(FDMExec, "buoyantforces")
 {
   Name = "FGBuoyantForces";
 

--- a/src/models/FGBuoyantForces.cpp
+++ b/src/models/FGBuoyantForces.cpp
@@ -51,7 +51,6 @@ CLASS IMPLEMENTATION
 
 FGBuoyantForces::FGBuoyantForces(FGFDMExec* FDMExec) : FGModel(FDMExec, "FGBuoyantForces")
 {
-
   NoneDefined = true;
 
   vTotalForces.InitMatrix();

--- a/src/models/FGExternalReactions.cpp
+++ b/src/models/FGExternalReactions.cpp
@@ -50,7 +50,7 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGExternalReactions::FGExternalReactions(FGFDMExec* fdmex) : FGModel(fdmex)
+FGExternalReactions::FGExternalReactions(FGFDMExec* fdmex) : FGModel(fdmex, "externalreactions")
 {
   Debug(0);
 }

--- a/src/models/FGExternalReactions.cpp
+++ b/src/models/FGExternalReactions.cpp
@@ -50,7 +50,7 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGExternalReactions::FGExternalReactions(FGFDMExec* fdmex) : FGModel(fdmex, "externalreactions")
+FGExternalReactions::FGExternalReactions(FGFDMExec* fdmex) : FGModel(fdmex, "FGExternalReactions")
 {
   Debug(0);
 }

--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -71,10 +71,9 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGFCS::FGFCS(FGFDMExec* fdm) : FGModel(fdm, "systems"), ChannelRate(1)
+FGFCS::FGFCS(FGFDMExec* fdm) : FGModel(fdm, "FGFCS"), ChannelRate(1)
 {
   int i;
-  Name = "FGFCS";
   systype = stFCS;
 
   DaCmd = DeCmd = DrCmd = DfCmd = DsbCmd = DspCmd = 0;

--- a/src/models/FGFCS.cpp
+++ b/src/models/FGFCS.cpp
@@ -71,7 +71,7 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGFCS::FGFCS(FGFDMExec* fdm) : FGModel(fdm), ChannelRate(1)
+FGFCS::FGFCS(FGFDMExec* fdm) : FGModel(fdm, "systems"), ChannelRate(1)
 {
   int i;
   Name = "FGFCS";

--- a/src/models/FGGroundReactions.cpp
+++ b/src/models/FGGroundReactions.cpp
@@ -52,11 +52,10 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGGroundReactions::FGGroundReactions(FGFDMExec* fgex) :
-   FGModel(fgex, "groundreactions"),
+   FGModel(fgex, "FGGroundReactions"),
    FGSurface(fgex),
    DsCmd(0.0)
 {
-  Name = "FGGroundReactions";
 
   bind();
 

--- a/src/models/FGGroundReactions.cpp
+++ b/src/models/FGGroundReactions.cpp
@@ -52,7 +52,7 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGGroundReactions::FGGroundReactions(FGFDMExec* fgex) :
-   FGModel(fgex),
+   FGModel(fgex, "groundreactions"),
    FGSurface(fgex),
    DsCmd(0.0)
 {

--- a/src/models/FGGroundReactions.cpp
+++ b/src/models/FGGroundReactions.cpp
@@ -56,7 +56,6 @@ FGGroundReactions::FGGroundReactions(FGFDMExec* fgex) :
    FGSurface(fgex),
    DsCmd(0.0)
 {
-
   bind();
 
   Debug(0);

--- a/src/models/FGInertial.cpp
+++ b/src/models/FGInertial.cpp
@@ -51,9 +51,8 @@ CLASS IMPLEMENTATION
 
 
 FGInertial::FGInertial(FGFDMExec* fgex)
-  : FGModel(fgex, "inertial")
+  : FGModel(fgex, "FGInertial")
 {
-  Name = "Earth";
 
   // Earth defaults
   double RotationRate    = 0.00007292115;

--- a/src/models/FGInertial.cpp
+++ b/src/models/FGInertial.cpp
@@ -51,7 +51,7 @@ CLASS IMPLEMENTATION
 
 
 FGInertial::FGInertial(FGFDMExec* fgex)
-  : FGModel(fgex)
+  : FGModel(fgex, "inertial")
 {
   Name = "Earth";
 

--- a/src/models/FGInertial.cpp
+++ b/src/models/FGInertial.cpp
@@ -53,6 +53,7 @@ CLASS IMPLEMENTATION
 FGInertial::FGInertial(FGFDMExec* fgex)
   : FGModel(fgex, "FGInertial")
 {
+  Name = "Earth";
 
   // Earth defaults
   double RotationRate    = 0.00007292115;

--- a/src/models/FGInput.cpp
+++ b/src/models/FGInput.cpp
@@ -54,7 +54,7 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGInput::FGInput(FGFDMExec* fdmex) : FGModel(fdmex)
+FGInput::FGInput(FGFDMExec* fdmex) : FGModel(fdmex, "input")
 {
   Name = "FGInput";
   enabled = true;

--- a/src/models/FGInput.cpp
+++ b/src/models/FGInput.cpp
@@ -54,9 +54,8 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGInput::FGInput(FGFDMExec* fdmex) : FGModel(fdmex, "input")
+FGInput::FGInput(FGFDMExec* fdmex) : FGModel(fdmex, "FGInput")
 {
-  Name = "FGInput";
   enabled = true;
 
   Debug(0);
@@ -142,7 +141,6 @@ bool FGInput::Run(bool Holding)
 {
   if (FDMExec->GetTrimStatus()) return true;
   if (FGModel::Run(Holding)) return true;
-  if (!enabled) return true;
 
   vector<FGInputType*>::iterator it;
   for (it = InputTypes.begin(); it != InputTypes.end(); ++it)

--- a/src/models/FGInput.h
+++ b/src/models/FGInput.h
@@ -145,7 +145,6 @@ public:
 
 private:
   std::vector<FGInputType*> InputTypes;
-  bool enabled;
 
   void Debug(int from) override;
 };

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -55,7 +55,7 @@ CLASS IMPLEMENTATION
 
 
 FGMassBalance::FGMassBalance(FGFDMExec* fdmex)
-  : FGModel(fdmex)
+  : FGModel(fdmex, "massbalance")
 {
   Name = "FGMassBalance";
   Weight = EmptyWeight = Mass = 0.0;

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -55,9 +55,8 @@ CLASS IMPLEMENTATION
 
 
 FGMassBalance::FGMassBalance(FGFDMExec* fdmex)
-  : FGModel(fdmex, "massbalance")
+  : FGModel(fdmex, "FGMassBalance")
 {
-  Name = "FGMassBalance";
   Weight = EmptyWeight = Mass = 0.0;
 
   vbaseXYZcg.InitMatrix();

--- a/src/models/FGModel.cpp
+++ b/src/models/FGModel.cpp
@@ -56,7 +56,8 @@ GLOBAL DECLARATIONS
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGModel::FGModel(FGFDMExec* fdmex, const std::string& enableName)
+FGModel::FGModel(FGFDMExec* fdmex, const std::string& name)
+ : Name(name)
 {
   FDMExec     = fdmex;
 
@@ -68,7 +69,14 @@ FGModel::FGModel(FGFDMExec* fdmex, const std::string& enableName)
   exe_ctr     = 1;
   rate        = 1;
 
-  if (!enableName.empty()) BindModelEnabled(enableName);
+  // A model that is scheduled by FGFDMExec is named and gets an enable property.
+  // The input and output types are not scheduled: they are instantiated one per
+  // <input> and <output> element, so a shared property path would be tied more
+  // than once. They pass an empty name and are enabled through the per-instance
+  // property that FGOutputType::SetIdx already binds, or through Enable() and
+  // Disable().
+  if (!Name.empty())
+    PropertyManager->Tie("simulation/models/" + Name + "/enabled", &enabled);
 
   Debug(0);
 }
@@ -90,26 +98,11 @@ bool FGModel::InitModel(void)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void FGModel::BindModelEnabled(const std::string& name)
-{
-  const string path = "simulation/models/" + name + "/enabled";
-  const bool existed = PropertyManager->HasNode(path);
-  ModelEnabled = PropertyManager->GetNode(path, true);
-  // Default to enabled; a freshly created node would otherwise read false.
-  if (!existed && ModelEnabled) ModelEnabled->setBoolValue(true);
-}
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
 bool FGModel::Run(bool Holding)
 {
   FGModel::Debug(2);
 
-  // A model whose simulation/models/<name>/enabled property is false is skipped
-  // entirely: its Run() body does not execute, but its last state and property
-  // bindings are preserved so an external system can replace it, for example
-  // external propagation or host-owned ground reactions.
-  if (ModelEnabled && !ModelEnabled->getBoolValue()) return true;
+  if (!enabled) return true;
 
   if (rate == 1) return false; // Fast exit if nothing to do
 

--- a/src/models/FGModel.cpp
+++ b/src/models/FGModel.cpp
@@ -102,14 +102,13 @@ bool FGModel::Run(bool Holding)
 {
   FGModel::Debug(2);
 
-  if (!enabled) return true;
-
-  if (rate == 1) return false; // Fast exit if nothing to do
+  if (rate == 1) return !enabled; // Fast exit if nothing to do
 
   if (exe_ctr >= rate) exe_ctr = 0;
 
-  if (exe_ctr++ == 1) return false;
-  else              return true;
+  if (exe_ctr++ == 1) return !enabled;
+
+  return true;
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/models/FGModel.cpp
+++ b/src/models/FGModel.cpp
@@ -56,7 +56,7 @@ GLOBAL DECLARATIONS
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGModel::FGModel(FGFDMExec* fdmex)
+FGModel::FGModel(FGFDMExec* fdmex, const std::string& enableName)
 {
   FDMExec     = fdmex;
 
@@ -67,6 +67,8 @@ FGModel::FGModel(FGFDMExec* fdmex)
 
   exe_ctr     = 1;
   rate        = 1;
+
+  if (!enableName.empty()) BindModelEnabled(enableName);
 
   Debug(0);
 }

--- a/src/models/FGModel.cpp
+++ b/src/models/FGModel.cpp
@@ -42,6 +42,7 @@ INCLUDES
 #include "FGFDMExec.h"
 #include "input_output/FGModelLoader.h"
 #include "input_output/FGLog.h"
+#include "input_output/FGPropertyManager.h"
 
 using namespace std;
 
@@ -87,9 +88,26 @@ bool FGModel::InitModel(void)
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+void FGModel::BindModelEnabled(const std::string& name)
+{
+  const string path = "simulation/models/" + name + "/enabled";
+  const bool existed = PropertyManager->HasNode(path);
+  ModelEnabled = PropertyManager->GetNode(path, true);
+  // Default to enabled; a freshly created node would otherwise read false.
+  if (!existed && ModelEnabled) ModelEnabled->setBoolValue(true);
+}
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 bool FGModel::Run(bool Holding)
 {
   FGModel::Debug(2);
+
+  // A model whose simulation/models/<name>/enabled property is false is skipped
+  // entirely: its Run() body does not execute, but its last state and property
+  // bindings are preserved so an external system can replace it, for example
+  // external propagation or host-owned ground reactions.
+  if (ModelEnabled && !ModelEnabled->getBoolValue()) return true;
 
   if (rate == 1) return false; // Fast exit if nothing to do
 

--- a/src/models/FGModel.h
+++ b/src/models/FGModel.h
@@ -48,6 +48,8 @@ INCLUDES
 FORWARD DECLARATIONS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+class SGPropertyNode;
+
 namespace JSBSim {
 
 class FGFDMExec;
@@ -93,6 +95,16 @@ public:
   unsigned int GetRate(void) const { return rate; }
   FGFDMExec* GetExec(void) const { return FDMExec; }
 
+  /** Bind this model's execution-enable flag to the property
+      simulation/models/<name>/enabled (default true), using the stable
+      canonical name supplied by FGFDMExec. When that property is set false,
+      Run() is skipped while the model's last state and property bindings are
+      preserved. This is the property-tree mechanism by which an external system
+      can replace a model, for example external propagation owning FGPropagate,
+      or a host physics engine owning FGGroundReactions. Behaviour is unchanged
+      unless the property is explicitly set false. */
+  void BindModelEnabled(const std::string& name);
+
   void SetPropertyManager(std::shared_ptr<FGPropertyManager> fgpm) { PropertyManager=fgpm;}
   virtual SGPath FindFullPathName(const SGPath& path) const;
   const std::string& GetName(void) const { return Name; }
@@ -101,6 +113,7 @@ public:
 protected:
   unsigned int exe_ctr;
   unsigned int rate;
+  SGPropertyNode* ModelEnabled = nullptr;
   std::string Name;
 
   /** Uploads this model in memory.

--- a/src/models/FGModel.h
+++ b/src/models/FGModel.h
@@ -48,8 +48,6 @@ INCLUDES
 FORWARD DECLARATIONS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-class SGPropertyNode;
-
 namespace JSBSim {
 
 class FGFDMExec;
@@ -90,7 +88,7 @@ public:
 
   /** Runs the model; called by the Executive.
       Can pass in a value indicating if the executive is directing the simulation to Hold.
-      @param Holding if true, the executive has been directed to hold the sim from 
+      @param Holding if true, the executive has been directed to hold the sim from
                      advancing time. Some models may ignore this flag, such as the Input
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given. The Holding flag is not used in the base

--- a/src/models/FGModel.h
+++ b/src/models/FGModel.h
@@ -61,6 +61,15 @@ CLASS DOCUMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 /** Base class for all scheduled JSBSim models
+
+    Each model binds simulation/models/<Name>/enabled (default true), where Name
+    is the name passed to the constructor. Setting that property false skips the
+    model's Run(): its last state and its property bindings are preserved, which
+    is the property-tree mechanism by which an external system can replace a
+    model, for example a host physics engine owning FGGroundReactions. The
+    binding is made at construction, so a model that renames itself while
+    loading does not move its enable property.
+
     @author Jon S. Berndt
   */
 
@@ -73,11 +82,9 @@ class JSBSIM_API FGModel : public FGModelFunctions
 public:
 
   /** Constructor.
-      @param enableName optional stable canonical name for this model. When
-                        non-empty it binds simulation/models/<enableName>/enabled
-                        (default true); setting that property false skips this
-                        model's Run(). Empty means the model has no enable flag. */
-  explicit FGModel(FGFDMExec*, const std::string& enableName = "");
+      @param name the name of this model. It populates the member Name and binds
+                  simulation/models/<name>/enabled. */
+  FGModel(FGFDMExec*, const std::string& name);
   /// Destructor
   ~FGModel() override;
 
@@ -107,17 +114,8 @@ public:
 protected:
   unsigned int exe_ctr;
   unsigned int rate;
-  SGPropertyNode* ModelEnabled = nullptr;
+  bool enabled = true;
   std::string Name;
-
-  /** Bind this model's execution-enable flag to
-      simulation/models/<name>/enabled (default true), where name is the stable
-      canonical name passed to the constructor. When that property is set false,
-      Run() is skipped while the model's last state and property bindings are
-      preserved, the property-tree mechanism by which an external system can
-      replace a model, for example external propagation owning FGPropagate or a
-      host physics engine owning FGGroundReactions. */
-  void BindModelEnabled(const std::string& name);
 
   /** Uploads this model in memory.
       Uploads the model in memory if its contents are contained in a separate

--- a/src/models/FGModel.h
+++ b/src/models/FGModel.h
@@ -72,8 +72,12 @@ class JSBSIM_API FGModel : public FGModelFunctions
 {
 public:
 
-  /// Constructor
-  explicit FGModel(FGFDMExec*);
+  /** Constructor.
+      @param enableName optional stable canonical name for this model. When
+                        non-empty it binds simulation/models/<enableName>/enabled
+                        (default true); setting that property false skips this
+                        model's Run(). Empty means the model has no enable flag. */
+  explicit FGModel(FGFDMExec*, const std::string& enableName = "");
   /// Destructor
   ~FGModel() override;
 
@@ -95,16 +99,6 @@ public:
   unsigned int GetRate(void) const { return rate; }
   FGFDMExec* GetExec(void) const { return FDMExec; }
 
-  /** Bind this model's execution-enable flag to the property
-      simulation/models/<name>/enabled (default true), using the stable
-      canonical name supplied by FGFDMExec. When that property is set false,
-      Run() is skipped while the model's last state and property bindings are
-      preserved. This is the property-tree mechanism by which an external system
-      can replace a model, for example external propagation owning FGPropagate,
-      or a host physics engine owning FGGroundReactions. Behaviour is unchanged
-      unless the property is explicitly set false. */
-  void BindModelEnabled(const std::string& name);
-
   void SetPropertyManager(std::shared_ptr<FGPropertyManager> fgpm) { PropertyManager=fgpm;}
   virtual SGPath FindFullPathName(const SGPath& path) const;
   const std::string& GetName(void) const { return Name; }
@@ -115,6 +109,15 @@ protected:
   unsigned int rate;
   SGPropertyNode* ModelEnabled = nullptr;
   std::string Name;
+
+  /** Bind this model's execution-enable flag to
+      simulation/models/<name>/enabled (default true), where name is the stable
+      canonical name passed to the constructor. When that property is set false,
+      Run() is skipped while the model's last state and property bindings are
+      preserved, the property-tree mechanism by which an external system can
+      replace a model, for example external propagation owning FGPropagate or a
+      host physics engine owning FGGroundReactions. */
+  void BindModelEnabled(const std::string& name);
 
   /** Uploads this model in memory.
       Uploads the model in memory if its contents are contained in a separate

--- a/src/models/FGOutput.cpp
+++ b/src/models/FGOutput.cpp
@@ -55,7 +55,7 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGOutput::FGOutput(FGFDMExec* fdmex) : FGModel(fdmex)
+FGOutput::FGOutput(FGFDMExec* fdmex) : FGModel(fdmex, "output")
 {
   Name = "FGOutput";
   enabled = true;

--- a/src/models/FGOutput.cpp
+++ b/src/models/FGOutput.cpp
@@ -55,9 +55,8 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGOutput::FGOutput(FGFDMExec* fdmex) : FGModel(fdmex, "output")
+FGOutput::FGOutput(FGFDMExec* fdmex) : FGModel(fdmex, "FGOutput")
 {
-  Name = "FGOutput";
   enabled = true;
 
   PropertyManager->Tie<FGOutput, int>("simulation/force-output", this, nullptr,
@@ -97,7 +96,6 @@ bool FGOutput::Run(bool Holding)
   if (FDMExec->GetTrimStatus()) return true;
   if (FGModel::Run(Holding)) return true;
   if (Holding) return false;
-  if (!enabled) return true;
 
   for (auto output: OutputTypes)
     output->Run(Holding);

--- a/src/models/FGOutput.h
+++ b/src/models/FGOutput.h
@@ -222,7 +222,6 @@ public:
 
 private:
   std::vector<FGOutputType*> OutputTypes;
-  bool enabled;
   SGPath includePath;
 
   void Debug(int from) override;

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -81,9 +81,8 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGPropagate::FGPropagate(FGFDMExec* fdmex)
-  : FGModel(fdmex, "propagate")
+  : FGModel(fdmex, "FGPropagate")
 {
-  Name = "FGPropagate";
 
   Inertial = FDMExec->GetInertial();
 

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -81,7 +81,7 @@ CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 FGPropagate::FGPropagate(FGFDMExec* fdmex)
-  : FGModel(fdmex)
+  : FGModel(fdmex, "propagate")
 {
   Name = "FGPropagate";
 

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -83,7 +83,6 @@ CLASS IMPLEMENTATION
 FGPropagate::FGPropagate(FGFDMExec* fdmex)
   : FGModel(fdmex, "FGPropagate")
 {
-
   Inertial = FDMExec->GetInertial();
 
   /// These define the indices use to select the various integrators.

--- a/src/models/FGPropulsion.cpp
+++ b/src/models/FGPropulsion.cpp
@@ -72,9 +72,8 @@ extern short debug_lvl;
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGPropulsion::FGPropulsion(FGFDMExec* exec) : FGModel(exec, "propulsion")
+FGPropulsion::FGPropulsion(FGFDMExec* exec) : FGModel(exec, "FGPropulsion")
 {
-  Name = "FGPropulsion";
 
   ActiveEngine = -1; // -1: ALL, 0: Engine 1, 1: Engine 2 ...
   tankJ.InitMatrix();

--- a/src/models/FGPropulsion.cpp
+++ b/src/models/FGPropulsion.cpp
@@ -72,7 +72,7 @@ extern short debug_lvl;
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGPropulsion::FGPropulsion(FGFDMExec* exec) : FGModel(exec)
+FGPropulsion::FGPropulsion(FGFDMExec* exec) : FGModel(exec, "propulsion")
 {
   Name = "FGPropulsion";
 

--- a/src/models/FGPropulsion.cpp
+++ b/src/models/FGPropulsion.cpp
@@ -74,7 +74,6 @@ CLASS IMPLEMENTATION
 
 FGPropulsion::FGPropulsion(FGFDMExec* exec) : FGModel(exec, "FGPropulsion")
 {
-
   ActiveEngine = -1; // -1: ALL, 0: Engine 1, 1: Engine 2 ...
   tankJ.InitMatrix();
   DumpRate = 0.0;

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -73,7 +73,7 @@ static inline double square_signed (double value)
 constexpr double sqr(double x) { return x*x; }
 
 FGWinds::FGWinds(FGFDMExec* fdmex)
-  : FGModel(fdmex), generator(fdmex->GetRandomGenerator())
+  : FGModel(fdmex, "winds"), generator(fdmex->GetRandomGenerator())
 {
   Name = "FGWinds";
 

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -73,9 +73,8 @@ static inline double square_signed (double value)
 constexpr double sqr(double x) { return x*x; }
 
 FGWinds::FGWinds(FGFDMExec* fdmex)
-  : FGModel(fdmex, "winds"), generator(fdmex->GetRandomGenerator())
+  : FGModel(fdmex, "FGWinds"), generator(fdmex->GetRandomGenerator())
 {
-  Name = "FGWinds";
 
   MagnitudedAccelDt = MagnitudeAccel = Magnitude = TurbDirection = 0.0;
   SetTurbType( ttMilspec );

--- a/src/models/atmosphere/FGWinds.cpp
+++ b/src/models/atmosphere/FGWinds.cpp
@@ -75,7 +75,6 @@ constexpr double sqr(double x) { return x*x; }
 FGWinds::FGWinds(FGFDMExec* fdmex)
   : FGModel(fdmex, "FGWinds"), generator(fdmex->GetRandomGenerator())
 {
-
   MagnitudedAccelDt = MagnitudeAccel = Magnitude = TurbDirection = 0.0;
   SetTurbType( ttMilspec );
   TurbGain = 1.0;


### PR DESCRIPTION
Implements per-model enable proposed by @bcoconni in #1390.

The suggested solution (https://github.com/JSBSim-Team/jsbsim/issues/1390#issuecomment-3901613611):
- add a property to each model, managed by FGModel
- when false, FGModel::Run() returns true and the model is skipped
- name it simulation/models/{Name}/enabled

This branch:
- adds simulation/models/<name>/enabled for every scheduled model, default true
- checks it in FGModel::Run() via the existing "skip this frame" return that every model already honours
- binds one property per model in FGFDMExec, in eModels order

Behaviour is unchanged unless a model is explicitly disabled. A disabled model's body does not run, but its last state and property bindings are preserved, so an external system can take over that model in place, for example an external propagator owning FGPropagate.

Two notes:
- the names are fixed in eModels order rather than read from FGModel::Name, because some models rename themselves when their config loads. That is the only deviation from the {Name} form in the original suggestion.
- a static_assert keeps the name table in step with the eModels enum
