### PR TITLE
Add FGAuxiliary setters for host-owned propagation

### DIFF
--- a/src/models/FGAuxiliary.h
+++ b/src/models/FGAuxiliary.h
@@ -291,6 +291,16 @@ public:
 
   void SetAeroPQR(const FGColumnVector3& tt) { vAeroPQR = tt; }
 
+  // External-injection setters for a host that owns the state integration
+  // (propagation and ground reactions) and provides the derived quantities
+  // Auxiliary would otherwise compute from the propagation it no longer runs:
+  // the alpha/beta rates and the body-axis load factors.
+  void Setadot(double v) { adot = v; }
+  void Setbdot(double v) { bdot = v; }
+  void SetNx(double v) { Nx = v; }
+  void SetNy(double v) { Ny = v; }
+  void SetNz(double v) { Nz = v; }
+
   struct Inputs {
     double Pressure;
     double Density;


### PR DESCRIPTION
Together with the per-model enable property (#1481), these five FGAuxiliary setters are the main JSBSim-core changes that permit running the engine inside an externally hosted simulation such as DCS World.

Adds to FGAuxiliary:
- Setadot, Setbdot (alpha/beta rates)
- SetNx, SetNy, SetNz (body-axis load factors)

When a host owns the state integration it injects the derived quantities Auxiliary would otherwise compute from the propagation it no longer runs. The host-owned domain is propagation together with ground reactions, tightly coupled through the 6DoF integration and externalised as one unit. These rates and load factors are among the few quantities Auxiliary cannot recompute once that integration is external, so the host supplies them.

Follows the state-propagation review @agodemar raised in #1390 and #1391.
