### PR TITLE
Fix typos in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20258621.svg)](https://doi.org/10.5281/zenodo.20258621)
 
 <p align="center">
-<img width="250" heigth="250" src="https://github.com/JSBSim-Team/jsbsim-logo/blob/master/logo_JSBSIM_globe.png">
+<img width="250" height="250" src="https://github.com/JSBSim-Team/jsbsim-logo/blob/master/logo_JSBSIM_globe.png">
 </p>
 
 # Introduction

--- a/UnrealEngine/README.md
+++ b/UnrealEngine/README.md
@@ -45,7 +45,7 @@ Unreal Engine requires that one plugin contains all its needed files in its sub-
 This application contains a `Plugins/JSBSimFlightDynamicsModel` folder containing the JSBSim files.
 In some of these subfolders, one has to place 
  - The JSBSim libraries, compiled as dynamic libs  
- - The aircrafts/engine/systems definition files.
+ - The aircraft/engine/systems definition files.
 
 When the UE application will be packaged, the resources will be copied along with the executable, and the application dynamically linked against the libs transparently.
 

--- a/doc/DevelopersDocs.md
+++ b/doc/DevelopersDocs.md
@@ -246,7 +246,7 @@ If you need to run all the tests which name contains `Altitude`, you can use
 > ctest -R Altitude
 ```
 
-If you need to run all the tests but thoses which name contains `Altitude`, you can use
+If you need to run all the tests but those which name contains `Altitude`, you can use
 
 ```bash
 > ctest -E Altitude
@@ -258,7 +258,7 @@ If you need to run tests #12 to #14, you can use
 > ctest -I 12,14
 ```
 
-You can find more informations about `ctest` from its [manual page](https://cmake.org/cmake/help/v3.0/manual/ctest.1.html)
+You can find more information about `ctest` from its [manual page](https://cmake.org/cmake/help/v3.0/manual/ctest.1.html)
 
 ### When I try to run `ctest`, most of the tests fail
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -136,7 +136,7 @@ In particular, this is how the Simulink block named `JSBSim_SFunction` appears w
 
 ![image](https://user-images.githubusercontent.com/819499/128169185-b334bbe0-27f9-4426-91f9-3e4393da6e07.png)
 
-When you run the test script you'll get the foloowing output in the Matlab command window:
+When you run the test script you'll get the following output in the Matlab command window:
 
 ```matlab
 >> TestJSBSim


### PR DESCRIPTION
Fixes 5 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, module paths, package names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.