### PR TITLE
Move console escape codes to `FGLogConsole`

### DIFF
--- a/python/JSBSim.py
+++ b/python/JSBSim.py
@@ -29,6 +29,31 @@ import xml.etree.ElementTree as et
 
 import jsbsim
 
+
+class LogConsole(jsbsim.DefaultLogger):
+    def format(self, log_format:jsbsim.LogFormat):
+        if log_format == jsbsim.LogFormat.RED:
+            print("\x1b[31m\0", end="")
+        elif log_format == jsbsim.LogFormat.BLUE:
+            print("\x1b[34m\0", end="")
+        elif log_format == jsbsim.LogFormat.CYAN:
+            print("\x1b[36m\0", end="")
+        elif log_format == jsbsim.LogFormat.GREEN:
+            print("\x1b[32m\0", end="")
+        elif log_format == jsbsim.LogFormat.DEFAULT:
+            print("\x1b[39m\0", end="")
+        elif log_format == jsbsim.LogFormat.BOLD:
+            print("\x1b[1m\0", end="")
+        elif log_format == jsbsim.LogFormat.NORMAL:
+            print("\x1b[22m\0", end="")
+        elif log_format == jsbsim.LogFormat.UNDERLINE_ON:
+            print("\x1b[4m\0", end="")
+        elif log_format == jsbsim.LogFormat.UNDERLINE_OFF:
+            print("\x1b[24m\0", end="")
+        else:
+            print("\x1b[0m\0", end="")  # Reset
+
+
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("input", nargs='?', help="script file name")
@@ -117,8 +142,8 @@ def main():
 
     fdm = jsbsim.FGFDMExec(args.root, None)
 
-    if args.nohighlight:
-        fdm.disable_highlighting()
+    if not args.nohighlight:
+        jsbsim.set_logger(LogConsole())
 
     if args.outputpath:
         fdm.set_output_path(args.outputpath)

--- a/python/jsbsim.pxd
+++ b/python/jsbsim.pxd
@@ -208,7 +208,6 @@ cdef extern from "FGJSBBase.h" namespace "JSBSim":
         c_FGJSBBase()
         short debug_lvl
         string GetVersion()
-        void disableHighLighting()
 
 cdef extern from "FGFDMExec.h" namespace "JSBSim":
     cdef cppclass c_FGFDMExec "JSBSim::FGFDMExec" (c_FGJSBBase):

--- a/python/jsbsim.pyx.in
+++ b/python/jsbsim.pyx.in
@@ -633,10 +633,6 @@ cdef class FGJSBBase:
         """@Dox(JSBSim::FGJSBBase::GetVersion)"""
         return self.baseptr.GetVersion().decode('utf-8')
 
-    def disable_highlighting(self) -> None:
-        """@Dox(JSBSim::FGJSBBase::disableHighLighting)"""
-        self.baseptr.disableHighLighting()
-
 cdef class FGPropulsion:
     """@Dox(JSBSim::FGPropulsion)"""
 

--- a/src/FGFDMExec.cpp
+++ b/src/FGFDMExec.cpp
@@ -1138,7 +1138,7 @@ void FGFDMExec::PrintPropertyCatalog(void)
 {
   FGLogging out(LogLevel::STDOUT);
   out << endl
-      << "  " << LogFormat::BLUE << highint << LogFormat::UNDERLINE_ON
+      << "  " << LogFormat::BLUE << LogFormat::BOLD << LogFormat::UNDERLINE_ON
       << "Property Catalog for " << modelName << LogFormat::RESET << endl << endl;
   for (auto &catalogElm: PropertyCatalog)
     out << "    " << catalogElm << endl;

--- a/src/FGJSBBase.cpp
+++ b/src/FGJSBBase.cpp
@@ -36,7 +36,7 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include "FGJSBBase.h"
-#include "models/FGAtmosphere.h"
+#include <sstream>
 
 using namespace std;
 
@@ -46,39 +46,10 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-char FGJSBBase::highint[5]  = {27, '[', '1', 'm', '\0'      };
-char FGJSBBase::halfint[5]  = {27, '[', '2', 'm', '\0'      };
-char FGJSBBase::normint[6]  = {27, '[', '2', '2', 'm', '\0' };
-char FGJSBBase::reset[5]    = {27, '[', '0', 'm', '\0'      };
-char FGJSBBase::underon[5]  = {27, '[', '4', 'm', '\0'      };
-char FGJSBBase::underoff[6] = {27, '[', '2', '4', 'm', '\0' };
-char FGJSBBase::fgblue[6]   = {27, '[', '3', '4', 'm', '\0' };
-char FGJSBBase::fgcyan[6]   = {27, '[', '3', '6', 'm', '\0' };
-char FGJSBBase::fgred[6]    = {27, '[', '3', '1', 'm', '\0' };
-char FGJSBBase::fggreen[6]  = {27, '[', '3', '2', 'm', '\0' };
-char FGJSBBase::fgdef[6]    = {27, '[', '3', '9', 'm', '\0' };
-
 const string FGJSBBase::needed_cfg_version = "2.0";
 const string FGJSBBase::JSBSim_version = JSBSIM_VERSION " " __DATE__ " " __TIME__ ;
 
 short FGJSBBase::debug_lvl  = 1;
-
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-void FGJSBBase::disableHighLighting(void)
-{
-  highint[0]='\0';
-  halfint[0]='\0';
-  normint[0]='\0';
-  reset[0]='\0';
-  underon[0]='\0';
-  underoff[0]='\0';
-  fgblue[0]='\0';
-  fgcyan[0]='\0';
-  fgred[0]='\0';
-  fggreen[0]='\0';
-  fgdef[0]='\0';
-}
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -91,4 +62,3 @@ string FGJSBBase::CreateIndexedPropertyName(const string& Property, int index)
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 } // namespace JSBSim
-

--- a/src/FGJSBBase.h
+++ b/src/FGJSBBase.h
@@ -39,9 +39,6 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <float.h>
-#include <queue>
-#include <string>
-#include <cmath>
 #include <stdexcept>
 #include <random>
 #include <chrono>
@@ -144,38 +141,9 @@ public:
     }
   };
 
-  ///@name JSBSim console output highlighting terms.
-  //@{
-  /// highlights text
-  static char highint[5];
-  /// low intensity text
-  static char halfint[5];
-  /// normal intensity text
-  static char normint[6];
-  /// resets text properties
-  static char reset[5];
-  /// underlines text
-  static char underon[5];
-  /// underline off
-  static char underoff[6];
-  /// blue text
-  static char fgblue[6];
-  /// cyan text
-  static char fgcyan[6];
-  /// red text
-  static char fgred[6];
-  /// green text
-  static char fggreen[6];
-  /// default text
-  static char fgdef[6];
-  //@}
-
   /** Returns the version number of JSBSim.
   *   @return The version number of JSBSim. */
   static const std::string& GetVersion(void) {return JSBSim_version;}
-
-  /// Disables highlighting in the console output.
-  void disableHighLighting(void);
 
   static short debug_lvl;
 

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -557,6 +557,7 @@ int real_main(int argc, char* argv[])
   }
 
   {
+    // Using FGLogging class so that the parameter --nohighlight can disable the formatting
     JSBSim::FGLogging out(JSBSim::LogLevel::STDOUT);
     out << endl << JSBSim::LogFormat::GREEN << JSBSim::LogFormat::BOLD
         << "---- JSBSim Execution beginning ... --------------------------------------------"

--- a/src/JSBSim.cpp
+++ b/src/JSBSim.cpp
@@ -415,7 +415,10 @@ int real_main(int argc, char* argv[])
     nohighlight = true;
 #endif
 
-  if (nohighlight) FDMExec->disableHighLighting();
+  if (nohighlight) {
+    auto logger = dynamic_cast<JSBSim::FGLogConsole*>(JSBSim::GetLogger().get());
+    if (logger) logger->DisableHighLighting();
+  }
 
   if (simulation_rate < 1.0 )
     FDMExec->Setdt(simulation_rate);
@@ -553,9 +556,12 @@ int real_main(int argc, char* argv[])
     }
   }
 
-  cout << endl << JSBSim::FGFDMExec::fggreen << JSBSim::FGFDMExec::highint
-       << "---- JSBSim Execution beginning ... --------------------------------------------"
-       << JSBSim::FGFDMExec::reset << endl << endl;
+  {
+    JSBSim::FGLogging out(JSBSim::LogLevel::STDOUT);
+    out << endl << JSBSim::LogFormat::GREEN << JSBSim::LogFormat::BOLD
+        << "---- JSBSim Execution beginning ... --------------------------------------------"
+        << JSBSim::LogFormat::RESET << endl << endl;
+  }
 
   result = FDMExec->Run();  // MAKE AN INITIAL RUN
 

--- a/src/input_output/FGLog.cpp
+++ b/src/input_output/FGLog.cpp
@@ -226,6 +226,9 @@ void FGLogConsole::Format(LogFormat format) {
   case LogFormat::GREEN:
     buffer.append(fggreen);
     break;
+  case LogFormat::CYAN:
+    buffer.append(fgcyan);
+    break;
   case LogFormat::BOLD:
     buffer.append(highint);
     break;

--- a/src/input_output/FGLog.cpp
+++ b/src/input_output/FGLog.cpp
@@ -51,6 +51,17 @@ thread_local FGLogger_ptr GlobalLogger = std::make_shared<FGLogConsole>();
 void SetLogger(FGLogger_ptr logger) { GlobalLogger = logger; }
 FGLogger_ptr GetLogger(void) { return GlobalLogger; }
 
+const char highint[5]  = {27, '[', '1', 'm', '\0'      };
+const char halfint[5]  = {27, '[', '2', 'm', '\0'      };
+const char normint[6]  = {27, '[', '2', '2', 'm', '\0' };
+const char reset[5]    = {27, '[', '0', 'm', '\0'      };
+const char underon[5]  = {27, '[', '4', 'm', '\0'      };
+const char underoff[6] = {27, '[', '2', '4', 'm', '\0' };
+const char fgblue[6]   = {27, '[', '3', '4', 'm', '\0' };
+const char fgcyan[6]   = {27, '[', '3', '6', 'm', '\0' };
+const char fgred[6]    = {27, '[', '3', '1', 'm', '\0' };
+const char fggreen[6]  = {27, '[', '3', '2', 'm', '\0' };
+const char fgdef[6]    = {27, '[', '3', '9', 'm', '\0' };
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 CLASS IMPLEMENTATION
@@ -202,32 +213,37 @@ void FGLogConsole::Flush(void) {
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGLogConsole::Format(LogFormat format) {
+  if (!highlighting) return;
+
   switch (format)
   {
   case LogFormat::RED:
-    buffer.append(FGJSBBase::fgred);
+    buffer.append(fgred);
     break;
   case LogFormat::BLUE:
-    buffer.append(FGJSBBase::fgblue);
+    buffer.append(fgblue);
+    break;
+  case LogFormat::GREEN:
+    buffer.append(fggreen);
     break;
   case LogFormat::BOLD:
-    buffer.append(FGJSBBase::highint);
+    buffer.append(highint);
     break;
   case LogFormat::NORMAL:
-    buffer.append(FGJSBBase::normint);
+    buffer.append(normint);
     break;
   case LogFormat::UNDERLINE_ON:
-    buffer.append(FGJSBBase::underon);
+    buffer.append(underon);
     break;
   case LogFormat::UNDERLINE_OFF:
-    buffer.append(FGJSBBase::underoff);
+    buffer.append(underoff);
     break;
   case LogFormat::DEFAULT:
-    buffer.append(FGJSBBase::fgdef);
+    buffer.append(fgdef);
     break;
   case LogFormat::RESET:
   default:
-    buffer.append(FGJSBBase::reset);
+    buffer.append(reset);
     break;
   }
 }

--- a/src/input_output/FGLog.h
+++ b/src/input_output/FGLog.h
@@ -209,8 +209,10 @@ public:
   void Format(LogFormat format) override;
   void Flush(void) override;
   ~FGLogConsole() override { Flush(); }
+  void DisableHighLighting(void) { highlighting = false; }
 
 protected:
+  bool highlighting = true;
   std::string buffer;
   LogLevel min_level = LogLevel::BULK;
 };

--- a/src/math/FGFunction.cpp
+++ b/src/math/FGFunction.cpp
@@ -54,12 +54,11 @@ constexpr unsigned int MaxArgs = 9999;
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-class WrongNumberOfArguments : public BaseException
+class WrongNumberOfArguments : public XMLLogException
 {
 public:
-  WrongNumberOfArguments(const string &msg, const vector<FGParameter_ptr> &p,
-                         Element* el)
-    : BaseException(msg), Parameters(p), element(el) {}
+  WrongNumberOfArguments(const vector<FGParameter_ptr> &p, Element* el)
+    : XMLLogException(el), Parameters(p), element(el) {}
   size_t NumberOfArguments(void) const { return Parameters.size(); }
   FGParameter* FirstParameter(void) const { return *(Parameters.cbegin()); }
   const Element* GetElement(void) const { return element; }
@@ -113,11 +112,10 @@ public:
     : FGFunction(pm), f(_f)
   {
     if (el->GetNumElements() != 0) {
-      ostringstream buffer;
-      buffer << el->ReadFrom() << fgred << highint
-             << "<" << el->GetName() << "> should have no arguments." << reset
-             << endl;
-      throw WrongNumberOfArguments(buffer.str(), Parameters, el);
+      WrongNumberOfArguments err(Parameters, el);
+      err << LogFormat::RED << LogFormat::BOLD
+          << "<" << el->GetName() << "> should have no arguments.\n" << LogFormat::RESET;
+      throw err;
     }
 
     bind(el, Prefix);
@@ -245,11 +243,11 @@ FGFunction::FGFunction(FGFDMExec* fdmex, Element* el, const string& prefix,
 void FGFunction::CheckMinArguments(Element* el, unsigned int _min)
 {
   if (Parameters.size() < _min) {
-    ostringstream buffer;
-    buffer << el->ReadFrom() << fgred << highint
-           << "<" << el->GetName() << "> should have at least " << _min
-           << " argument(s)." << reset << endl;
-    throw WrongNumberOfArguments(buffer.str(), Parameters, el);
+    WrongNumberOfArguments err(Parameters, el);
+    err << LogFormat::RED << LogFormat::BOLD
+        << "<" << el->GetName() << "> should have at least " << _min
+        << " argument(s).\n" << LogFormat::RESET;
+    throw err;
   }
 }
 
@@ -258,11 +256,11 @@ void FGFunction::CheckMinArguments(Element* el, unsigned int _min)
 void FGFunction::CheckMaxArguments(Element* el, unsigned int _max)
 {
   if (Parameters.size() > _max) {
-    ostringstream buffer;
-    buffer << el->ReadFrom() << fgred << highint
-           << "<" << el->GetName() << "> should have no more than " << _max
-           << " argument(s)." << reset << endl;
-    throw WrongNumberOfArguments(buffer.str(), Parameters, el);
+    WrongNumberOfArguments err(Parameters, el);
+    err << LogFormat::RED << LogFormat::BOLD
+        << "<" << el->GetName() << "> should have no more than " << _max
+        << " argument(s).\n" << LogFormat::RESET;
+    throw err;
   }
 }
 

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -438,14 +438,13 @@ void FGMassBalance::GetMassPropertiesReport(int i)
 {
   FGLogging out(LogLevel::STDOUT);
   out << endl << LogFormat::BLUE << LogFormat::BOLD
-      << "  Mass Properties Report (English units: lbf, in, slug-ft^2)"
+      << "  Mass Properties Report (English units: lb, in, slug-ft^2)"
       << LogFormat::RESET << endl;
-  out << "                                  " << LogFormat::UNDERLINE_ON << "    Weight    CG-X    CG-Y"
+  out << "                                  " << LogFormat::UNDERLINE_ON << "      Mass    CG-X    CG-Y"
       << "    CG-Z         Ixx         Iyy         Izz"
       << "         Ixy         Ixz         Iyz" << LogFormat::UNDERLINE_OFF << endl;
   out << fixed << setprecision(1);
-  out << LogFormat::BOLD << setw(34) << left << "    Base Vehicle " << LogFormat::NORMAL
-      << right << setw(12) << EmptyWeight
+  out << setw(34) << left << "    Base Vehicle " << right << setw(12) << EmptyWeight
       << setw(8) << vbaseXYZcg(eX) << setw(8) << vbaseXYZcg(eY) << setw(8) << vbaseXYZcg(eZ)
       << setw(12) << baseJ(1,1) << setw(12) << baseJ(2,2) << setw(12) << baseJ(3,3)
       << setw(12) << baseJ(1,2) << setw(12) << baseJ(1,3) << setw(12) << baseJ(2,3) << endl;
@@ -453,17 +452,23 @@ void FGMassBalance::GetMassPropertiesReport(int i)
   for (unsigned int i=0;i<PointMasses.size();i++) {
     PointMass* pm = PointMasses[i];
     double pmweight = pm->GetPointMassWeight();
-    out << LogFormat::BOLD << left << setw(4) << i << setw(30) << pm->GetName() << LogFormat::NORMAL
+    out << left << setw(4) << i << setw(30) << pm->GetName()
         << right << setw(12) << pmweight << setw(8) << pm->GetLocation()(eX)
         << setw(8) << pm->GetLocation()(eY) << setw(8) << pm->GetLocation()(eZ)
         << setw(12) << pm->GetPointMassMoI(1,1) << setw(12) << pm->GetPointMassMoI(2,2) << setw(12) << pm->GetPointMassMoI(3,3)
         << setw(12) << pm->GetPointMassMoI(1,2) << setw(12) << pm->GetPointMassMoI(1,3) << setw(12) << pm->GetPointMassMoI(2,3) << endl;
   }
 
-  out << FDMExec->GetPropulsionTankReport();
+  const string tank_report = FDMExec->GetPropulsionTankReport();
+
+  if (!tank_report.empty()) {
+    out << "\n    " << setw(34) << left << LogFormat::UNDERLINE_ON << LogFormat::BOLD
+        << "Tanks Content" << LogFormat::RESET << endl
+        << tank_report;
+  }
 
   out << "    " << LogFormat::UNDERLINE_ON << setw(136) << " " << LogFormat::UNDERLINE_OFF << endl;
-  out << LogFormat::BOLD << left << setw(30) << "    Total: " << right << setw(14) << Weight
+  out << LogFormat::BOLD << left << setw(34) << "    Total: " << right << setw(12) << Weight
       << setw(8) << vXYZcg(eX)
       << setw(8) << vXYZcg(eY)
       << setw(8) << vXYZcg(eZ)

--- a/src/models/FGMassBalance.cpp
+++ b/src/models/FGMassBalance.cpp
@@ -514,7 +514,7 @@ void FGMassBalance::Debug(int from)
       log << "    baseIxy: " << baseJ(1,2) << " slug-ft2" << endl;
       log << "    baseIxz: " << baseJ(1,3) << " slug-ft2" << endl;
       log << "    baseIyz: " << baseJ(2,3) << " slug-ft2" << endl;
-      log << "    Empty Weight: " << EmptyWeight << " lbm" << endl;
+      log << "    Empty Mass: " << EmptyWeight << " lbm" << endl;
       log << "    CG (x, y, z): " << vbaseXYZcg << endl;
       // ToDo: Need to add point mass outputs here
       for (unsigned int i=0; i<PointMasses.size(); i++) {

--- a/src/models/FGPropagate.h
+++ b/src/models/FGPropagate.h
@@ -39,6 +39,7 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <memory>
+#include <deque>
 
 #include "models/FGModel.h"
 #include "math/FGLocation.h"

--- a/src/models/FGPropulsion.cpp
+++ b/src/models/FGPropulsion.cpp
@@ -565,7 +565,8 @@ string FGPropulsion::GetPropulsionTankReport()
       tankdesc += "Unknown tank type";
     }
     if (!tankname.empty()) tankdesc += ")";
-    outstream << highint << left << setw(4) << i++ << setw(30) << tankdesc << normint
+    outstream << fixed << setprecision(1)
+      << left << setw(4) << i++ << setw(30) << tankdesc
       << right << setw(12) << tank->GetContents() << setw(8) << tank->GetXYZ(eX)
       << setw(8) << tank->GetXYZ(eY) << setw(8) << tank->GetXYZ(eZ)
       << setw(12) << tank->GetIxx() << setw(12) << tank->GetIyy()

--- a/tests/unit_tests/FGJSBBaseTest.h
+++ b/tests/unit_tests/FGJSBBaseTest.h
@@ -49,7 +49,6 @@ public:
 
   void testMisc() {
     std::string version = GetVersion();
-    disableHighLighting();
   }
 
   void testRandomNumberGenerator() {


### PR DESCRIPTION
This PR is a continuation of the logging redesign series (PRs #1094 and others).

Since we now use `LogFormat` in messages, the terminal escape codes can now be moved from `FGJSBBase` to `FGLog`:
https://github.com/JSBSim-Team/jsbsim/blob/d371f384f1920677582d04233b326a45c9033542/src/FGJSBBase.cpp#L49-L59

Indeed, these escape codes are now only used by the class `FGLogConsole`. In the process of this migration, I have discovered that:
* The parameter `--nohighlight` passed to the Python script `python/JSBSim.py` is no longer working since the method `FGJSBBase::disableHighLighting` has no effect on `FGLogConsole`. This has been fixed by creating a new Python class `LogConsole` that inherits `DefaultLogger` and displays the required escape codes on the terminal.

* The method `FGJSBBase::disableHighLighting` is now useless and has been removed. A new method `FGLogConsole::DisableHighLighting` has been added to allow disabling the usage of terminal escape codes when `FGLogConsole` is the current logger.
  * As a result, the executable `JSBSim.cpp` has been rewritten to use `FGLogConsole::disableHighLighting` when the parameter `--nohighlight` is passed.

* Some terminal escape codes are still used here and there (in `JSBSim.cpp`, `FGFDMExec.cpp`, `FGFunction.cpp` and `FGPropulsion.cpp`). Their occurrences are replaced by the equivalent `LogFormat`.
  * The terminal escape codes used in the executable `JSBSim.cpp` have been replaced by their equivalent from `LogFormat`. This was needed so that this formatting would react to the call to `FGLogConsole::DisableHghLighting`.
  * The exception `WrongNumberOfArguments` now inherits from `XMLLogException` instead of `BaseException` to allow using `LogFormat` in replacement of terminal escape codes.

  * For the particular case of `FGPropulsion::GetPropulsionTankReport`, the method is returning a `std::string` so `LogFormat` cannot be used. So I have simply removed the formatting from `FGPropulsion::GetPropulsionTankReport` and updated the formatting of `FGMassBalance::GetMassPropertiesReport` to match that removal (i.e. the first column of the report is no longer displayed in bold characters).
    * The mass and inertia of tank contents are now displayed with a one digit precision to match the precision used for the other items in the mass report.

    * While I was going down the rabbit hole of the mass properties report, I took the opportunity to replace `Weight` and `lbf` by `Mass` and `lb`. I have also added a `Tank Content` label in the report so that it is now more obvious that the last lines in the report are displaying the content of the tanks. And the line for the totals have been modified to match the vertical alignment of the columns.

* The colors `GREEN` and `CYAN` are missing in the method `FGLogConsole::Format`. They have been added. 

I also took this opportunity to clean up the header inclusion in `FGJSBBase.h`. Since the header `<queue>` has been removed from `FGJSBBase.h`, the header `<deque>` had to be added to `FGPropagate.h`.

My initial goal was just to move the terminal escape codes to `FGLogConsole` and while pulling that thread, a lof of other things unraveled 😄