### PR TITLE
Fix Emscripten portability

### DIFF
--- a/src/input_output/FGfdmSocket.cpp
+++ b/src/input_output/FGfdmSocket.cpp
@@ -40,10 +40,13 @@ INCLUDES
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include <ws2tcpip.h>
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__EMSCRIPTEN__)
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netdb.h>
+#include <sys/select.h>
+#include <sys/time.h>
 #include <unistd.h>
 #include <fcntl.h>
 #else

--- a/src/simgear/misc/strutils.cxx
+++ b/src/simgear/misc/strutils.cxx
@@ -685,9 +685,9 @@ std::string error_string(int errnum)
   errno_t retcode;
   // Always makes the string in 'buf' null-terminated
   retcode = strerror_s(buf, sizeof(buf), errnum);
-#elif defined(_GNU_SOURCE)
+#elif defined(_GNU_SOURCE) && !defined(__EMSCRIPTEN__)
   return std::string(strerror_r(errnum, buf, sizeof(buf)));
-#elif (_POSIX_C_SOURCE >= 200112L) || defined(SG_MAC) || defined(__FreeBSD__)
+#elif (_POSIX_C_SOURCE >= 200112L) || defined(SG_MAC) || defined(__FreeBSD__) || defined(__EMSCRIPTEN__)
   int retcode;
   // POSIX.1-2001 and POSIX.1-2008
   retcode = strerror_r(errnum, buf, sizeof(buf));
@@ -695,7 +695,7 @@ std::string error_string(int errnum)
 #error "Could not find a thread-safe alternative to strerror()."
 #endif
 
-#if !defined(_GNU_SOURCE)
+#if !defined(_GNU_SOURCE) || defined(__EMSCRIPTEN__)
   if (retcode) {
     std::string msg = "unable to get error message for a given error number";
     // C++11 would make this shorter with std::to_string()
@@ -713,7 +713,7 @@ std::string error_string(int errnum)
   }
 
   return std::string(buf);
-#endif  // !defined(_GNU_SOURCE)
+#endif  // !defined(_GNU_SOURCE) || defined(__EMSCRIPTEN__)
 }
 
 } // end namespace strutils


### PR DESCRIPTION
## Summary
- include the POSIX socket declarations required when compiling `FGfdmSocket` with Emscripten
- use Emscripten's POSIX `strerror_r` ABI even when `_GNU_SOURCE` is defined

## Testing
- configured and built the `jsbsim_wasm` target with Emscripten 6.0.9 against this branch to completion

This ports the socket and `strerror_r` fixes from the compatibility patch in my downstream `jsbsim-wasm` fork. It does not change terminal-color behavior or add a WASM build target to this repository.
